### PR TITLE
[codex] Add JS parity fixtures

### DIFF
--- a/fixtures/parity/README.md
+++ b/fixtures/parity/README.md
@@ -1,0 +1,17 @@
+# Parity Fixtures
+
+이 디렉터리는 현재 JS 구현을 기준으로 고정한 parity baseline을 담습니다.
+Rust 구현은 이후 단계에서 이 산출물과 동등한 동작을 재현해야 합니다.
+
+규칙:
+
+- 사람이 fixture 내용을 직접 수정하지 않습니다.
+- fixture는 `node ./scripts/capture-parity-fixtures.mjs`로만 갱신합니다.
+- 절대 경로는 `<ROOT>`와 `<REPORT>` placeholder로 정규화됩니다.
+- 생성 시각은 `<GENERATED_AT>` placeholder로 고정됩니다.
+
+재생성 명령:
+
+```bash
+node ./scripts/capture-parity-fixtures.mjs
+```

--- a/fixtures/parity/demo-app/latest-report.v1.json
+++ b/fixtures/parity/demo-app/latest-report.v1.json
@@ -1,0 +1,113 @@
+{
+  "version": 1,
+  "generatedAt": "<GENERATED_AT>",
+  "root": "<ROOT>",
+  "summary": {
+    "filesScanned": 5,
+    "entrypoints": 1,
+    "brokenImports": 1,
+    "orphanFiles": 2,
+    "deadExports": 3,
+    "unusedImports": 0,
+    "routeEntrypoints": 1,
+    "deletionCandidates": 2
+  },
+  "findings": {
+    "brokenImports": [
+      {
+        "file": "<ROOT>/src/lib/broken.ts",
+        "source": "./missing-helper",
+        "kind": "static"
+      }
+    ],
+    "orphanFiles": [
+      {
+        "file": "<ROOT>/src/components/DeadWidget.tsx",
+        "kind": "orphan-component",
+        "reason": "Component-like module has no inbound references."
+      },
+      {
+        "file": "<ROOT>/src/lib/broken.ts",
+        "kind": "orphan-module",
+        "reason": "Module has no inbound references and is not treated as an entrypoint."
+      }
+    ],
+    "deadExports": [
+      {
+        "file": "<ROOT>/src/components/DeadWidget.tsx",
+        "exportName": "DeadWidget"
+      },
+      {
+        "file": "<ROOT>/src/lib/broken.ts",
+        "exportName": "brokenFeature"
+      },
+      {
+        "file": "<ROOT>/src/lib/math.ts",
+        "exportName": "multiply"
+      }
+    ],
+    "unusedImports": [],
+    "routeEntrypoints": [
+      {
+        "file": "<ROOT>/pages/home.tsx",
+        "kind": "next-pages-route"
+      }
+    ],
+    "deletionCandidates": [
+      {
+        "file": "<ROOT>/src/components/DeadWidget.tsx",
+        "reason": "Component-like module has no inbound references.",
+        "confidence": 0.92,
+        "safe": true
+      },
+      {
+        "file": "<ROOT>/src/lib/broken.ts",
+        "reason": "Module has no inbound references and is not treated as an entrypoint.",
+        "confidence": 0.88,
+        "safe": true
+      }
+    ]
+  },
+  "modules": [
+    {
+      "file": "<ROOT>/pages/home.tsx",
+      "relativePath": "pages/home.tsx",
+      "entrypointKind": "next-pages-route",
+      "importedByCount": 0,
+      "importCount": 2,
+      "exportCount": 1
+    },
+    {
+      "file": "<ROOT>/src/components/DeadWidget.tsx",
+      "relativePath": "src/components/DeadWidget.tsx",
+      "entrypointKind": null,
+      "importedByCount": 0,
+      "importCount": 0,
+      "exportCount": 1
+    },
+    {
+      "file": "<ROOT>/src/components/LiveCard.tsx",
+      "relativePath": "src/components/LiveCard.tsx",
+      "entrypointKind": null,
+      "importedByCount": 1,
+      "importCount": 0,
+      "exportCount": 1
+    },
+    {
+      "file": "<ROOT>/src/lib/broken.ts",
+      "relativePath": "src/lib/broken.ts",
+      "entrypointKind": null,
+      "importedByCount": 0,
+      "importCount": 0,
+      "exportCount": 1
+    },
+    {
+      "file": "<ROOT>/src/lib/math.ts",
+      "relativePath": "src/lib/math.ts",
+      "entrypointKind": null,
+      "importedByCount": 1,
+      "importCount": 0,
+      "exportCount": 2
+    }
+  ]
+}

--- a/fixtures/parity/demo-app/report-markdown.md
+++ b/fixtures/parity/demo-app/report-markdown.md
@@ -1,0 +1,39 @@
+# Kratos Report
+
+- Generated: <GENERATED_AT>
+- Root: <ROOT>
+- Report: <REPORT>
+
+## Summary
+
+- Files scanned: 5
+- Entrypoints: 1
+- Broken imports: 1
+- Orphan files: 2
+- Dead exports: 3
+- Unused imports: 0
+- Deletion candidates: 2
+
+## Broken imports
+
+- <ROOT>/src/lib/broken.ts -> `./missing-helper`
+
+## Orphan files
+
+- <ROOT>/src/components/DeadWidget.tsx (Component-like module has no inbound references.)
+- <ROOT>/src/lib/broken.ts (Module has no inbound references and is not treated as an entrypoint.)
+
+## Dead exports
+
+- <ROOT>/src/components/DeadWidget.tsx -> `DeadWidget`
+- <ROOT>/src/lib/broken.ts -> `brokenFeature`
+- <ROOT>/src/lib/math.ts -> `multiply`
+
+## Unused imports
+
+- None
+
+## Deletion candidates
+
+- <ROOT>/src/components/DeadWidget.tsx (Component-like module has no inbound references., confidence 0.92)
+- <ROOT>/src/lib/broken.ts (Module has no inbound references and is not treated as an entrypoint., confidence 0.88)

--- a/fixtures/parity/demo-app/report-summary.txt
+++ b/fixtures/parity/demo-app/report-summary.txt
@@ -1,0 +1,24 @@
+Kratos report.
+
+Root: <ROOT>
+Files scanned: 5
+Entrypoints: 1
+Broken imports: 1
+Orphan files: 2
+Dead exports: 3
+Unused imports: 0
+Deletion candidates: 2
+
+Saved report: <REPORT>
+
+Broken imports:
+- <ROOT>/src/lib/broken.ts -> ./missing-helper
+
+Orphan files:
+- <ROOT>/src/components/DeadWidget.tsx
+- <ROOT>/src/lib/broken.ts
+
+Dead exports:
+- <ROOT>/src/components/DeadWidget.tsx#DeadWidget
+- <ROOT>/src/lib/broken.ts#brokenFeature
+- <ROOT>/src/lib/math.ts#multiply

--- a/fixtures/parity/manifest.json
+++ b/fixtures/parity/manifest.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "generatedBy": "node ./scripts/capture-parity-fixtures.mjs",
+  "fixtures": [
+    {
+      "id": "demo-app",
+      "sourceRoot": "fixtures/demo-app",
+      "outputs": {
+        "report": "fixtures/parity/demo-app/latest-report.v1.json",
+        "summary": "fixtures/parity/demo-app/report-summary.txt",
+        "markdown": "fixtures/parity/demo-app/report-markdown.md"
+      }
+    }
+  ]
+}

--- a/scripts/capture-parity-fixtures.mjs
+++ b/scripts/capture-parity-fixtures.mjs
@@ -1,0 +1,145 @@
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+const cliPath = path.join(repoRoot, "src", "cli.js");
+const parityRoot = path.join(repoRoot, "fixtures", "parity");
+const fixtures = [
+  {
+    id: "demo-app",
+    sourceRoot: path.join(repoRoot, "fixtures", "demo-app"),
+    outputRoot: path.join(parityRoot, "demo-app"),
+  },
+];
+
+await mkdir(parityRoot, { recursive: true });
+await writeManifest();
+
+for (const fixture of fixtures) {
+  await captureFixture(fixture);
+}
+
+async function writeManifest() {
+  const manifest = {
+    version: 1,
+    generatedBy: "node ./scripts/capture-parity-fixtures.mjs",
+    fixtures: fixtures.map((fixture) => ({
+      id: fixture.id,
+      sourceRoot: toRepoRelative(fixture.sourceRoot),
+      outputs: {
+        report: `fixtures/parity/${fixture.id}/latest-report.v1.json`,
+        summary: `fixtures/parity/${fixture.id}/report-summary.txt`,
+        markdown: `fixtures/parity/${fixture.id}/report-markdown.md`,
+      },
+    })),
+  };
+
+  await writeFile(
+    path.join(parityRoot, "manifest.json"),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+}
+
+async function captureFixture(fixture) {
+  await mkdir(fixture.outputRoot, { recursive: true });
+
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "kratos-parity-"));
+  const tempReportPath = path.join(tempRoot, `${fixture.id}-latest-report.json`);
+
+  try {
+    runCli(["scan", fixture.sourceRoot, "--output", tempReportPath]);
+
+    const summaryOutput = runCli([
+      "report",
+      tempReportPath,
+      "--format",
+      "summary",
+    ]);
+    const markdownOutput = runCli([
+      "report",
+      tempReportPath,
+      "--format",
+      "md",
+    ]);
+
+    const rawReport = JSON.parse(await readFile(tempReportPath, "utf8"));
+    const normalizedReport = normalizeValue(rawReport, fixture.sourceRoot, tempReportPath);
+
+    await writeFile(
+      path.join(fixture.outputRoot, "latest-report.v1.json"),
+      `${JSON.stringify(normalizedReport, null, 2)}\n`,
+    );
+    await writeFile(
+      path.join(fixture.outputRoot, "report-summary.txt"),
+      `${normalizeText(summaryOutput, fixture.sourceRoot, tempReportPath)}\n`,
+    );
+    await writeFile(
+      path.join(fixture.outputRoot, "report-markdown.md"),
+      `${normalizeText(markdownOutput, fixture.sourceRoot, tempReportPath)}\n`,
+    );
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+function runCli(args) {
+  const result = spawnSync(process.execPath, [cliPath, ...args], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+
+  if (result.status !== 0) {
+    const stderr = result.stderr?.trim() ? `\n${result.stderr.trim()}` : "";
+    throw new Error(`Failed to run kratos ${args.join(" ")}${stderr}`);
+  }
+
+  return result.stdout.trimEnd();
+}
+
+function normalizeValue(value, fixtureRoot, reportPath) {
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizeValue(entry, fixtureRoot, reportPath));
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [
+        key,
+        normalizeValue(normalizeScalar(key, entry), fixtureRoot, reportPath),
+      ]),
+    );
+  }
+
+  if (typeof value === "string") {
+    return normalizeText(value, fixtureRoot, reportPath);
+  }
+
+  return value;
+}
+
+function normalizeText(text, fixtureRoot, reportPath) {
+  return toPosixPath(text)
+    .replaceAll(toPosixPath(reportPath), "<REPORT>")
+    .replaceAll(toPosixPath(fixtureRoot), "<ROOT>")
+    .replaceAll(/Generated: .+/g, "Generated: <GENERATED_AT>");
+}
+
+function normalizeScalar(key, value) {
+  if (key === "generatedAt") {
+    return "<GENERATED_AT>";
+  }
+
+  return value;
+}
+
+function toRepoRelative(absolutePath) {
+  return toPosixPath(path.relative(repoRoot, absolutePath));
+}
+
+function toPosixPath(value) {
+  return String(value).replaceAll("\\", "/");
+}


### PR DESCRIPTION
## Background

This PR adds the Phase 1 parity baseline capture for the current JS implementation.
The goal is to lock down reproducible fixture outputs before the Rust analyzer starts replacing the runtime.

## Changes

- add `scripts/capture-parity-fixtures.mjs` to run the current JS CLI against `fixtures/demo-app`
- add `fixtures/parity/manifest.json` and `fixtures/parity/README.md`
- commit normalized parity outputs for:
  - JSON report
  - summary report
  - markdown report
- normalize absolute paths with `<ROOT>` and `<REPORT>`
- normalize timestamps with `<GENERATED_AT>` so reruns stay stable

## Verification

- `node ./scripts/capture-parity-fixtures.mjs`
- `npm test`
- reran parity capture twice and verified no drift in the generated JSON/markdown snapshots
- completed a Devil's Advocate review loop
  - Round 1 fixed timestamp churn in parity fixtures
  - Round 2 found no additional issues

## Risks / Follow-ups

- Phase 1 intentionally captures only `fixtures/demo-app`
- additional fixtures can be added in later phases if broader parity coverage is needed
