### PR TITLE
[codex] CLI help 출력을 모듈화

### DIFF
--- a/docs/plans/00-cli-help-modularization.md
+++ b/docs/plans/00-cli-help-modularization.md
@@ -1,0 +1,55 @@
+# CLI Help Modularization Plan
+
+## Objective
+
+CLI 루트 help 텍스트를 `src/cli.js`의 고정 문자열에서 분리해, 각 command 파일이 자기 usage와 summary를 직접 소유하도록 바꾼다. 이 작업의 목적은 이후 `scan`, `report`, `clean` 기능 확장 PR이 help 문구 변경 때문에 `src/cli.js`와 충돌하지 않게 만드는 것이며, 실제 command 동작이나 출력 포맷 자체를 바꾸는 것은 아니다.
+
+## Conflict Surface
+
+- `src/cli.js`
+- `src/commands/scan.js`
+- `src/commands/report.js`
+- `src/commands/clean.js`
+- `src/lib/help.js`
+- `test/cli-help.test.js`
+
+## Rules
+
+- 기존 root help 진입점인 `kratos`, `kratos --help`, `kratos -h`, `kratos help`는 계속 동작해야 한다.
+- command 실행 동작은 바꾸지 않고, help metadata 소유권만 command 파일 쪽으로 이동한다.
+- `scan`, `report`, `clean`의 usage 문구 변경은 이후 해당 command 파일만 수정하면 되도록 경계를 만든다.
+- unknown command 실패 시에는 non-zero 종료와 함께 root help를 계속 보여준다.
+- 이 PR에서는 새 command를 추가하지 않는다.
+
+## Slice 1. Command Metadata Extraction
+
+### Target Files
+
+- `src/cli.js`
+- `src/commands/scan.js`
+- `src/commands/report.js`
+- `src/commands/clean.js`
+- `new helper file: src/lib/help.js`
+- `new helper spec: test/cli-help.test.js`
+
+### Steps
+
+1. `src/lib/help.js`에 root help와 command help를 포맷하는 공용 함수를 만든다.
+2. `src/commands/scan.js`, `src/commands/report.js`, `src/commands/clean.js`가 각각 자기 command metadata를 export 하게 바꾼다.
+3. `src/cli.js`는 command metadata 목록을 기반으로 dispatch와 help 출력을 수행하게 바꾼다.
+4. `kratos <command> --help`가 해당 command metadata에서 직접 나온 usage를 보여주게 만든다.
+5. unknown command 시 stderr에 root help를 함께 출력하는 회귀 테스트를 추가한다.
+
+## Done Criteria
+
+- [ ] root help가 `src/lib/help.js`를 통해 생성된다.
+- [ ] `scan`, `report`, `clean` help metadata가 각 command 파일에 위치한다.
+- [ ] 이후 command 옵션 문구 변경이 `src/cli.js`를 수정하지 않고도 가능하다.
+- [ ] CLI help 회귀 테스트가 추가되고 통과한다.
+
+## Out Of Scope
+
+- `diff` 같은 신규 command 추가
+- `scan`, `report`, `clean`의 실제 기능 변경
+- README 문서 갱신
+- command별 상세 examples, 색상 출력, interactive help UI

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,24 +1,17 @@
 #!/usr/bin/env node
 
-import { runClean } from "./commands/clean.js";
-import { runReport } from "./commands/report.js";
-import { runScan } from "./commands/scan.js";
+import { cleanCommand } from "./commands/clean.js";
+import { reportCommand } from "./commands/report.js";
+import { scanCommand } from "./commands/scan.js";
+import {
+  formatCommandHelp,
+  formatRootHelp,
+  formatUnknownCommand,
+} from "./lib/help.js";
 
 const [, , command, ...args] = process.argv;
-
-const HELP_TEXT = `Kratos
-Destroy dead code ruthlessly.
-
-Usage:
-  kratos scan [root] [--output path] [--json]
-  kratos report [report-path-or-root] [--format summary|json|md]
-  kratos clean [report-path-or-root] [--apply]
-
-Commands:
-  scan    Analyze a codebase and save the latest report.
-  report  Print a saved report in summary, json, or markdown form.
-  clean   Show deletion candidates or delete them with --apply.
-`;
+const COMMANDS = [scanCommand, reportCommand, cleanCommand];
+const COMMANDS_BY_NAME = new Map(COMMANDS.map((entry) => [entry.name, entry]));
 
 async function main() {
   switch (command) {
@@ -26,23 +19,26 @@ async function main() {
     case "--help":
     case "-h":
     case "help":
-      console.log(HELP_TEXT);
-      return;
-    case "scan":
-      await runScan(args);
-      return;
-    case "report":
-      await runReport(args);
-      return;
-    case "clean":
-      await runClean(args);
+      console.log(formatRootHelp(COMMANDS));
       return;
     default:
-      console.error(`Unknown command: ${command}`);
-      console.error("");
-      console.error(HELP_TEXT);
-      process.exitCode = 1;
+      break;
   }
+
+  const commandEntry = COMMANDS_BY_NAME.get(command);
+
+  if (!commandEntry) {
+    console.error(formatUnknownCommand(command, COMMANDS));
+    process.exitCode = 1;
+    return;
+  }
+
+  if (shouldShowCommandHelp(args)) {
+    console.log(formatCommandHelp(commandEntry));
+    return;
+  }
+
+  await commandEntry.run(args);
 }
 
 main().catch((error) => {
@@ -50,3 +46,7 @@ main().catch((error) => {
   console.error(`Kratos failed: ${message}`);
   process.exitCode = 1;
 });
+
+function shouldShowCommandHelp(args) {
+  return args.includes("--help") || (args.length === 1 && args[0] === "-h");
+}

--- a/src/commands/clean.js
+++ b/src/commands/clean.js
@@ -11,6 +11,13 @@ import {
 } from "../lib/fs.js";
 import { resolveReportInput } from "../lib/report.js";
 
+export const cleanCommand = {
+  name: "clean",
+  summary: "Show deletion candidates or delete them with --apply.",
+  usage: ["kratos clean [report-path-or-root] [--apply]"],
+  run: runClean,
+};
+
 export async function runClean(argv) {
   const { positionals, flags } = parseCliOptions(argv);
   const reportPath = resolveReportInput(positionals[0], process.cwd());

--- a/src/commands/report.js
+++ b/src/commands/report.js
@@ -6,6 +6,13 @@ import {
   resolveReportInput,
 } from "../lib/report.js";
 
+export const reportCommand = {
+  name: "report",
+  summary: "Print a saved report in summary, json, or markdown form.",
+  usage: ["kratos report [report-path-or-root] [--format summary|json|md]"],
+  run: runReport,
+};
+
 export async function runReport(argv) {
   const { positionals, flags } = parseCliOptions(argv);
   const reportPath = resolveReportInput(positionals[0], process.cwd());

--- a/src/commands/scan.js
+++ b/src/commands/scan.js
@@ -6,6 +6,13 @@ import { DEFAULT_REPORT_RELATIVE_PATH } from "../lib/constants.js";
 import { ensureDir, writeJsonFile } from "../lib/fs.js";
 import { formatSummaryReport } from "../lib/report.js";
 
+export const scanCommand = {
+  name: "scan",
+  summary: "Analyze a codebase and save the latest report.",
+  usage: ["kratos scan [root] [--output path] [--json]"],
+  run: runScan,
+};
+
 export async function runScan(argv) {
   const { positionals, flags } = parseCliOptions(argv);
   const root = path.resolve(positionals[0] ?? process.cwd());

--- a/src/lib/help.js
+++ b/src/lib/help.js
@@ -1,0 +1,44 @@
+export function formatRootHelp(commands) {
+  const lines = [
+    "Kratos",
+    "Destroy dead code ruthlessly.",
+    "",
+    "Usage:",
+    ...commands.flatMap((command) => command.usage.map((usageLine) => `  ${usageLine}`)),
+    "",
+    "Commands:",
+    ...formatCommandSummaries(commands),
+  ];
+
+  return lines.join("\n");
+}
+
+export function formatCommandHelp(command) {
+  return [
+    "Kratos",
+    "Destroy dead code ruthlessly.",
+    "",
+    `${command.name} command`,
+    command.summary,
+    "",
+    "Usage:",
+    ...command.usage.map((usageLine) => `  ${usageLine}`),
+    "",
+    "Run `kratos --help` to see every command.",
+  ].join("\n");
+}
+
+export function formatUnknownCommand(commandName, commands) {
+  return [`Unknown command: ${commandName}`, "", formatRootHelp(commands)].join("\n");
+}
+
+function formatCommandSummaries(commands) {
+  const maxNameLength = commands.reduce(
+    (longest, command) => Math.max(longest, command.name.length),
+    0,
+  );
+
+  return commands.map(
+    (command) => `  ${command.name.padEnd(maxNameLength)}  ${command.summary}`,
+  );
+}

--- a/test/cli-help.test.js
+++ b/test/cli-help.test.js
@@ -1,0 +1,70 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const cliPath = fileURLToPath(new URL("../src/cli.js", import.meta.url));
+
+test("root help is generated from command metadata", async () => {
+  const { stdout, stderr } = await execFileAsync(process.execPath, [cliPath, "--help"]);
+
+  assert.equal(stderr, "");
+  assert.match(stdout, /kratos scan \[root] \[--output path] \[--json]/);
+  assert.match(stdout, /kratos report \[report-path-or-root] \[--format summary\|json\|md]/);
+  assert.match(stdout, /kratos clean \[report-path-or-root] \[--apply]/);
+  assert.match(stdout, /scan\s+Analyze a codebase and save the latest report\./);
+  assert.match(stdout, /clean\s+Show deletion candidates or delete them with --apply\./);
+});
+
+test("command help is served from its command module", async () => {
+  const { stdout, stderr } = await execFileAsync(process.execPath, [cliPath, "scan", "--help"]);
+
+  assert.equal(stderr, "");
+  assert.match(stdout, /scan command/);
+  assert.match(stdout, /Analyze a codebase and save the latest report\./);
+  assert.match(stdout, /kratos scan \[root] \[--output path] \[--json]/);
+  assert.match(stdout, /Run `kratos --help` to see every command\./);
+});
+
+test("command short help works when -h is the only subcommand argument", async () => {
+  const { stdout, stderr } = await execFileAsync(process.execPath, [cliPath, "scan", "-h"]);
+
+  assert.equal(stderr, "");
+  assert.match(stdout, /scan command/);
+  assert.match(stdout, /kratos scan \[root] \[--output path] \[--json]/);
+});
+
+test("command help does not steal -h when it is a command argument value", async () => {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "kratos-cli-help-"));
+  const outputPath = path.join(tempRoot, "-h");
+  const { stdout, stderr } = await execFileAsync(process.execPath, [
+    cliPath,
+    "scan",
+    tempRoot,
+    "--output",
+    "-h",
+  ]);
+
+  assert.equal(stderr, "");
+  assert.match(stdout, /Kratos scan complete\./);
+  assert.doesNotMatch(stdout, /scan command/);
+  await fs.access(outputPath);
+});
+
+test("unknown commands print root help to stderr and exit non-zero", async () => {
+  await assert.rejects(
+    execFileAsync(process.execPath, [cliPath, "explode"]),
+    (error) => {
+      assert.equal(error.code, 1);
+      assert.match(error.stderr, /Unknown command: explode/);
+      assert.match(error.stderr, /Usage:/);
+      assert.match(error.stderr, /kratos clean \[report-path-or-root] \[--apply]/);
+      return true;
+    },
+  );
+});


### PR DESCRIPTION
## 배경

Kratos의 CLI help는 지금까지 `src/cli.js` 안의 고정 문자열에 묶여 있어서, 각 command의 옵션/usage가 바뀔 때마다 루트 CLI 파일까지 함께 수정해야 했습니다. 이 구조는 이후 `scan`, `report`, `clean` 기능 확장 PR들이 같은 파일에서 충돌할 가능성을 키웠습니다.

## 변경 사항

- `scan`, `report`, `clean` command가 각각 자신의 help metadata를 직접 소유하도록 변경
- 공용 help formatter를 `src/lib/help.js`로 분리
- `src/cli.js`는 command metadata를 조합해 root help, command help, unknown command 출력을 담당하도록 정리
- `kratos <command> --help` 지원 추가
- `-h`가 command 인자 값으로 쓰일 때 help로 오인하지 않도록 회귀 수정
- CLI help 회귀 테스트와 PR 0A plan 문서 추가

## 영향

- 이후 command별 옵션 문구 변경이 `src/cli.js`를 덜 건드리게 되어 충돌면이 줄어듭니다.
- 루트 help와 command help의 소유권이 명확해져 다음 phase 작업을 진행하기 쉬워집니다.
- 기존 root help 진입점(`kratos`, `kratos --help`, `kratos -h`, `kratos help`)은 유지됩니다.

## 검증

- `npm run verify`
- `node --test test/cli-help.test.js test/kratos.test.js`
- `node ./src/cli.js --help`
- `node ./src/cli.js scan --help`
- `node ./src/cli.js scan . --output -h`

## 리스크 / 후속 포인트

- 현재 command short help는 `kratos <command> -h` 대신 `kratos <command> --help`만 지원합니다. 이는 `-h`를 command 인자 값으로 쓰는 경우와의 충돌을 피하기 위한 선택입니다.
- `TODO.md`는 로컬 execution surface라 이번 PR에 포함하지 않았습니다.
