### PR TITLE
[codex] Port config discovery to Rust

### DIFF
--- a/crates/kratos-core/src/config.rs
+++ b/crates/kratos-core/src/config.rs
@@ -1,18 +1,72 @@
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
-use crate::error::{KratosError, KratosResult};
+use crate::error::KratosResult;
+use crate::jsonc::{parse_loose_json, JsonValue};
 use crate::model::{PathAlias, ProjectConfig};
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+const DEFAULT_CONFIG_FILENAME: &str = "kratos.config.json";
+const DEFAULT_IGNORED_DIRS: &[&str] = &[
+    ".git",
+    ".next",
+    ".nuxt",
+    ".output",
+    ".parcel-cache",
+    ".svelte-kit",
+    ".turbo",
+    ".vercel",
+    ".yarn",
+    "build",
+    "coverage",
+    "dist",
+    "examples",
+    "fixtures",
+    "node_modules",
+    "out",
+    "storybook-static",
+    "test",
+    "tests",
+    "__fixtures__",
+    "__tests__",
+];
+
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct RawConfigDocument {
-    pub package_json: Option<String>,
-    pub tsconfig_json: Option<String>,
-    pub kratos_json: Option<String>,
+    pub package_json: Option<JsonValue>,
+    pub tsconfig_json: Option<JsonValue>,
+    pub kratos_json: Option<JsonValue>,
 }
 
 pub fn load_project_config(root: impl Into<PathBuf>) -> KratosResult<ProjectConfig> {
-    let _ = root.into();
-    Err(KratosError::not_implemented("config::load_project_config"))
+    let root = normalize_project_root(root.into());
+    let package_json = read_loose_json_file(&resolve_config_path(&root, "package.json"))?
+        .unwrap_or_else(empty_object);
+    let tsconfig_json = match read_loose_json_file(&resolve_config_path(&root, "tsconfig.json"))? {
+        Some(value) => value,
+        None => read_loose_json_file(&resolve_config_path(&root, "jsconfig.json"))?
+            .unwrap_or_else(empty_object),
+    };
+    let user_config = read_loose_json_file(&resolve_config_path(&root, DEFAULT_CONFIG_FILENAME))?
+        .unwrap_or_else(empty_object);
+
+    let compiler_options = tsconfig_json.get("compilerOptions");
+    let base_url = compiler_options
+        .and_then(|value| value.get("baseUrl"))
+        .and_then(JsonValue::as_str)
+        .map(|value| resolve_path(&root, value));
+
+    Ok(ProjectConfig {
+        root: root.clone(),
+        base_url: base_url.clone(),
+        roots: normalize_roots(&root, user_config.get("roots"))?,
+        ignored_directories: normalize_ignored_directories(user_config.get("ignore")),
+        explicit_entries: normalize_entry_paths(&root, user_config.get("entry"))?,
+        package_entries: collect_package_entry_files(&root, &package_json),
+        path_aliases: normalize_path_aliases(
+            &root,
+            compiler_options.and_then(|value| value.get("paths")),
+            base_url.as_deref(),
+        )?,
+    })
 }
 
 pub fn resolve_config_path(root: &Path, file_name: &str) -> PathBuf {
@@ -20,8 +74,247 @@ pub fn resolve_config_path(root: &Path, file_name: &str) -> PathBuf {
 }
 
 pub fn apply_path_aliases(
-    _config: &mut ProjectConfig,
-    _aliases: Vec<PathAlias>,
+    config: &mut ProjectConfig,
+    mut aliases: Vec<PathAlias>,
 ) -> KratosResult<()> {
-    Err(KratosError::not_implemented("config::apply_path_aliases"))
+    aliases.sort_by(|left, right| right.alias.len().cmp(&left.alias.len()));
+    config.path_aliases = aliases;
+    Ok(())
+}
+
+fn read_loose_json_file(file_path: &Path) -> KratosResult<Option<JsonValue>> {
+    if !file_path.exists() {
+        return Ok(None);
+    }
+
+    let content = std::fs::read_to_string(file_path)?;
+    Ok(Some(parse_loose_json(&content)?))
+}
+
+fn normalize_roots(root: &Path, roots: Option<&JsonValue>) -> KratosResult<Vec<PathBuf>> {
+    let values = extract_required_string_array(roots, "roots")?;
+
+    if values.is_empty() {
+        return Ok(vec![root.to_path_buf()]);
+    }
+
+    Ok(values
+        .into_iter()
+        .map(|value| resolve_path(root, &value))
+        .collect())
+}
+
+fn normalize_ignored_directories(ignore: Option<&JsonValue>) -> Vec<String> {
+    let mut values = DEFAULT_IGNORED_DIRS
+        .iter()
+        .map(|entry| (*entry).to_string())
+        .collect::<Vec<_>>();
+
+    for value in extract_string_array(ignore) {
+        push_unique_string(&mut values, value);
+    }
+
+    values
+}
+
+fn normalize_entry_paths(root: &Path, entries: Option<&JsonValue>) -> KratosResult<Vec<PathBuf>> {
+    Ok(extract_required_string_array(entries, "entry")?
+        .into_iter()
+        .map(|entry| resolve_path(root, &entry))
+        .collect())
+}
+
+fn normalize_path_aliases(
+    root: &Path,
+    raw_paths: Option<&JsonValue>,
+    base_url: Option<&Path>,
+) -> KratosResult<Vec<PathAlias>> {
+    let Some(paths) = raw_paths.and_then(JsonValue::as_object) else {
+        return Ok(Vec::new());
+    };
+
+    let resolution_base = base_url.unwrap_or(root);
+    let mut aliases = Vec::new();
+
+    for (alias, targets) in paths.iter() {
+        let Some(targets) = targets.as_array() else {
+            continue;
+        };
+
+        for target in targets {
+            let Some(target) = target.as_str() else {
+                return Err(config_error(&format!(
+                    "compilerOptions.paths['{alias}'] must contain only string targets"
+                )));
+            };
+
+            aliases.push(PathAlias {
+                alias: alias.clone(),
+                target: resolve_path(resolution_base, strip_wildcard(target)),
+            });
+        }
+    }
+
+    aliases.sort_by(|left, right| {
+        right.alias.len().cmp(&left.alias.len())
+    });
+    Ok(aliases)
+}
+
+fn collect_package_entry_files(root: &Path, package_json: &JsonValue) -> Vec<PathBuf> {
+    let mut entries = Vec::new();
+
+    add_entry_value(&mut entries, root, package_json.get("main"));
+    add_entry_value(&mut entries, root, package_json.get("module"));
+    add_entry_value(&mut entries, root, package_json.get("types"));
+
+    if let Some(bin) = package_json.get("bin") {
+        if let Some(value) = bin.as_str() {
+            push_unique_path(&mut entries, resolve_path(root, value));
+        } else if let Some(values) = bin.as_object() {
+            for value in values.values() {
+                add_entry_value(&mut entries, root, Some(value));
+            }
+        }
+    }
+
+    if let Some(exports) = package_json.get("exports") {
+        collect_exports(&mut entries, root, exports);
+    }
+
+    entries
+}
+
+fn collect_exports(entries: &mut Vec<PathBuf>, root: &Path, value: &JsonValue) {
+    match value {
+        JsonValue::String(path) => push_unique_path(entries, resolve_path(root, path)),
+        JsonValue::Array(values) => {
+            for nested in values {
+                collect_exports(entries, root, nested);
+            }
+        }
+        JsonValue::Object(values) => {
+            for nested in values.values() {
+                collect_exports(entries, root, nested);
+            }
+        }
+        JsonValue::Null | JsonValue::Bool(_) | JsonValue::Number(_) => {}
+    }
+}
+
+fn add_entry_value(entries: &mut Vec<PathBuf>, root: &Path, value: Option<&JsonValue>) {
+    let Some(value) = value.and_then(JsonValue::as_str) else {
+        return;
+    };
+
+    push_unique_path(entries, resolve_path(root, value));
+}
+
+fn extract_string_array(value: Option<&JsonValue>) -> Vec<String> {
+    let Some(values) = value.and_then(JsonValue::as_array) else {
+        return Vec::new();
+    };
+
+    values
+        .iter()
+        .filter_map(JsonValue::as_str)
+        .map(str::to_string)
+        .collect()
+}
+
+fn extract_required_string_array(
+    value: Option<&JsonValue>,
+    field_name: &str,
+) -> KratosResult<Vec<String>> {
+    let Some(values) = value else {
+        return Ok(Vec::new());
+    };
+
+    let Some(values) = values.as_array() else {
+        return Ok(Vec::new());
+    };
+
+    let mut output = Vec::new();
+
+    for entry in values {
+        let Some(entry) = entry.as_str() else {
+            return Err(config_error(&format!(
+                "{field_name} must contain only string values"
+            )));
+        };
+
+        output.push(entry.to_string());
+    }
+
+    Ok(output)
+}
+
+fn empty_object() -> JsonValue {
+    JsonValue::Object(Default::default())
+}
+
+fn normalize_project_root(root: PathBuf) -> PathBuf {
+    let absolute = if root.is_absolute() {
+        root
+    } else {
+        std::env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join(root)
+    };
+
+    normalize_path(absolute)
+}
+
+fn resolve_path(root: &Path, value: &str) -> PathBuf {
+    let path = Path::new(value);
+
+    if path.is_absolute() {
+        normalize_path(path.to_path_buf())
+    } else {
+        normalize_path(root.join(path))
+    }
+}
+
+fn strip_wildcard(value: &str) -> &str {
+    value.strip_suffix('*').unwrap_or(value)
+}
+
+fn push_unique_path(values: &mut Vec<PathBuf>, candidate: PathBuf) {
+    if !values.iter().any(|entry| entry == &candidate) {
+        values.push(candidate);
+    }
+}
+
+fn push_unique_string(values: &mut Vec<String>, candidate: String) {
+    if !values.iter().any(|entry| entry == &candidate) {
+        values.push(candidate);
+    }
+}
+
+fn config_error(message: &str) -> crate::error::KratosError {
+    crate::error::KratosError::Config(message.to_string())
+}
+
+fn normalize_path(path: PathBuf) -> PathBuf {
+    let mut normalized = PathBuf::new();
+
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => normalized.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !normalized.pop() && !path.is_absolute() {
+                    normalized.push(component.as_os_str());
+                }
+            }
+            Component::Normal(part) => normalized.push(part),
+        }
+    }
+
+    if normalized.as_os_str().is_empty() && !path.is_absolute() {
+        PathBuf::from(".")
+    } else {
+        normalized
+    }
 }

--- a/crates/kratos-core/src/config.rs
+++ b/crates/kratos-core/src/config.rs
@@ -1,3 +1,4 @@
+use std::cmp::Reverse;
 use std::path::{Component, Path, PathBuf};
 
 use crate::error::KratosResult;
@@ -77,7 +78,8 @@ pub fn apply_path_aliases(
     config: &mut ProjectConfig,
     mut aliases: Vec<PathAlias>,
 ) -> KratosResult<()> {
-    aliases.sort_by(|left, right| right.alias.len().cmp(&left.alias.len()));
+    // Stable ordering keeps same-length aliases in insertion order, matching JS behavior.
+    aliases.sort_by_key(|alias| Reverse(alias.alias.len()));
     config.path_aliases = aliases;
     Ok(())
 }
@@ -118,10 +120,13 @@ fn normalize_ignored_directories(ignore: Option<&JsonValue>) -> Vec<String> {
 }
 
 fn normalize_entry_paths(root: &Path, entries: Option<&JsonValue>) -> KratosResult<Vec<PathBuf>> {
-    Ok(extract_required_string_array(entries, "entry")?
-        .into_iter()
-        .map(|entry| resolve_path(root, &entry))
-        .collect())
+    let mut normalized = Vec::new();
+
+    for entry in extract_required_string_array(entries, "entry")? {
+        push_unique_path(&mut normalized, resolve_path(root, &entry));
+    }
+
+    Ok(normalized)
 }
 
 fn normalize_path_aliases(
@@ -150,14 +155,16 @@ fn normalize_path_aliases(
 
             aliases.push(PathAlias {
                 alias: alias.clone(),
-                target: resolve_path(resolution_base, strip_wildcard(target)),
+                target: resolve_path(resolution_base, &target.replace('*', "")),
+                target_pattern: target
+                    .contains('*')
+                    .then(|| resolve_alias_target_pattern(resolution_base, target)),
             });
         }
     }
 
-    aliases.sort_by(|left, right| {
-        right.alias.len().cmp(&left.alias.len())
-    });
+    // Stable ordering keeps same-length aliases in insertion order, matching JS behavior.
+    aliases.sort_by_key(|alias| Reverse(alias.alias.len()));
     Ok(aliases)
 }
 
@@ -187,7 +194,13 @@ fn collect_package_entry_files(root: &Path, package_json: &JsonValue) -> Vec<Pat
 
 fn collect_exports(entries: &mut Vec<PathBuf>, root: &Path, value: &JsonValue) {
     match value {
-        JsonValue::String(path) => push_unique_path(entries, resolve_path(root, path)),
+        JsonValue::String(path) => {
+            if path.is_empty() {
+                return;
+            }
+
+            push_unique_path(entries, resolve_path(root, path))
+        }
         JsonValue::Array(values) => {
             for nested in values {
                 collect_exports(entries, root, nested);
@@ -275,10 +288,6 @@ fn resolve_path(root: &Path, value: &str) -> PathBuf {
     }
 }
 
-fn strip_wildcard(value: &str) -> &str {
-    value.strip_suffix('*').unwrap_or(value)
-}
-
 fn push_unique_path(values: &mut Vec<PathBuf>, candidate: PathBuf) {
     if !values.iter().any(|entry| entry == &candidate) {
         values.push(candidate);
@@ -289,6 +298,16 @@ fn push_unique_string(values: &mut Vec<String>, candidate: String) {
     if !values.iter().any(|entry| entry == &candidate) {
         values.push(candidate);
     }
+}
+
+fn resolve_alias_target_pattern(root: &Path, value: &str) -> String {
+    const WILDCARD_TOKEN: &str = "__KRATOS_WILDCARD__";
+
+    let tokenized = value.replace('*', WILDCARD_TOKEN);
+    let resolved = resolve_path(root, &tokenized);
+    resolved
+        .to_string_lossy()
+        .replace(WILDCARD_TOKEN, "*")
 }
 
 fn config_error(message: &str) -> crate::error::KratosError {
@@ -304,8 +323,16 @@ fn normalize_path(path: PathBuf) -> PathBuf {
             Component::RootDir => normalized.push(component.as_os_str()),
             Component::CurDir => {}
             Component::ParentDir => {
-                if !normalized.pop() && !path.is_absolute() {
-                    normalized.push(component.as_os_str());
+                match normalized.components().next_back() {
+                    Some(Component::Normal(_)) => {
+                        normalized.pop();
+                    }
+                    Some(Component::ParentDir) | None => {
+                        if !path.is_absolute() {
+                            normalized.push(component.as_os_str());
+                        }
+                    }
+                    Some(Component::Prefix(_)) | Some(Component::RootDir) | Some(Component::CurDir) => {}
                 }
             }
             Component::Normal(part) => normalized.push(part),
@@ -316,5 +343,19 @@ fn normalize_path(path: PathBuf) -> PathBuf {
         PathBuf::from(".")
     } else {
         normalized
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_path;
+    use std::path::PathBuf;
+
+    #[test]
+    fn normalize_path_preserves_leading_parent_segments() {
+        assert_eq!(
+            normalize_path(PathBuf::from("../../src")),
+            PathBuf::from("../../src")
+        );
     }
 }

--- a/crates/kratos-core/src/discover.rs
+++ b/crates/kratos-core/src/discover.rs
@@ -1,12 +1,72 @@
 use std::path::{Path, PathBuf};
 
-use crate::error::{KratosError, KratosResult};
+use crate::error::KratosResult;
 use crate::model::ProjectConfig;
 
+const SOURCE_EXTENSIONS: &[&str] = &[".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".mts", ".cts"];
+
 pub fn normalize_root(root: &Path) -> PathBuf {
-    root.to_path_buf()
+    if root.is_absolute() {
+        root.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join(root)
+    }
 }
 
-pub fn collect_source_files(_config: &ProjectConfig) -> KratosResult<Vec<PathBuf>> {
-    Err(KratosError::not_implemented("discover::collect_source_files"))
+pub fn collect_source_files(config: &ProjectConfig) -> KratosResult<Vec<PathBuf>> {
+    let mut discovered = std::collections::BTreeSet::new();
+
+    for root in &config.roots {
+        let root = normalize_root(root);
+
+        if !root.is_dir() {
+            continue;
+        }
+
+        visit_directory(&root, &config.ignored_directories, &mut discovered)?;
+    }
+
+    Ok(discovered.into_iter().collect())
+}
+
+fn visit_directory(
+    current: &Path,
+    ignored_directories: &[String],
+    discovered: &mut std::collections::BTreeSet<PathBuf>,
+) -> KratosResult<()> {
+    for entry in std::fs::read_dir(current)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let path = entry.path();
+
+        if file_type.is_dir() {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+
+            if ignored_directories.iter().any(|ignored| ignored == &name) {
+                continue;
+            }
+
+            visit_directory(&path, ignored_directories, discovered)?;
+            continue;
+        }
+
+        if file_type.is_file() && is_source_path(&path) {
+            discovered.insert(path);
+        }
+    }
+
+    Ok(())
+}
+
+fn is_source_path(path: &Path) -> bool {
+    let Some(extension) = path.extension().and_then(|value| value.to_str()) else {
+        return false;
+    };
+
+    SOURCE_EXTENSIONS
+        .iter()
+        .any(|candidate| candidate.trim_start_matches('.') == extension)
 }

--- a/crates/kratos-core/src/jsonc.rs
+++ b/crates/kratos-core/src/jsonc.rs
@@ -369,7 +369,7 @@ impl Parser {
                         'n' => value.push('\n'),
                         'r' => value.push('\r'),
                         't' => value.push('\t'),
-                        'u' => value.push(self.parse_unicode_escape()?),
+                        'u' => value.push_str(&self.parse_unicode_escape_fragment()?),
                         _ => return Err(self.error("Unsupported escape sequence")),
                     }
                 }
@@ -383,34 +383,38 @@ impl Parser {
         Err(self.error("Unterminated string"))
     }
 
-    fn parse_unicode_escape(&mut self) -> KratosResult<char> {
-        let first = self.parse_unicode_code_unit()?;
+    fn parse_unicode_escape_fragment(&mut self) -> KratosResult<String> {
+        let (first, first_hex) = self.parse_unicode_code_unit()?;
 
         if (0xD800..=0xDBFF).contains(&first) {
-            self.expect('\\')?;
-            self.expect('u')?;
-            let second = self.parse_unicode_code_unit()?;
+            if let Some((second, _)) = self.peek_unicode_code_unit_after_escape()? {
+                if (0xDC00..=0xDFFF).contains(&second) {
+                    self.pos += 2;
+                    let (second, _) = self.parse_unicode_code_unit()?;
 
-            if !(0xDC00..=0xDFFF).contains(&second) {
-                return Err(self.error("Invalid unicode surrogate pair"));
+                    let high = u32::from(first) - 0xD800;
+                    let low = u32::from(second) - 0xDC00;
+                    let codepoint = 0x10000 + ((high << 10) | low);
+
+                    let decoded = char::from_u32(codepoint)
+                        .ok_or_else(|| self.error("Invalid unicode codepoint"))?;
+                    return Ok(decoded.to_string());
+                }
             }
 
-            let high = u32::from(first) - 0xD800;
-            let low = u32::from(second) - 0xDC00;
-            let codepoint = 0x10000 + ((high << 10) | low);
-
-            return char::from_u32(codepoint)
-                .ok_or_else(|| self.error("Invalid unicode codepoint"));
+            return Ok(format!("\\u{first_hex}"));
         }
 
         if (0xDC00..=0xDFFF).contains(&first) {
-            return Err(self.error("Unexpected low surrogate"));
+            return Ok(format!("\\u{first_hex}"));
         }
 
-        char::from_u32(u32::from(first)).ok_or_else(|| self.error("Invalid unicode codepoint"))
+        let decoded = char::from_u32(u32::from(first))
+            .ok_or_else(|| self.error("Invalid unicode codepoint"))?;
+        Ok(decoded.to_string())
     }
 
-    fn parse_unicode_code_unit(&mut self) -> KratosResult<u16> {
+    fn parse_unicode_code_unit(&mut self) -> KratosResult<(u16, String)> {
         let mut hex = String::new();
 
         for _ in 0..4 {
@@ -425,7 +429,33 @@ impl Parser {
             hex.push(ch);
         }
 
-        u16::from_str_radix(&hex, 16).map_err(|_| self.error("Invalid unicode escape"))
+        let code_unit =
+            u16::from_str_radix(&hex, 16).map_err(|_| self.error("Invalid unicode escape"))?;
+        Ok((code_unit, hex))
+    }
+
+    fn peek_unicode_code_unit_after_escape(&self) -> KratosResult<Option<(u16, String)>> {
+        if self.chars.get(self.pos) != Some(&'\\') || self.chars.get(self.pos + 1) != Some(&'u') {
+            return Ok(None);
+        }
+
+        let mut hex = String::new();
+
+        for offset in 2..6 {
+            let Some(ch) = self.chars.get(self.pos + offset).copied() else {
+                return Ok(None);
+            };
+
+            if !ch.is_ascii_hexdigit() {
+                return Err(self.error("Invalid unicode escape"));
+            }
+
+            hex.push(ch);
+        }
+
+        let code_unit =
+            u16::from_str_radix(&hex, 16).map_err(|_| self.error("Invalid unicode escape"))?;
+        Ok(Some((code_unit, hex)))
     }
 
     fn parse_number(&mut self) -> KratosResult<String> {
@@ -435,7 +465,17 @@ impl Parser {
             self.pos += 1;
         }
 
-        self.consume_digits()?;
+        match self.peek() {
+            Some('0') => {
+                self.pos += 1;
+
+                if matches!(self.peek(), Some('0'..='9')) {
+                    return Err(self.error("Leading zeros are not allowed"));
+                }
+            }
+            Some('1'..='9') => self.consume_digits()?,
+            _ => return Err(self.error("Expected digit")),
+        }
 
         if self.peek() == Some('.') {
             self.pos += 1;

--- a/crates/kratos-core/src/jsonc.rs
+++ b/crates/kratos-core/src/jsonc.rs
@@ -1,24 +1,512 @@
 use crate::error::{KratosError, KratosResult};
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct JsoncDocument {
     pub raw: String,
+    pub sanitized: String,
+    pub value: JsonValue,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum JsonValue {
+    Null,
+    Bool(bool),
+    Number(String),
+    String(String),
+    Array(Vec<JsonValue>),
+    Object(JsonObject),
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct JsonObject {
+    entries: Vec<(String, JsonValue)>,
+}
+
+impl JsonObject {
+    pub fn get(&self, key: &str) -> Option<&JsonValue> {
+        self.entries
+            .iter()
+            .find(|(entry_key, _)| entry_key == key)
+            .map(|(_, value)| value)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &JsonValue)> {
+        self.entries.iter().map(|(key, value)| (key, value))
+    }
+
+    pub fn values(&self) -> impl Iterator<Item = &JsonValue> {
+        self.entries.iter().map(|(_, value)| value)
+    }
+
+    fn insert(&mut self, key: String, value: JsonValue) {
+        if let Some((_, existing)) = self
+            .entries
+            .iter_mut()
+            .find(|(entry_key, _)| entry_key == &key)
+        {
+            *existing = value;
+            return;
+        }
+
+        self.entries.push((key, value));
+    }
+}
+
+impl JsonValue {
+    pub fn get(&self, key: &str) -> Option<&JsonValue> {
+        match self {
+            Self::Object(object) => object.get(key),
+            _ => None,
+        }
+    }
+
+    pub fn as_array(&self) -> Option<&[JsonValue]> {
+        match self {
+            Self::Array(values) => Some(values),
+            _ => None,
+        }
+    }
+
+    pub fn as_object(&self) -> Option<&JsonObject> {
+        match self {
+            Self::Object(object) => Some(object),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            Self::String(value) => Some(value),
+            _ => None,
+        }
+    }
 }
 
 pub fn strip_jsonc_comments(source: &str) -> KratosResult<String> {
-    let _ = source;
-    Err(KratosError::not_implemented(
-        "jsonc::strip_jsonc_comments",
-    ))
+    Ok(strip_comments(source))
 }
 
 pub fn parse_jsonc_document(source: &str) -> KratosResult<JsoncDocument> {
-    let _ = source;
-    Err(KratosError::not_implemented(
-        "jsonc::parse_jsonc_document",
-    ))
+    let without_comments = strip_jsonc_comments(source)?;
+    let sanitized = strip_trailing_commas(&without_comments);
+    let value = Parser::new(&sanitized).parse()?;
+
+    Ok(JsoncDocument {
+        raw: source.to_string(),
+        sanitized,
+        value,
+    })
 }
 
-pub fn parse_loose_json(_source: &str) -> KratosResult<JsoncDocument> {
-    Err(KratosError::not_implemented("jsonc::parse_loose_json"))
+pub fn parse_loose_json(source: &str) -> KratosResult<JsonValue> {
+    Ok(parse_jsonc_document(source)?.value)
+}
+
+fn strip_comments(input: &str) -> String {
+    let chars: Vec<char> = input.chars().collect();
+    let mut output = String::with_capacity(input.len());
+    let mut index = 0;
+    let mut state = "code";
+
+    while index < chars.len() {
+        let current = chars[index];
+        let next = chars.get(index + 1).copied();
+
+        if state == "line-comment" {
+            if current == '\n' {
+                state = "code";
+                output.push('\n');
+            } else {
+                output.push(' ');
+            }
+
+            index += 1;
+            continue;
+        }
+
+        if state == "block-comment" {
+            if current == '*' && next == Some('/') {
+                output.push(' ');
+                output.push(' ');
+                index += 2;
+                state = "code";
+            } else {
+                output.push(if current == '\n' { '\n' } else { ' ' });
+                index += 1;
+            }
+
+            continue;
+        }
+
+        if state == "string" {
+            output.push(current);
+
+            if current == '\\' {
+                if let Some(next_char) = next {
+                    output.push(next_char);
+                    index += 2;
+                    continue;
+                }
+            } else if current == '"' {
+                state = "code";
+            }
+
+            index += 1;
+            continue;
+        }
+
+        if current == '/' && next == Some('/') {
+            output.push(' ');
+            output.push(' ');
+            index += 2;
+            state = "line-comment";
+            continue;
+        }
+
+        if current == '/' && next == Some('*') {
+            output.push(' ');
+            output.push(' ');
+            index += 2;
+            state = "block-comment";
+            continue;
+        }
+
+        if current == '"' {
+            state = "string";
+        }
+
+        output.push(current);
+        index += 1;
+    }
+
+    output
+}
+
+fn strip_trailing_commas(input: &str) -> String {
+    let chars: Vec<char> = input.chars().collect();
+    let mut output = String::with_capacity(input.len());
+    let mut index = 0;
+    let mut state = "code";
+
+    while index < chars.len() {
+        let current = chars[index];
+
+        if state == "string" {
+            output.push(current);
+
+            if current == '\\' {
+                if let Some(next_char) = chars.get(index + 1).copied() {
+                    output.push(next_char);
+                    index += 2;
+                    continue;
+                }
+            } else if current == '"' {
+                state = "code";
+            }
+
+            index += 1;
+            continue;
+        }
+
+        if current == '"' {
+            state = "string";
+            output.push(current);
+            index += 1;
+            continue;
+        }
+
+        if current == ',' {
+            let mut lookahead = index + 1;
+
+            while lookahead < chars.len() && chars[lookahead].is_whitespace() {
+                lookahead += 1;
+            }
+
+            if matches!(chars.get(lookahead), Some(&'}') | Some(&']')) {
+                index += 1;
+                continue;
+            }
+        }
+
+        output.push(current);
+        index += 1;
+    }
+
+    output
+}
+
+struct Parser {
+    chars: Vec<char>,
+    pos: usize,
+}
+
+impl Parser {
+    fn new(input: &str) -> Self {
+        Self {
+            chars: input.chars().collect(),
+            pos: 0,
+        }
+    }
+
+    fn parse(mut self) -> KratosResult<JsonValue> {
+        self.skip_whitespace();
+        let value = self.parse_value()?;
+        self.skip_whitespace();
+
+        if self.pos != self.chars.len() {
+            return Err(self.error("Unexpected trailing content"));
+        }
+
+        Ok(value)
+    }
+
+    fn parse_value(&mut self) -> KratosResult<JsonValue> {
+        self.skip_whitespace();
+
+        match self.peek() {
+            Some('{') => self.parse_object(),
+            Some('[') => self.parse_array(),
+            Some('"') => self.parse_string().map(JsonValue::String),
+            Some('t') => self.parse_keyword("true", JsonValue::Bool(true)),
+            Some('f') => self.parse_keyword("false", JsonValue::Bool(false)),
+            Some('n') => self.parse_keyword("null", JsonValue::Null),
+            Some('-' | '0'..='9') => self.parse_number().map(JsonValue::Number),
+            Some(_) => Err(self.error("Unexpected token")),
+            None => Err(self.error("Unexpected end of input")),
+        }
+    }
+
+    fn parse_object(&mut self) -> KratosResult<JsonValue> {
+        self.expect('{')?;
+        self.skip_whitespace();
+
+        let mut values = JsonObject::default();
+
+        if self.peek() == Some('}') {
+            self.pos += 1;
+            return Ok(JsonValue::Object(values));
+        }
+
+        loop {
+            self.skip_whitespace();
+
+            if self.peek() != Some('"') {
+                return Err(self.error("Object keys must be strings"));
+            }
+
+            let key = self.parse_string()?;
+            self.skip_whitespace();
+            self.expect(':')?;
+            self.skip_whitespace();
+
+            let value = self.parse_value()?;
+            values.insert(key, value);
+            self.skip_whitespace();
+
+            match self.peek() {
+                Some(',') => {
+                    self.pos += 1;
+                }
+                Some('}') => {
+                    self.pos += 1;
+                    break;
+                }
+                _ => return Err(self.error("Expected ',' or '}' in object")),
+            }
+        }
+
+        Ok(JsonValue::Object(values))
+    }
+
+    fn parse_array(&mut self) -> KratosResult<JsonValue> {
+        self.expect('[')?;
+        self.skip_whitespace();
+
+        let mut values = Vec::new();
+
+        if self.peek() == Some(']') {
+            self.pos += 1;
+            return Ok(JsonValue::Array(values));
+        }
+
+        loop {
+            values.push(self.parse_value()?);
+            self.skip_whitespace();
+
+            match self.peek() {
+                Some(',') => {
+                    self.pos += 1;
+                }
+                Some(']') => {
+                    self.pos += 1;
+                    break;
+                }
+                _ => return Err(self.error("Expected ',' or ']' in array")),
+            }
+        }
+
+        Ok(JsonValue::Array(values))
+    }
+
+    fn parse_string(&mut self) -> KratosResult<String> {
+        self.expect('"')?;
+        let mut value = String::new();
+
+        while let Some(current) = self.next() {
+            match current {
+                '"' => return Ok(value),
+                '\\' => {
+                    let escaped = self
+                        .next()
+                        .ok_or_else(|| self.error("Unterminated escape sequence"))?;
+
+                    match escaped {
+                        '"' => value.push('"'),
+                        '\\' => value.push('\\'),
+                        '/' => value.push('/'),
+                        'b' => value.push('\u{0008}'),
+                        'f' => value.push('\u{000C}'),
+                        'n' => value.push('\n'),
+                        'r' => value.push('\r'),
+                        't' => value.push('\t'),
+                        'u' => value.push(self.parse_unicode_escape()?),
+                        _ => return Err(self.error("Unsupported escape sequence")),
+                    }
+                }
+                other if other <= '\u{001F}' => {
+                    return Err(self.error("Unescaped control character in string"))
+                }
+                other => value.push(other),
+            }
+        }
+
+        Err(self.error("Unterminated string"))
+    }
+
+    fn parse_unicode_escape(&mut self) -> KratosResult<char> {
+        let first = self.parse_unicode_code_unit()?;
+
+        if (0xD800..=0xDBFF).contains(&first) {
+            self.expect('\\')?;
+            self.expect('u')?;
+            let second = self.parse_unicode_code_unit()?;
+
+            if !(0xDC00..=0xDFFF).contains(&second) {
+                return Err(self.error("Invalid unicode surrogate pair"));
+            }
+
+            let high = u32::from(first) - 0xD800;
+            let low = u32::from(second) - 0xDC00;
+            let codepoint = 0x10000 + ((high << 10) | low);
+
+            return char::from_u32(codepoint)
+                .ok_or_else(|| self.error("Invalid unicode codepoint"));
+        }
+
+        if (0xDC00..=0xDFFF).contains(&first) {
+            return Err(self.error("Unexpected low surrogate"));
+        }
+
+        char::from_u32(u32::from(first)).ok_or_else(|| self.error("Invalid unicode codepoint"))
+    }
+
+    fn parse_unicode_code_unit(&mut self) -> KratosResult<u16> {
+        let mut hex = String::new();
+
+        for _ in 0..4 {
+            let ch = self
+                .next()
+                .ok_or_else(|| self.error("Incomplete unicode escape"))?;
+
+            if !ch.is_ascii_hexdigit() {
+                return Err(self.error("Invalid unicode escape"));
+            }
+
+            hex.push(ch);
+        }
+
+        u16::from_str_radix(&hex, 16).map_err(|_| self.error("Invalid unicode escape"))
+    }
+
+    fn parse_number(&mut self) -> KratosResult<String> {
+        let start = self.pos;
+
+        if self.peek() == Some('-') {
+            self.pos += 1;
+        }
+
+        self.consume_digits()?;
+
+        if self.peek() == Some('.') {
+            self.pos += 1;
+            self.consume_digits()?;
+        }
+
+        if matches!(self.peek(), Some('e') | Some('E')) {
+            self.pos += 1;
+
+            if matches!(self.peek(), Some('+') | Some('-')) {
+                self.pos += 1;
+            }
+
+            self.consume_digits()?;
+        }
+
+        Ok(self.chars[start..self.pos].iter().collect())
+    }
+
+    fn parse_keyword(&mut self, keyword: &str, value: JsonValue) -> KratosResult<JsonValue> {
+        if self.starts_with(keyword) {
+            self.pos += keyword.chars().count();
+            Ok(value)
+        } else {
+            Err(self.error("Unexpected token"))
+        }
+    }
+
+    fn consume_digits(&mut self) -> KratosResult<()> {
+        let start = self.pos;
+
+        while matches!(self.peek(), Some('0'..='9')) {
+            self.pos += 1;
+        }
+
+        if self.pos == start {
+            return Err(self.error("Expected digit"));
+        }
+
+        Ok(())
+    }
+
+    fn skip_whitespace(&mut self) {
+        while matches!(self.peek(), Some(ch) if ch.is_whitespace()) {
+            self.pos += 1;
+        }
+    }
+
+    fn expect(&mut self, expected: char) -> KratosResult<()> {
+        match self.next() {
+            Some(found) if found == expected => Ok(()),
+            _ => Err(self.error(&format!("Expected '{expected}'"))),
+        }
+    }
+
+    fn starts_with(&self, keyword: &str) -> bool {
+        let needle: Vec<char> = keyword.chars().collect();
+        self.chars[self.pos..].starts_with(&needle)
+    }
+
+    fn peek(&self) -> Option<char> {
+        self.chars.get(self.pos).copied()
+    }
+
+    fn next(&mut self) -> Option<char> {
+        let ch = self.peek()?;
+        self.pos += 1;
+        Some(ch)
+    }
+
+    fn error(&self, message: &str) -> KratosError {
+        KratosError::Json(format!("{message} at character {}", self.pos))
+    }
 }

--- a/crates/kratos-core/src/model.rs
+++ b/crates/kratos-core/src/model.rs
@@ -31,6 +31,7 @@ impl ProjectConfig {
 pub struct PathAlias {
     pub alias: String,
     pub target: PathBuf,
+    pub target_pattern: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -148,6 +149,7 @@ pub struct ImportResolution {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ImportResolutionKind {
     Source,
+    Asset,
     External,
     MissingInternal,
 }

--- a/crates/kratos-core/src/resolve.rs
+++ b/crates/kratos-core/src/resolve.rs
@@ -19,6 +19,7 @@ pub fn resolve_import_target(
     config: &ProjectConfig,
 ) -> KratosResult<ImportResolution> {
     let project_root = normalize_config_path(&config.root);
+    let importer_path = normalize_config_path(importer_path);
 
     if request.starts_with("node:") {
         return Ok(external_import(request, None));
@@ -62,6 +63,11 @@ fn resolve_aliased_import(request: &str, alias: &PathAlias) -> PathBuf {
         return alias.target.clone();
     };
 
+    if let Some(pattern) = &alias.target_pattern {
+        let substituted = pattern.replacen('*', capture, 1);
+        return normalize_path(PathBuf::from(substituted));
+    }
+
     if capture.is_empty() {
         alias.target.clone()
     } else {
@@ -92,6 +98,8 @@ fn resolve_internal_path(base_path: &Path, request: &str) -> KratosResult<Import
 
     let kind = if is_source_path(&path) {
         ImportResolutionKind::Source
+    } else if path.is_file() {
+        ImportResolutionKind::Asset
     } else {
         ImportResolutionKind::External
     };
@@ -174,8 +182,16 @@ fn normalize_path(path: PathBuf) -> PathBuf {
             Component::RootDir => normalized.push(component.as_os_str()),
             Component::CurDir => {}
             Component::ParentDir => {
-                if !normalized.pop() && !path.is_absolute() {
-                    normalized.push(component.as_os_str());
+                match normalized.components().next_back() {
+                    Some(Component::Normal(_)) => {
+                        normalized.pop();
+                    }
+                    Some(Component::ParentDir) | None => {
+                        if !path.is_absolute() {
+                            normalized.push(component.as_os_str());
+                        }
+                    }
+                    Some(Component::Prefix(_)) | Some(Component::RootDir) | Some(Component::CurDir) => {}
                 }
             }
             Component::Normal(part) => normalized.push(part),
@@ -186,5 +202,19 @@ fn normalize_path(path: PathBuf) -> PathBuf {
         PathBuf::from(".")
     } else {
         normalized
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_path;
+    use std::path::PathBuf;
+
+    #[test]
+    fn normalize_path_preserves_leading_parent_segments() {
+        assert_eq!(
+            normalize_path(PathBuf::from("../../src")),
+            PathBuf::from("../../src")
+        );
     }
 }

--- a/crates/kratos-core/src/resolve.rs
+++ b/crates/kratos-core/src/resolve.rs
@@ -1,7 +1,9 @@
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 
-use crate::error::{KratosError, KratosResult};
-use crate::model::{ImportResolution, ImportResolutionKind, ProjectConfig};
+use crate::error::KratosResult;
+use crate::model::{ImportResolution, ImportResolutionKind, PathAlias, ProjectConfig};
+
+const SOURCE_EXTENSIONS: &[&str] = &[".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".mts", ".cts"];
 
 pub fn unresolved_import(source: impl Into<String>) -> ImportResolution {
     ImportResolution {
@@ -12,11 +14,177 @@ pub fn unresolved_import(source: impl Into<String>) -> ImportResolution {
 }
 
 pub fn resolve_import_target(
-    _source: &str,
-    _from: &Path,
-    _config: &ProjectConfig,
+    request: &str,
+    importer_path: &Path,
+    config: &ProjectConfig,
 ) -> KratosResult<ImportResolution> {
-    Err(KratosError::not_implemented(
-        "resolve::resolve_import_target",
-    ))
+    let project_root = normalize_config_path(&config.root);
+
+    if request.starts_with("node:") {
+        return Ok(external_import(request, None));
+    }
+
+    if request.starts_with('.') {
+        let base = importer_path
+            .parent()
+            .unwrap_or(project_root.as_path())
+            .join(request);
+        return resolve_internal_path(&base, request);
+    }
+
+    if request.starts_with('/') {
+        let relative = request.trim_start_matches('/');
+        return resolve_internal_path(&project_root.join(relative), request);
+    }
+
+    for alias in &config.path_aliases {
+        if !matches_alias(&alias.alias, request) {
+            continue;
+        }
+
+        let candidate = resolve_aliased_import(request, alias);
+        return resolve_internal_path(&candidate, request);
+    }
+
+    if let Some(base_url) = config.base_url.as_ref().map(|value| normalize_config_path(value)) {
+        let resolution = resolve_internal_path(&base_url.join(request), request)?;
+
+        if resolution.kind != ImportResolutionKind::MissingInternal {
+            return Ok(resolution);
+        }
+    }
+
+    Ok(external_import(request, None))
+}
+
+fn resolve_aliased_import(request: &str, alias: &PathAlias) -> PathBuf {
+    let Some(capture) = match_alias_capture(&alias.alias, request) else {
+        return alias.target.clone();
+    };
+
+    if capture.is_empty() {
+        alias.target.clone()
+    } else {
+        normalize_path(alias.target.join(capture))
+    }
+}
+
+fn matches_alias(alias: &str, request: &str) -> bool {
+    match_alias_capture(alias, request).is_some()
+}
+
+fn match_alias_capture<'a>(alias: &str, request: &'a str) -> Option<&'a str> {
+    let Some((prefix, suffix)) = alias.split_once('*') else {
+        return (request == alias).then_some("");
+    };
+
+    let remainder = request.strip_prefix(prefix)?;
+    let capture = remainder.strip_suffix(suffix)?;
+    Some(capture)
+}
+
+fn resolve_internal_path(base_path: &Path, request: &str) -> KratosResult<ImportResolution> {
+    let normalized_base_path = normalize_path(base_path.to_path_buf());
+
+    let Some(path) = resolve_file(&normalized_base_path)? else {
+        return Ok(unresolved_import(request));
+    };
+
+    let kind = if is_source_path(&path) {
+        ImportResolutionKind::Source
+    } else {
+        ImportResolutionKind::External
+    };
+
+    Ok(ImportResolution {
+        kind,
+        source: request.to_string(),
+        path: Some(path),
+    })
+}
+
+fn resolve_file(base_path: &Path) -> KratosResult<Option<PathBuf>> {
+    if base_path.is_file() {
+        return Ok(Some(base_path.to_path_buf()));
+    }
+
+    if base_path.extension().is_none() {
+        for extension in SOURCE_EXTENSIONS {
+            let candidate = append_extension(base_path, extension);
+
+            if candidate.is_file() {
+                return Ok(Some(candidate));
+            }
+        }
+    }
+
+    if base_path.is_dir() {
+        for extension in SOURCE_EXTENSIONS {
+            let candidate = base_path.join(format!("index{extension}"));
+
+            if candidate.is_file() {
+                return Ok(Some(candidate));
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+fn append_extension(base_path: &Path, extension: &str) -> PathBuf {
+    PathBuf::from(format!("{}{}", base_path.to_string_lossy(), extension))
+}
+
+fn normalize_config_path(path: &Path) -> PathBuf {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join(path)
+    };
+
+    normalize_path(absolute)
+}
+
+fn external_import(source: &str, path: Option<PathBuf>) -> ImportResolution {
+    ImportResolution {
+        kind: ImportResolutionKind::External,
+        source: source.to_string(),
+        path,
+    }
+}
+
+fn is_source_path(path: &Path) -> bool {
+    let Some(extension) = path.extension().and_then(|value| value.to_str()) else {
+        return false;
+    };
+
+    SOURCE_EXTENSIONS
+        .iter()
+        .any(|candidate| candidate.trim_start_matches('.') == extension)
+}
+
+fn normalize_path(path: PathBuf) -> PathBuf {
+    let mut normalized = PathBuf::new();
+
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => normalized.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !normalized.pop() && !path.is_absolute() {
+                    normalized.push(component.as_os_str());
+                }
+            }
+            Component::Normal(part) => normalized.push(part),
+        }
+    }
+
+    if normalized.as_os_str().is_empty() && !path.is_absolute() {
+        PathBuf::from(".")
+    } else {
+        normalized
+    }
 }

--- a/crates/kratos-core/tests/config_and_discovery.rs
+++ b/crates/kratos-core/tests/config_and_discovery.rs
@@ -24,7 +24,8 @@ fn load_project_config_parses_comments_and_collects_entries() {
       "import": "./dist/index.mjs",
       "types": "./dist/index.d.ts"
     },
-    "./cli": "./dist/cli.js"
+    "./cli": "./dist/cli.js",
+    "./empty": ""
   }
 }
 "#,
@@ -47,7 +48,7 @@ fn load_project_config_parses_comments_and_collects_entries() {
         "kratos.config.json",
         r#"{
   "ignore": ["custom-cache",],
-  "entry": ["src/main.ts",],
+  "entry": ["src/main.ts", "./src/./main.ts"],
   "roots": ["src", "missing",],
 }
 "#,
@@ -86,6 +87,10 @@ fn load_project_config_parses_comments_and_collects_entries() {
     assert!(config
         .package_entries
         .contains(&project.root().join("dist/cli.js")));
+    assert!(
+        !config.package_entries.contains(&project.root().to_path_buf()),
+        "empty export targets should be ignored"
+    );
 }
 
 #[test]
@@ -125,16 +130,21 @@ fn resolve_import_target_uses_paths_base_url_and_directory_fallbacks() {
     "baseUrl": "src",
     "paths": {
       "@/*": ["./*"],
-      "@cfg": ["./config/index.ts"]
+      "@cfg": ["./config/index.ts"],
+      "@view/*": ["./views/*/index.ts"],
+      "@fixed/*": ["./fixed/index.ts"]
     }
   }
 }
 "#,
     );
     project.write("src/app/main.ts", "export const main = true;\n");
+    project.write("src/app/logo.svg", "<svg />\n");
     project.write("src/lib/math.ts", "export const add = true;\n");
     project.write("src/shared/index.ts", "export const shared = true;\n");
     project.write("src/config/index.ts", "export const config = true;\n");
+    project.write("src/views/home/index.ts", "export const view = true;\n");
+    project.write("src/fixed/index.ts", "export const fixed = true;\n");
     project.write("lib/root-entry.ts", "export const rootEntry = true;\n");
 
     let config = load_project_config(project.root()).expect("config should load");
@@ -152,6 +162,19 @@ fn resolve_import_target_uses_paths_base_url_and_directory_fallbacks() {
     assert_eq!(base_url.kind, ImportResolutionKind::Source);
     assert_eq!(base_url.path, Some(project.root().join("src/shared/index.ts")));
 
+    let middle_wildcard =
+        resolve_import_target("@view/home", &importer, &config).expect("middle wildcard");
+    assert_eq!(middle_wildcard.kind, ImportResolutionKind::Source);
+    assert_eq!(
+        middle_wildcard.path,
+        Some(project.root().join("src/views/home/index.ts"))
+    );
+
+    let fixed_target =
+        resolve_import_target("@fixed/anything", &importer, &config).expect("fixed target");
+    assert_eq!(fixed_target.kind, ImportResolutionKind::MissingInternal);
+    assert_eq!(fixed_target.path, None);
+
     let root_relative =
         resolve_import_target("/lib/root-entry", &importer, &config).expect("root relative");
     assert_eq!(root_relative.kind, ImportResolutionKind::Source);
@@ -160,6 +183,10 @@ fn resolve_import_target_uses_paths_base_url_and_directory_fallbacks() {
     let builtin = resolve_import_target("node:path", &importer, &config).expect("builtin");
     assert_eq!(builtin.kind, ImportResolutionKind::External);
     assert_eq!(builtin.path, None);
+
+    let asset = resolve_import_target("./logo.svg", &importer, &config).expect("asset resolves");
+    assert_eq!(asset.kind, ImportResolutionKind::Asset);
+    assert_eq!(asset.path, Some(project.root().join("src/app/logo.svg")));
 
     let missing = resolve_import_target("./missing", &importer, &config).expect("missing");
     assert_eq!(missing.kind, ImportResolutionKind::MissingInternal);
@@ -326,6 +353,21 @@ fn resolve_import_target_normalizes_dot_segments_in_requests() {
 }
 
 #[test]
+fn resolve_import_target_accepts_relative_importer_paths() {
+    let (project, relative_root) = TestProject::new_relative_to_current_dir("relative-importer");
+    project.write("src/app/main.ts", "export const main = true;\n");
+    project.write("src/app/bar.ts", "export const bar = true;\n");
+
+    let config = load_project_config(relative_root.clone()).expect("config should load");
+    let importer = relative_root.join("src/app/main.ts");
+
+    let resolution =
+        resolve_import_target("./bar", &importer, &config).expect("relative importer resolves");
+    assert_eq!(resolution.kind, ImportResolutionKind::Source);
+    assert_eq!(resolution.path, Some(project.root().join("src/app/bar.ts")));
+}
+
+#[test]
 fn parse_loose_json_rejects_control_characters_and_supports_surrogate_pairs() {
     let parsed = parse_loose_json(r#"{ "emoji": "\uD83D\uDE00" }"#)
         .expect("surrogate pair should parse");
@@ -343,6 +385,26 @@ fn parse_loose_json_rejects_control_characters_and_supports_surrogate_pairs() {
             .contains("Unescaped control character in string"),
         "unexpected error: {invalid}"
     );
+
+    let leading_zero = parse_loose_json(r#"{"count":01}"#)
+        .expect_err("leading-zero numbers should be rejected");
+    assert!(
+        leading_zero
+            .to_string()
+            .contains("Leading zeros are not allowed"),
+        "unexpected error: {leading_zero}"
+    );
+
+    let lone_surrogate = parse_loose_json(r#"{ "value": "\uD83D" }"#)
+        .expect("lone surrogate escapes should stay loadable");
+    let lone_value = lone_surrogate
+        .get("value")
+        .and_then(JsonValue::as_str)
+        .expect("value string should exist");
+    assert!(
+        lone_value == "\\uD83D" || lone_value == "\\ud83d",
+        "unexpected lone surrogate representation: {lone_value}"
+    );
 }
 
 #[test]
@@ -359,7 +421,9 @@ fn load_project_config_rejects_non_string_array_items() {
 
     let error = load_project_config(project.root()).expect_err("invalid roots should fail");
     assert!(
-        error.to_string().contains("roots must contain only string values"),
+        error
+            .to_string()
+            .contains("roots must contain only string values"),
         "unexpected error: {error}"
     );
 
@@ -373,7 +437,9 @@ fn load_project_config_rejects_non_string_array_items() {
 
     let error = load_project_config(project.root()).expect_err("invalid entry should fail");
     assert!(
-        error.to_string().contains("entry must contain only string values"),
+        error
+            .to_string()
+            .contains("entry must contain only string values"),
         "unexpected error: {error}"
     );
 
@@ -397,6 +463,47 @@ fn load_project_config_rejects_non_string_array_items() {
             .contains("compilerOptions.paths['@/*'] must contain only string targets"),
         "unexpected error: {error}"
     );
+
+    project.write(
+        "kratos.config.json",
+        r#"{
+  "roots": "src"
+}
+"#,
+    );
+    project.write("tsconfig.json", "{}\n");
+
+    let config = load_project_config(project.root()).expect("non-array roots should be ignored");
+    assert_eq!(config.roots, vec![project.root().to_path_buf()]);
+
+    project.write(
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "paths": []
+  }
+}
+"#,
+    );
+    project.write("kratos.config.json", "{}\n");
+
+    let config = load_project_config(project.root()).expect("non-object paths should be ignored");
+    assert!(config.path_aliases.is_empty());
+
+    project.write(
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "paths": {
+      "@/*": "./src/*"
+    }
+  }
+}
+"#,
+    );
+
+    let config = load_project_config(project.root()).expect("non-array alias targets should be ignored");
+    assert!(config.path_aliases.is_empty());
 }
 
 struct TestProject {

--- a/crates/kratos-core/tests/config_and_discovery.rs
+++ b/crates/kratos-core/tests/config_and_discovery.rs
@@ -1,0 +1,458 @@
+use std::path::{Path, PathBuf};
+
+use kratos_core::config::load_project_config;
+use kratos_core::discover::collect_source_files;
+use kratos_core::jsonc::parse_loose_json;
+use kratos_core::jsonc::JsonValue;
+use kratos_core::model::ImportResolutionKind;
+use kratos_core::resolve::resolve_import_target;
+
+#[test]
+fn load_project_config_parses_comments_and_collects_entries() {
+    let project = TestProject::new("config-parsing");
+    project.write(
+        "package.json",
+        r#"{
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "kratos": "./bin/kratos.js"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
+    },
+    "./cli": "./dist/cli.js"
+  }
+}
+"#,
+    );
+    project.write(
+        "tsconfig.json",
+        r#"{
+  // comment
+  "compilerOptions": {
+    "baseUrl": "src",
+    "paths": {
+      "@/*": ["./*"],
+      "@deep/*": ["./deep/*"],
+    },
+  },
+}
+"#,
+    );
+    project.write(
+        "kratos.config.json",
+        r#"{
+  "ignore": ["custom-cache",],
+  "entry": ["src/main.ts",],
+  "roots": ["src", "missing",],
+}
+"#,
+    );
+
+    let config = load_project_config(project.root()).expect("config should load");
+
+    assert_eq!(config.base_url, Some(project.root().join("src")));
+    assert_eq!(
+        config.roots,
+        vec![project.root().join("src"), project.root().join("missing")]
+    );
+    assert!(config
+        .ignored_directories
+        .iter()
+        .any(|entry| entry == ".git"));
+    assert!(config
+        .ignored_directories
+        .iter()
+        .any(|entry| entry == "custom-cache"));
+    assert_eq!(config.explicit_entries, vec![project.root().join("src/main.ts")]);
+    assert_eq!(config.path_aliases[0].alias, "@deep/*");
+    assert_eq!(config.path_aliases[1].alias, "@/*");
+    assert!(config
+        .package_entries
+        .contains(&project.root().join("dist/index.js")));
+    assert!(config
+        .package_entries
+        .contains(&project.root().join("dist/index.mjs")));
+    assert!(config
+        .package_entries
+        .contains(&project.root().join("dist/index.d.ts")));
+    assert!(config
+        .package_entries
+        .contains(&project.root().join("bin/kratos.js")));
+    assert!(config
+        .package_entries
+        .contains(&project.root().join("dist/cli.js")));
+}
+
+#[test]
+fn collect_source_files_skips_missing_roots_and_ignored_dirs() {
+    let project = TestProject::new("source-discovery");
+    project.write(
+        "kratos.config.json",
+        r#"{
+  "roots": ["src", "missing"]
+}
+"#,
+    );
+    project.write("src/main.ts", "export const main = true;\n");
+    project.write("src/nested/util.ts", "export const util = true;\n");
+    project.write("src/dist/generated.js", "export const generated = true;\n");
+    project.write("src/assets/logo.svg", "<svg />\n");
+
+    let config = load_project_config(project.root()).expect("config should load");
+    let discovered = collect_source_files(&config).expect("source discovery should succeed");
+
+    assert_eq!(
+        discovered,
+        vec![
+            project.root().join("src/main.ts"),
+            project.root().join("src/nested/util.ts")
+        ]
+    );
+}
+
+#[test]
+fn resolve_import_target_uses_paths_base_url_and_directory_fallbacks() {
+    let project = TestProject::new("resolve-targets");
+    project.write(
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "baseUrl": "src",
+    "paths": {
+      "@/*": ["./*"],
+      "@cfg": ["./config/index.ts"]
+    }
+  }
+}
+"#,
+    );
+    project.write("src/app/main.ts", "export const main = true;\n");
+    project.write("src/lib/math.ts", "export const add = true;\n");
+    project.write("src/shared/index.ts", "export const shared = true;\n");
+    project.write("src/config/index.ts", "export const config = true;\n");
+    project.write("lib/root-entry.ts", "export const rootEntry = true;\n");
+
+    let config = load_project_config(project.root()).expect("config should load");
+    let importer = project.root().join("src/app/main.ts");
+
+    let alias = resolve_import_target("@/lib/math", &importer, &config).expect("alias resolves");
+    assert_eq!(alias.kind, ImportResolutionKind::Source);
+    assert_eq!(alias.path, Some(project.root().join("src/lib/math.ts")));
+
+    let exact_alias = resolve_import_target("@cfg", &importer, &config).expect("exact alias");
+    assert_eq!(exact_alias.kind, ImportResolutionKind::Source);
+    assert_eq!(exact_alias.path, Some(project.root().join("src/config/index.ts")));
+
+    let base_url = resolve_import_target("shared", &importer, &config).expect("baseUrl resolves");
+    assert_eq!(base_url.kind, ImportResolutionKind::Source);
+    assert_eq!(base_url.path, Some(project.root().join("src/shared/index.ts")));
+
+    let root_relative =
+        resolve_import_target("/lib/root-entry", &importer, &config).expect("root relative");
+    assert_eq!(root_relative.kind, ImportResolutionKind::Source);
+    assert_eq!(root_relative.path, Some(project.root().join("lib/root-entry.ts")));
+
+    let builtin = resolve_import_target("node:path", &importer, &config).expect("builtin");
+    assert_eq!(builtin.kind, ImportResolutionKind::External);
+    assert_eq!(builtin.path, None);
+
+    let missing = resolve_import_target("./missing", &importer, &config).expect("missing");
+    assert_eq!(missing.kind, ImportResolutionKind::MissingInternal);
+    assert_eq!(missing.path, None);
+}
+
+#[test]
+fn resolve_import_target_preserves_same_length_alias_insertion_order() {
+    let project = TestProject::new("alias-order");
+    project.write(
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "baseUrl": "src",
+    "paths": {
+      "@foo*": ["./preferred/*"],
+      "@*bar": ["./fallback/*"]
+    }
+  }
+}
+"#,
+    );
+    project.write("src/main.ts", "export const main = true;\n");
+    project.write("src/preferred/bar.ts", "export const preferred = true;\n");
+    project.write("src/fallback/foo.ts", "export const fallback = true;\n");
+
+    let config = load_project_config(project.root()).expect("config should load");
+    let aliases = config
+        .path_aliases
+        .iter()
+        .map(|alias| alias.alias.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(aliases, vec!["@foo*", "@*bar"]);
+
+    let importer = project.root().join("src/main.ts");
+    let resolution =
+        resolve_import_target("@foobar", &importer, &config).expect("alias should resolve");
+    assert_eq!(resolution.kind, ImportResolutionKind::Source);
+    assert_eq!(resolution.path, Some(project.root().join("src/preferred/bar.ts")));
+}
+
+#[test]
+fn resolve_import_target_honors_wildcard_alias_suffix() {
+    let project = TestProject::new("alias-suffix");
+    project.write(
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "baseUrl": "src",
+    "paths": {
+      "@foo*baz": ["./preferred/*"],
+      "@foo*bar": ["./fallback/*"]
+    }
+  }
+}
+"#,
+    );
+    project.write("src/main.ts", "export const main = true;\n");
+    project.write("src/preferred/qux.ts", "export const preferred = true;\n");
+    project.write("src/fallback/qux.ts", "export const fallback = true;\n");
+
+    let config = load_project_config(project.root()).expect("config should load");
+    let importer = project.root().join("src/main.ts");
+
+    let preferred =
+        resolve_import_target("@fooquxbaz", &importer, &config).expect("suffix alias resolves");
+    assert_eq!(preferred.kind, ImportResolutionKind::Source);
+    assert_eq!(preferred.path, Some(project.root().join("src/preferred/qux.ts")));
+
+    let fallback =
+        resolve_import_target("@fooquxbar", &importer, &config).expect("suffix alias resolves");
+    assert_eq!(fallback.kind, ImportResolutionKind::Source);
+    assert_eq!(fallback.path, Some(project.root().join("src/fallback/qux.ts")));
+
+    let missing =
+        resolve_import_target("@fooquxnope", &importer, &config).expect("suffix mismatch");
+    assert_eq!(missing.kind, ImportResolutionKind::External);
+    assert_eq!(missing.path, None);
+}
+
+#[test]
+fn load_project_config_normalizes_relative_root_for_discovery_and_resolution() {
+    let (project, relative_root) = TestProject::new_relative_to_current_dir("relative-root");
+    project.write(
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "baseUrl": "src"
+  }
+}
+"#,
+    );
+    project.write(
+        "kratos.config.json",
+        r#"{
+  "roots": ["src"]
+}
+"#,
+    );
+    project.write("src/app/main.ts", "export const main = true;\n");
+    project.write("src/lib/math.ts", "export const math = true;\n");
+    project.write("app/root-entry.ts", "export const rootEntry = true;\n");
+
+    let config = load_project_config(relative_root).expect("relative root should load");
+    assert_eq!(config.root, project.root());
+    assert_eq!(config.base_url, Some(project.root().join("src")));
+    assert_eq!(config.roots, vec![project.root().join("src")]);
+
+    let discovered = collect_source_files(&config).expect("source discovery should succeed");
+    assert_eq!(
+        discovered,
+        vec![
+            project.root().join("src/app/main.ts"),
+            project.root().join("src/lib/math.ts")
+        ]
+    );
+
+    let importer = project.root().join("src/app/main.ts");
+    let base_url = resolve_import_target("lib/math", &importer, &config).expect("baseUrl resolves");
+    assert_eq!(base_url.kind, ImportResolutionKind::Source);
+    assert_eq!(base_url.path, Some(project.root().join("src/lib/math.ts")));
+
+    let root_relative =
+        resolve_import_target("/app/root-entry", &importer, &config).expect("root relative");
+    assert_eq!(root_relative.kind, ImportResolutionKind::Source);
+    assert_eq!(root_relative.path, Some(project.root().join("app/root-entry.ts")));
+}
+
+#[test]
+fn load_project_config_normalizes_dot_segments_in_base_url_and_alias_targets() {
+    let project = TestProject::new("normalized-config-paths");
+    project.write(
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "baseUrl": "./src/app/..",
+    "paths": {
+      "@/*": ["./generated/../shared/*"]
+    }
+  }
+}
+"#,
+    );
+
+    let config = load_project_config(project.root()).expect("config should load");
+    assert_eq!(config.base_url, Some(project.root().join("src")));
+    assert_eq!(config.path_aliases.len(), 1);
+    assert_eq!(config.path_aliases[0].target, project.root().join("src/shared"));
+}
+
+#[test]
+fn resolve_import_target_normalizes_dot_segments_in_requests() {
+    let project = TestProject::new("normalized-requests");
+    project.write("src/app/main.ts", "export const main = true;\n");
+    project.write("src/app/bar.ts", "export const bar = true;\n");
+
+    let config = load_project_config(project.root()).expect("config should load");
+    let importer = project.root().join("src/app/main.ts");
+
+    let resolution =
+        resolve_import_target("./foo/../bar", &importer, &config).expect("request resolves");
+    assert_eq!(resolution.kind, ImportResolutionKind::Source);
+    assert_eq!(resolution.path, Some(project.root().join("src/app/bar.ts")));
+}
+
+#[test]
+fn parse_loose_json_rejects_control_characters_and_supports_surrogate_pairs() {
+    let parsed = parse_loose_json(r#"{ "emoji": "\uD83D\uDE00" }"#)
+        .expect("surrogate pair should parse");
+    let emoji = parsed
+        .get("emoji")
+        .and_then(JsonValue::as_str)
+        .expect("emoji string should exist");
+    assert_eq!(emoji, "😀");
+
+    let invalid = parse_loose_json("{\"label\":\"line\nbreak\"}")
+        .expect_err("raw newline inside string should be rejected");
+    assert!(
+        invalid
+            .to_string()
+            .contains("Unescaped control character in string"),
+        "unexpected error: {invalid}"
+    );
+}
+
+#[test]
+fn load_project_config_rejects_non_string_array_items() {
+    let project = TestProject::new("invalid-config-items");
+    project.write(
+        "kratos.config.json",
+        r#"{
+  "roots": [null],
+  "entry": ["src/main.ts"]
+}
+"#,
+    );
+
+    let error = load_project_config(project.root()).expect_err("invalid roots should fail");
+    assert!(
+        error.to_string().contains("roots must contain only string values"),
+        "unexpected error: {error}"
+    );
+
+    project.write(
+        "kratos.config.json",
+        r#"{
+  "entry": [null]
+}
+"#,
+    );
+
+    let error = load_project_config(project.root()).expect_err("invalid entry should fail");
+    assert!(
+        error.to_string().contains("entry must contain only string values"),
+        "unexpected error: {error}"
+    );
+
+    project.write(
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "paths": {
+      "@/*": [null]
+    }
+  }
+}
+"#,
+    );
+    project.write("kratos.config.json", "{}\n");
+
+    let error = load_project_config(project.root()).expect_err("invalid paths should fail");
+    assert!(
+        error
+            .to_string()
+            .contains("compilerOptions.paths['@/*'] must contain only string targets"),
+        "unexpected error: {error}"
+    );
+}
+
+struct TestProject {
+    root: PathBuf,
+}
+
+impl TestProject {
+    fn new(label: &str) -> Self {
+        let mut root = std::env::temp_dir();
+        root.push(format!(
+            "kratos-{label}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("time should move forward")
+                .as_nanos()
+        ));
+
+        std::fs::create_dir_all(&root).expect("temp project should be created");
+        Self { root }
+    }
+
+    fn new_relative_to_current_dir(label: &str) -> (Self, PathBuf) {
+        let current_dir = std::env::current_dir().expect("current dir should be available");
+        let unique = format!(
+            "kratos-{label}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("time should move forward")
+                .as_nanos()
+        );
+        let relative = PathBuf::from(".tmp").join(unique);
+        let root = current_dir.join(&relative);
+
+        std::fs::create_dir_all(&root).expect("temp project should be created");
+        (Self { root }, relative)
+    }
+
+    fn root(&self) -> &Path {
+        &self.root
+    }
+
+    fn write(&self, relative: &str, contents: &str) {
+        let path = self.root.join(relative);
+
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("parent directories should exist");
+        }
+
+        std::fs::write(path, contents).expect("file should be written");
+    }
+}
+
+impl Drop for TestProject {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}


### PR DESCRIPTION
## What changed
- ported the Rust `kratos-core` config-loading path so it can read `package.json`, `tsconfig.json` or `jsconfig.json`, and `kratos.config.json`
- implemented loose JSON/JSONC parsing with comment stripping, trailing comma handling, control-character validation, and surrogate-pair decoding
- implemented source discovery and import resolution for relative imports, root-relative imports, `baseUrl`, `paths` aliases, and directory `index.*` fallbacks
- added integration coverage for config loading, missing-root handling, discovery, resolution, and JSONC parsing edge cases

## Why
Phase 2A in the Rust migration is the first step that moves real analysis inputs over from the JS implementation. Without config loading, discovery, and resolution parity, the Rust analyzer cannot safely reason about project structure or match the current CLI behavior.

## Impact
- Rust foundation code now has working config/discovery primitives instead of `NotImplemented` stubs
- malformed config arrays now fail explicitly instead of being silently ignored
- the existing JS CLI remains unchanged while the Rust core grows behind the scenes

## Validation
- `cargo test --workspace`
- `npm test`
- adversarial review loop completed with accepted fixes for JSON string parsing and config array validation
