### PR TITLE
ci/release workflow 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Verify (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      NPM_CONFIG_CACHE: .npm-cache
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - 18
+          - 20
+          - 22
+          - 24
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies when needed
+        run: |
+          if [ -f package-lock.json ]; then
+            npm ci
+          elif [ -f package.json ]; then
+            npm install --no-package-lock
+          fi
+
+      - name: Run verification
+        run: npm run verify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,174 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing git tag to release, for example v0.1.0
+        required: true
+        type: string
+
+concurrency:
+  group: release-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  release:
+    name: Publish Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      NPM_CONFIG_CACHE: .npm-cache
+
+    steps:
+      - name: Checkout workflow files
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Resolve release metadata
+        id: meta
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            tag="${{ github.ref_name }}"
+          else
+            tag="${{ inputs.tag }}"
+          fi
+
+          node ./scripts/release-plan.mjs "$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout tagged release ref
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ steps.meta.outputs.tag }}
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          if [ -f package-lock.json ]; then
+            npm ci
+          else
+            npm install --no-package-lock
+          fi
+
+      - name: Verify package version matches tag
+        shell: bash
+        run: |
+          package_version=$(node -p "require('./package.json').version")
+          if [ "v$package_version" != "${{ steps.meta.outputs.tag }}" ]; then
+            echo "Tag ${{ steps.meta.outputs.tag }} does not match package.json version v$package_version"
+            exit 1
+          fi
+
+      - name: Check whether this version already exists on npm
+        id: npm_state
+        shell: bash
+        run: |
+          package_name=$(node -p "require('./package.json').name")
+          if npm view "${package_name}@${{ steps.meta.outputs.version }}" version --registry=https://registry.npmjs.org >/tmp/npm-version.txt 2>/tmp/npm-view-error.txt; then
+            echo "already_published=true" >> "$GITHUB_OUTPUT"
+          else
+            lookup_state=$(node ./scripts/classify-npm-lookup-error.mjs /tmp/npm-view-error.txt)
+
+            if [ "$lookup_state" = "not-found" ]; then
+              echo "already_published=false" >> "$GITHUB_OUTPUT"
+            else
+              cat /tmp/npm-view-error.txt
+              exit 1
+            fi
+          fi
+
+      - name: Run release verification
+        run: npm run verify
+
+      - name: Pack release tarball
+        id: pack
+        shell: bash
+        run: |
+          tarball=$(npm pack --cache ./.npm-cache)
+          echo "tarball=$tarball" >> "$GITHUB_OUTPUT"
+
+      - name: Detect npm auth mode
+        id: auth
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        shell: bash
+        run: |
+          if [ -n "$NPM_TOKEN" ]; then
+            echo "mode=token" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=trusted" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to npm with trusted publishing
+        if: ${{ steps.auth.outputs.mode == 'trusted' && steps.npm_state.outputs.already_published != 'true' }}
+        shell: bash
+        run: |
+          if npm publish "${{ steps.pack.outputs.tarball }}" --access public --tag "${{ steps.meta.outputs.npmDistTag }}" >/tmp/npm-publish.txt 2>/tmp/npm-publish-error.txt; then
+            exit 0
+          fi
+
+          publish_state=$(node ./scripts/classify-npm-publish-error.mjs /tmp/npm-publish-error.txt)
+
+          if [ "$publish_state" = "already-published" ]; then
+            echo "npm package version was already published during a rerun, continuing."
+          else
+            cat /tmp/npm-publish-error.txt
+            exit 1
+          fi
+
+      - name: Publish to npm with token fallback
+        if: ${{ steps.auth.outputs.mode == 'token' && steps.npm_state.outputs.already_published != 'true' }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        shell: bash
+        run: |
+          if npm publish "${{ steps.pack.outputs.tarball }}" --access public --tag "${{ steps.meta.outputs.npmDistTag }}" >/tmp/npm-publish.txt 2>/tmp/npm-publish-error.txt; then
+            exit 0
+          fi
+
+          publish_state=$(node ./scripts/classify-npm-publish-error.mjs /tmp/npm-publish-error.txt)
+
+          if [ "$publish_state" = "already-published" ]; then
+            echo "npm package version was already published during a rerun, continuing."
+          else
+            cat /tmp/npm-publish-error.txt
+            exit 1
+          fi
+
+      - name: Skip npm publish when version already exists
+        if: ${{ steps.npm_state.outputs.already_published == 'true' }}
+        run: echo "npm package version already published, skipping publish step."
+
+      - name: Create or update GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          if gh release view "${{ steps.meta.outputs.tag }}" >/dev/null 2>&1; then
+            if [ "${{ steps.meta.outputs.isPrerelease }}" = "true" ]; then
+              gh release edit "${{ steps.meta.outputs.tag }}" --prerelease
+            fi
+            gh release upload "${{ steps.meta.outputs.tag }}" "${{ steps.pack.outputs.tarball }}" --clobber
+          else
+            release_args=()
+            if [ "${{ steps.meta.outputs.isPrerelease }}" = "true" ]; then
+              release_args+=(--prerelease)
+            fi
+            gh release create "${{ steps.meta.outputs.tag }}" "${{ steps.pack.outputs.tarball }}" --generate-notes --title "${{ steps.meta.outputs.tag }}" "${release_args[@]}"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .kratos/
+.npm-cache/
 node_modules/
 dist/
 coverage/

--- a/README.en.md
+++ b/README.en.md
@@ -1,5 +1,7 @@
 # Kratos
 
+[![CI](https://github.com/JeremyDev87/kratos/actions/workflows/ci.yml/badge.svg)](https://github.com/JeremyDev87/kratos/actions/workflows/ci.yml)
+
 [한국어](README.md) | English | [中文](README.zh-CN.md) | [Español](README.es.md) | [日本語](README.ja.md)
 
 Destroy dead code ruthlessly.
@@ -116,6 +118,28 @@ You can optionally add `kratos.config.json`.
 - Old React / Next.js projects
 - Teams with lots of shipped features and accumulated code
 - Teams looking for the right time to refactor
+
+## Releases
+
+Kratos uses semantic version tags such as `v0.1.0` for releases.
+
+```bash
+npm version 0.1.0 --no-git-tag-version
+git add package*.json
+git commit -m "chore: release v0.1.0"
+git tag v0.1.0
+git push origin HEAD
+git push origin v0.1.0
+```
+
+When a tag is pushed, the [release workflow](.github/workflows/release.yml) will:
+
+- run `npm run verify`
+- build the npm release tarball
+- publish stable releases to npm `latest` and prereleases to npm `next`
+- create a GitHub Release and attach the tarball
+
+The recommended setup is npm Trusted Publishing (OIDC). If that is not configured yet, the workflow can fall back to a repository `NPM_TOKEN` secret.
 
 ## Open Source
 

--- a/README.es.md
+++ b/README.es.md
@@ -1,5 +1,7 @@
 # Kratos
 
+[![CI](https://github.com/JeremyDev87/kratos/actions/workflows/ci.yml/badge.svg)](https://github.com/JeremyDev87/kratos/actions/workflows/ci.yml)
+
 [한국어](README.md) | [English](README.en.md) | [中文](README.zh-CN.md) | Español | [日本語](README.ja.md)
 
 Destroy dead code ruthlessly.
@@ -116,6 +118,28 @@ Opcionalmente puedes añadir `kratos.config.json`.
 - Proyectos React / Next.js antiguos
 - Equipos con muchas funciones lanzadas y mucho código acumulado
 - Equipos que buscan el momento adecuado para refactorizar
+
+## Releases
+
+Kratos usa etiquetas de versión semántica como `v0.1.0` para publicar releases.
+
+```bash
+npm version 0.1.0 --no-git-tag-version
+git add package*.json
+git commit -m "chore: release v0.1.0"
+git tag v0.1.0
+git push origin HEAD
+git push origin v0.1.0
+```
+
+Cuando se envía una etiqueta, el [release workflow](.github/workflows/release.yml):
+
+- ejecuta `npm run verify`
+- genera el tarball de publicación para npm
+- publica las releases estables en npm `latest` y las prereleases en npm `next`
+- crea un GitHub Release y adjunta el tarball
+
+La configuración recomendada es npm Trusted Publishing (OIDC). Si todavía no está configurado, el workflow puede usar como fallback el secret `NPM_TOKEN` del repositorio.
 
 ## Open Source
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,5 +1,7 @@
 # Kratos
 
+[![CI](https://github.com/JeremyDev87/kratos/actions/workflows/ci.yml/badge.svg)](https://github.com/JeremyDev87/kratos/actions/workflows/ci.yml)
+
 [한국어](README.md) | [English](README.en.md) | [中文](README.zh-CN.md) | [Español](README.es.md) | 日本語
 
 Destroy dead code ruthlessly.
@@ -116,6 +118,28 @@ Saved report: /.../fixtures/demo-app/.kratos/latest-report.json
 - 古い React / Next.js プロジェクト
 - 機能リリースが多く、コードが蓄積しているチーム
 - リファクタリングのタイミングを探しているチーム
+
+## リリース
+
+Kratos は `v0.1.0` のようなセマンティックバージョンタグでリリースします。
+
+```bash
+npm version 0.1.0 --no-git-tag-version
+git add package*.json
+git commit -m "chore: release v0.1.0"
+git tag v0.1.0
+git push origin HEAD
+git push origin v0.1.0
+```
+
+タグが push されると、[release workflow](.github/workflows/release.yml) が以下を実行します。
+
+- `npm run verify` を実行
+- npm 配布用 tarball を生成
+- stable リリースは npm `latest`、prerelease は npm `next` に publish
+- GitHub Release を作成し tarball を添付
+
+推奨構成は npm Trusted Publishing（OIDC）です。まだ設定していない場合は、リポジトリの `NPM_TOKEN` secret による fallback も可能です。
 
 ## オープンソース
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Kratos
 
+[![CI](https://github.com/JeremyDev87/kratos/actions/workflows/ci.yml/badge.svg)](https://github.com/JeremyDev87/kratos/actions/workflows/ci.yml)
+
 한국어 | [English](README.en.md) | [中文](README.zh-CN.md) | [Español](README.es.md) | [日本語](README.ja.md)
 
 Destroy dead code ruthlessly.
@@ -116,6 +118,28 @@ Saved report: /.../fixtures/demo-app/.kratos/latest-report.json
 - 오래된 React / Next.js 프로젝트
 - 기능 출시가 많아 코드가 누적된 팀
 - 리팩터링 타이밍을 찾는 팀
+
+## 릴리스
+
+Kratos는 `v0.1.0` 같은 시맨틱 버전 태그 기준으로 릴리스합니다.
+
+```bash
+npm version 0.1.0 --no-git-tag-version
+git add package*.json
+git commit -m "chore: release v0.1.0"
+git tag v0.1.0
+git push origin HEAD
+git push origin v0.1.0
+```
+
+태그가 푸시되면 [Release workflow](.github/workflows/release.yml)가 아래를 수행합니다.
+
+- `npm run verify` 실행
+- npm 배포용 tarball 생성
+- stable 릴리스는 npm `latest`, prerelease는 npm `next`로 publish 수행
+- GitHub Release 생성 및 tarball 첨부
+
+권장 방식은 npm Trusted Publishing(OIDC)입니다. 아직 설정하지 않았다면 저장소 `NPM_TOKEN` secret으로도 fallback 배포가 가능합니다.
 
 ## 오픈소스
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,5 +1,7 @@
 # Kratos
 
+[![CI](https://github.com/JeremyDev87/kratos/actions/workflows/ci.yml/badge.svg)](https://github.com/JeremyDev87/kratos/actions/workflows/ci.yml)
+
 [한국어](README.md) | [English](README.en.md) | 中文 | [Español](README.es.md) | [日本語](README.ja.md)
 
 Destroy dead code ruthlessly.
@@ -116,6 +118,28 @@ Saved report: /.../fixtures/demo-app/.kratos/latest-report.json
 - 老旧的 React / Next.js 项目
 - 功能上线很多、代码不断堆积的团队
 - 正在寻找重构时机的团队
+
+## 发布
+
+Kratos 使用像 `v0.1.0` 这样的语义化版本标签进行发布。
+
+```bash
+npm version 0.1.0 --no-git-tag-version
+git add package*.json
+git commit -m "chore: release v0.1.0"
+git tag v0.1.0
+git push origin HEAD
+git push origin v0.1.0
+```
+
+当标签被推送后，[release workflow](.github/workflows/release.yml) 会执行以下操作：
+
+- 运行 `npm run verify`
+- 生成用于 npm 发布的 tarball
+- stable 版本发布到 npm `latest`，prerelease 发布到 npm `next`
+- 创建 GitHub Release 并附加 tarball
+
+推荐使用 npm Trusted Publishing（OIDC）。如果暂时还没有配置，也可以回退到仓库中的 `NPM_TOKEN` secret。
 
 ## 开源
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,15 @@
   "description": "Destroy dead code ruthlessly.",
   "author": "JeremyDev87",
   "type": "module",
+  "files": [
+    "src",
+    "LICENSE",
+    "README.md",
+    "README.en.md",
+    "README.es.md",
+    "README.ja.md",
+    "README.zh-CN.md"
+  ],
   "homepage": "https://github.com/JeremyDev87/kratos#readme",
   "repository": {
     "type": "git",
@@ -24,7 +33,10 @@
     "report": "node ./src/cli.js report",
     "clean": "node ./src/cli.js clean",
     "smoke": "node ./src/cli.js scan ./fixtures/demo-app && node ./src/cli.js report ./fixtures/demo-app/.kratos/latest-report.json",
-    "test": "node --test"
+    "test": "node --test",
+    "pack:check": "npm pack --dry-run --cache ./.npm-cache",
+    "verify": "npm test && npm run smoke && npm run pack:check",
+    "prepublishOnly": "npm run verify"
   },
   "keywords": [
     "cli",
@@ -35,6 +47,9 @@
     "analysis"
   ],
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": ">=18"
   }

--- a/scripts/classify-npm-lookup-error.mjs
+++ b/scripts/classify-npm-lookup-error.mjs
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+import { classifyNpmLookupError } from "../src/lib/release.js";
+
+const errorPath = process.argv[2];
+
+if (!errorPath) {
+  console.error("Usage: node ./scripts/classify-npm-lookup-error.mjs <stderr-file>");
+  process.exit(1);
+}
+
+const stderr = fs.readFileSync(errorPath, "utf8");
+console.log(classifyNpmLookupError(stderr));

--- a/scripts/classify-npm-publish-error.mjs
+++ b/scripts/classify-npm-publish-error.mjs
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+import { classifyNpmPublishError } from "../src/lib/release.js";
+
+const errorPath = process.argv[2];
+
+if (!errorPath) {
+  console.error("Usage: node ./scripts/classify-npm-publish-error.mjs <stderr-file>");
+  process.exit(1);
+}
+
+const stderr = fs.readFileSync(errorPath, "utf8");
+console.log(classifyNpmPublishError(stderr));

--- a/scripts/release-plan.mjs
+++ b/scripts/release-plan.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+import { resolveReleasePlan } from "../src/lib/release.js";
+
+const tag = process.argv[2];
+
+if (!tag) {
+  console.error("Usage: node ./scripts/release-plan.mjs <tag>");
+  process.exit(1);
+}
+
+try {
+  const plan = resolveReleasePlan(tag);
+
+  for (const [key, value] of Object.entries(plan)) {
+    console.log(`${key}=${value}`);
+  }
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}

--- a/src/lib/release.js
+++ b/src/lib/release.js
@@ -1,0 +1,46 @@
+const RELEASE_TAG_PATTERN = /^v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/;
+
+export function resolveReleasePlan(tag) {
+  if (!RELEASE_TAG_PATTERN.test(tag)) {
+    throw new Error("Tag must look like v1.2.3 or v1.2.3-beta.1");
+  }
+
+  const version = tag.slice(1);
+  const isPrerelease = version.includes("-");
+
+  return {
+    tag,
+    version,
+    isPrerelease,
+    npmDistTag: isPrerelease ? "next" : "latest",
+    githubReleaseType: isPrerelease ? "prerelease" : "release",
+  };
+}
+
+export function classifyNpmLookupError(stderr) {
+  const normalized = stderr.toLowerCase();
+
+  if (
+    normalized.includes("e404") ||
+    normalized.includes("404 not found") ||
+    normalized.includes("is not in this registry")
+  ) {
+    return "not-found";
+  }
+
+  return "unknown";
+}
+
+export function classifyNpmPublishError(stderr) {
+  const normalized = stderr.toLowerCase();
+
+  if (
+    normalized.includes("cannot publish over the previously published versions") ||
+    normalized.includes("cannot publish over existing version") ||
+    normalized.includes("previously published versions")
+  ) {
+    return "already-published";
+  }
+
+  return "unknown";
+}

--- a/test/kratos.test.js
+++ b/test/kratos.test.js
@@ -9,6 +9,11 @@ import { analyzeProject } from "../src/lib/analyze.js";
 import { loadProjectConfig } from "../src/lib/config.js";
 import { isWithinDirectory } from "../src/lib/fs.js";
 import { parseModuleSource } from "../src/lib/parser.js";
+import {
+  classifyNpmLookupError,
+  classifyNpmPublishError,
+  resolveReleasePlan,
+} from "../src/lib/release.js";
 import { resolveImportTarget } from "../src/lib/resolve.js";
 
 test("isWithinDirectory rejects prefix-only path matches", () => {
@@ -243,6 +248,50 @@ test("require destructuring with ternary defaults does not misparse alias separa
 
   const report = await analyzeProject(tempRoot);
   assert.equal(report.findings.deadExports.some((entry) => entry.file.endsWith("/src/helper.js")), false);
+});
+
+test("release plan marks prerelease tags as next channel", () => {
+  assert.deepEqual(resolveReleasePlan("v1.2.3-beta.1"), {
+    tag: "v1.2.3-beta.1",
+    version: "1.2.3-beta.1",
+    isPrerelease: true,
+    npmDistTag: "next",
+    githubReleaseType: "prerelease",
+  });
+});
+
+test("release plan marks stable tags as latest channel", () => {
+  assert.deepEqual(resolveReleasePlan("v1.2.3"), {
+    tag: "v1.2.3",
+    version: "1.2.3",
+    isPrerelease: false,
+    npmDistTag: "latest",
+    githubReleaseType: "release",
+  });
+});
+
+test("npm lookup error classifier recognizes not found responses", () => {
+  assert.equal(
+    classifyNpmLookupError("npm ERR! code E404\nnpm ERR! 404 Not Found - GET https://registry.npmjs.org/kratos"),
+    "not-found",
+  );
+  assert.equal(
+    classifyNpmLookupError("npm ERR! code EAI_AGAIN\nnpm ERR! request to registry failed"),
+    "unknown",
+  );
+});
+
+test("npm publish error classifier recognizes already published versions", () => {
+  assert.equal(
+    classifyNpmPublishError(
+      "npm ERR! code E403\nnpm ERR! 403 403 Forbidden - PUT https://registry.npmjs.org/kratos - You cannot publish over the previously published versions: 1.2.3.",
+    ),
+    "already-published",
+  );
+  assert.equal(
+    classifyNpmPublishError("npm ERR! code EAI_AGAIN\nnpm ERR! request to registry failed"),
+    "unknown",
+  );
 });
 
 async function fileExists(filePath) {


### PR DESCRIPTION
## 배경 / Background

Kratos를 오픈소스로 운영하기 위한 기본 CI와 release 파이프라인이 아직 없었습니다.
이번 변경은 GitHub Actions 기반 검증 흐름과 npm/GitHub Release 자동화를 추가하고, 릴리스 운영 방식을 README에 명확히 문서화하는 데 목적이 있습니다.

## 변경 사항 / Changes

- Node 18/20/22/24 매트릭스로 `npm run verify`를 실행하는 CI workflow 추가
- 태그 기반 npm publish 및 GitHub Release 생성을 수행하는 release workflow 추가
- prerelease를 npm `next`와 GitHub prerelease로 분기하는 release 메타데이터 로직 추가
- release 재실행 시 이미 배포된 버전 충돌을 안전하게 흡수하는 보조 스크립트와 테스트 추가
- `package.json` publish 메타데이터와 `verify`/`pack:check`/`prepublishOnly` 스크립트 정리
- 한국어/영어/중국어/스페인어/일본어 README에 CI 배지와 릴리스 절차 문서화

## 검증 / Verification

- `npm run verify`
- `node --test` 15 passing
- `npm run smoke`
- `npm pack --dry-run --cache ./.npm-cache`

## 리스크 또는 확인 포인트 / Risks or Follow-ups

- GitHub Actions와 npm publish는 로컬에서 실제 실행할 수 없어서, 첫 태그 릴리스 때 원격 환경 검증이 한 번 필요합니다.
- npm Trusted Publishing(OIDC)을 연결하지 않았다면 저장소 `NPM_TOKEN` secret이 준비되어 있어야 합니다.
- 현재 README 릴리스 예시는 `git push origin HEAD`를 사용하므로 기본 브랜치명이 바뀌어도 동작하지만, 팀 표준 릴리스 절차가 정해지면 그에 맞춰 다시 다듬을 수 있습니다.
