### PR TITLE
[codex] Rust 그래프 분석과 Report V2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 dist/
 coverage/
 *.tgz
+target/

--- a/crates/kratos-cli/src/commands/mod.rs
+++ b/crates/kratos-cli/src/commands/mod.rs
@@ -43,7 +43,11 @@ pub fn format_root_help() -> String {
 }
 
 pub fn format_command_help(spec: CommandSpec) -> String {
-    let mut lines = vec![format!("kratos {}", spec.name), spec.summary.to_string(), String::new()];
+    let mut lines = vec![
+        format!("kratos {}", spec.name),
+        spec.summary.to_string(),
+        String::new(),
+    ];
 
     for usage in spec.usage {
         lines.push(format!("Usage: {usage}"));

--- a/crates/kratos-core/src/analyze.rs
+++ b/crates/kratos-core/src/analyze.rs
@@ -8,7 +8,7 @@ use crate::discover::collect_source_files;
 use crate::entrypoints::detect_entrypoint_kind;
 use crate::error::KratosResult;
 use crate::model::{
-    BrokenImportFinding, DeadExportFinding, DeletionCandidateFinding, ExportRecord,
+    BrokenImportFinding, DeadExportFinding, DeletionCandidateFinding, EntrypointKind, ExportRecord,
     ImportSpecifierKind, ImportUsageRecord, ModuleRecord, OrphanFileFinding, OrphanKind,
     ProjectConfig, ReportV2, ResolvedImportRecord, RouteEntrypointFinding, UnusedImportFinding,
 };
@@ -165,13 +165,19 @@ pub fn analyze_with_config(config: &ProjectConfig) -> KratosResult<ReportV2> {
         }
 
         let export_usage = summarize_export_usage(module);
-        let should_skip_dead_exports = module.entrypoint_kind.is_some()
+        let should_skip_dead_exports = should_skip_dead_exports(module.entrypoint_kind.as_ref())
             || export_usage.uses_namespace
             || export_usage.uses_unknown;
 
         if !should_skip_dead_exports {
             for exported in &module.exports {
-                if exported.name == "*" || export_usage.used_names.contains(&exported.name) {
+                if exported.name == "*"
+                    || export_usage.used_names.contains(&exported.name)
+                    || is_framework_consumed_export(
+                        module.entrypoint_kind.as_ref(),
+                        exported.name.as_str(),
+                    )
+                {
                     continue;
                 }
 
@@ -270,10 +276,7 @@ fn classify_orphan(relative_path: &str) -> OrphanClassification {
         };
     }
 
-    if normalized.contains("/routes/")
-        || file_name.to_ascii_lowercase().contains("page")
-        || file_name.to_ascii_lowercase().contains("route")
-    {
+    if normalized.contains("/routes/") || is_route_like_file_name(file_name) {
         return OrphanClassification {
             kind: OrphanKind::RouteModule,
             reason: "Route-like module is not connected to any router entry.".to_string(),
@@ -286,6 +289,73 @@ fn classify_orphan(relative_path: &str) -> OrphanClassification {
         reason: "Module has no inbound references and is not treated as an entrypoint.".to_string(),
         confidence: 0.88,
     }
+}
+
+fn should_skip_dead_exports(entrypoint_kind: Option<&EntrypointKind>) -> bool {
+    matches!(
+        entrypoint_kind,
+        Some(
+            EntrypointKind::UserEntry
+                | EntrypointKind::PackageEntry
+                | EntrypointKind::AppEntry
+                | EntrypointKind::ToolingEntry
+                | EntrypointKind::FrameworkEntry
+        )
+    )
+}
+
+fn is_framework_consumed_export(
+    entrypoint_kind: Option<&EntrypointKind>,
+    export_name: &str,
+) -> bool {
+    match entrypoint_kind {
+        Some(EntrypointKind::NextAppRoute) => matches!(
+            export_name,
+            "default"
+                | "metadata"
+                | "generateMetadata"
+                | "generateImageMetadata"
+                | "generateSitemaps"
+                | "viewport"
+                | "generateViewport"
+                | "generateStaticParams"
+                | "revalidate"
+                | "dynamic"
+                | "dynamicParams"
+                | "fetchCache"
+                | "runtime"
+                | "preferredRegion"
+                | "maxDuration"
+                | "GET"
+                | "POST"
+                | "PUT"
+                | "PATCH"
+                | "DELETE"
+                | "HEAD"
+                | "OPTIONS"
+        ),
+        Some(EntrypointKind::NextPagesRoute) => matches!(
+            export_name,
+            "default"
+                | "config"
+                | "getInitialProps"
+                | "getStaticProps"
+                | "getStaticPaths"
+                | "getServerSideProps"
+        ),
+        _ => false,
+    }
+}
+
+fn is_route_like_file_name(file_name: &str) -> bool {
+    let base_name = file_name
+        .rsplit_once('.')
+        .map(|(stem, _)| stem)
+        .unwrap_or(file_name);
+
+    base_name
+        .split(|character: char| !character.is_ascii_alphanumeric())
+        .any(|token| token.eq_ignore_ascii_case("page") || token.eq_ignore_ascii_case("route"))
 }
 
 fn push_unique_path(paths: &mut Vec<std::path::PathBuf>, path: std::path::PathBuf) {
@@ -349,4 +419,62 @@ struct OrphanClassification {
     kind: OrphanKind,
     reason: String,
     confidence: f32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{classify_orphan, is_framework_consumed_export, should_skip_dead_exports};
+    use crate::model::{EntrypointKind, OrphanKind};
+
+    #[test]
+    fn classify_orphan_avoids_route_false_positives_from_substrings() {
+        assert_eq!(
+            classify_orphan("src/lib/package.ts").kind,
+            OrphanKind::Module
+        );
+        assert_eq!(
+            classify_orphan("src/lib/router.ts").kind,
+            OrphanKind::Module
+        );
+        assert_eq!(
+            classify_orphan("src/routes/account.ts").kind,
+            OrphanKind::RouteModule
+        );
+        assert_eq!(
+            classify_orphan("src/features/user.page.tsx").kind,
+            OrphanKind::RouteModule
+        );
+    }
+
+    #[test]
+    fn next_route_entrypoints_only_skip_framework_consumed_exports() {
+        assert!(is_framework_consumed_export(
+            Some(&EntrypointKind::NextAppRoute),
+            "generateMetadata"
+        ));
+        assert!(is_framework_consumed_export(
+            Some(&EntrypointKind::NextAppRoute),
+            "generateImageMetadata"
+        ));
+        assert!(is_framework_consumed_export(
+            Some(&EntrypointKind::NextAppRoute),
+            "generateSitemaps"
+        ));
+        assert!(is_framework_consumed_export(
+            Some(&EntrypointKind::NextPagesRoute),
+            "getStaticProps"
+        ));
+        assert!(is_framework_consumed_export(
+            Some(&EntrypointKind::NextPagesRoute),
+            "getInitialProps"
+        ));
+        assert!(!is_framework_consumed_export(
+            Some(&EntrypointKind::NextAppRoute),
+            "helper"
+        ));
+        assert!(!should_skip_dead_exports(Some(
+            &EntrypointKind::NextAppRoute
+        )));
+        assert!(should_skip_dead_exports(Some(&EntrypointKind::AppEntry)));
+    }
 }

--- a/crates/kratos-core/src/config.rs
+++ b/crates/kratos-core/src/config.rs
@@ -306,9 +306,7 @@ fn resolve_alias_target_pattern(root: &Path, value: &str) -> String {
 
     let tokenized = value.replace('*', WILDCARD_TOKEN);
     let resolved = resolve_path(root, &tokenized);
-    resolved
-        .to_string_lossy()
-        .replace(WILDCARD_TOKEN, "*")
+    resolved.to_string_lossy().replace(WILDCARD_TOKEN, "*")
 }
 
 fn config_error(message: &str) -> crate::error::KratosError {
@@ -323,19 +321,18 @@ fn normalize_path(path: PathBuf) -> PathBuf {
             Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
             Component::RootDir => normalized.push(component.as_os_str()),
             Component::CurDir => {}
-            Component::ParentDir => {
-                match normalized.components().next_back() {
-                    Some(Component::Normal(_)) => {
-                        normalized.pop();
-                    }
-                    Some(Component::ParentDir) | None => {
-                        if !path.is_absolute() {
-                            normalized.push(component.as_os_str());
-                        }
-                    }
-                    Some(Component::Prefix(_)) | Some(Component::RootDir) | Some(Component::CurDir) => {}
+            Component::ParentDir => match normalized.components().next_back() {
+                Some(Component::Normal(_)) => {
+                    normalized.pop();
                 }
-            }
+                Some(Component::ParentDir) | None => {
+                    if !path.is_absolute() {
+                        normalized.push(component.as_os_str());
+                    }
+                }
+                Some(Component::Prefix(_)) | Some(Component::RootDir) | Some(Component::CurDir) => {
+                }
+            },
             Component::Normal(part) => normalized.push(part),
         }
     }

--- a/crates/kratos-core/src/config.rs
+++ b/crates/kratos-core/src/config.rs
@@ -1,4 +1,5 @@
 use std::cmp::Reverse;
+use std::collections::BTreeSet;
 use std::path::{Component, Path, PathBuf};
 
 use crate::error::KratosResult;
@@ -6,6 +7,12 @@ use crate::jsonc::{parse_loose_json, JsonValue};
 use crate::model::{PathAlias, ProjectConfig};
 
 const DEFAULT_CONFIG_FILENAME: &str = "kratos.config.json";
+const PACKAGE_ENTRY_EXTENSIONS: &[&str] = &[
+    ".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".mts", ".cts", ".d.ts", ".d.mts", ".d.cts",
+];
+const PACKAGE_TYPE_ENTRY_EXTENSIONS: &[&str] = &[
+    ".d.ts", ".d.mts", ".d.cts", ".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs",
+];
 const DEFAULT_IGNORED_DIRS: &[&str] = &[
     ".git",
     ".next",
@@ -68,6 +75,7 @@ pub fn load_project_config(root: impl Into<PathBuf>) -> KratosResult<ProjectConf
             compiler_options.and_then(|value| value.get("paths")),
             base_url.as_deref(),
         )?,
+        external_packages: collect_external_packages(&package_json),
     })
 }
 
@@ -172,56 +180,143 @@ fn normalize_path_aliases(
 fn collect_package_entry_files(root: &Path, package_json: &JsonValue) -> Vec<PathBuf> {
     let mut entries = Vec::new();
 
-    add_entry_value(&mut entries, root, package_json.get("main"));
-    add_entry_value(&mut entries, root, package_json.get("module"));
-    add_entry_value(&mut entries, root, package_json.get("types"));
+    add_entry_value(&mut entries, root, package_json.get("main"), false);
+    add_entry_value(&mut entries, root, package_json.get("module"), false);
+    add_entry_value(&mut entries, root, package_json.get("types"), true);
 
     if let Some(bin) = package_json.get("bin") {
-        if let Some(value) = bin.as_str() {
-            push_unique_path(&mut entries, resolve_path(root, value));
+        if bin.as_str().is_some() {
+            add_entry_value(&mut entries, root, Some(bin), false);
         } else if let Some(values) = bin.as_object() {
             for value in values.values() {
-                add_entry_value(&mut entries, root, Some(value));
+                add_entry_value(&mut entries, root, Some(value), false);
             }
         }
     }
 
     if let Some(exports) = package_json.get("exports") {
-        collect_exports(&mut entries, root, exports);
+        collect_exports(&mut entries, root, exports, false);
     }
 
     entries
 }
 
-fn collect_exports(entries: &mut Vec<PathBuf>, root: &Path, value: &JsonValue) {
+fn collect_external_packages(package_json: &JsonValue) -> BTreeSet<String> {
+    let mut packages = BTreeSet::new();
+
+    collect_dependency_names(&mut packages, package_json.get("dependencies"));
+    collect_dependency_names(&mut packages, package_json.get("devDependencies"));
+    collect_dependency_names(&mut packages, package_json.get("peerDependencies"));
+    collect_dependency_names(&mut packages, package_json.get("optionalDependencies"));
+
+    packages
+}
+
+fn collect_dependency_names(packages: &mut BTreeSet<String>, value: Option<&JsonValue>) {
+    let Some(entries) = value.and_then(JsonValue::as_object) else {
+        return;
+    };
+
+    for (name, _) in entries.iter() {
+        packages.insert(name.clone());
+    }
+}
+
+fn collect_exports(
+    entries: &mut Vec<PathBuf>,
+    root: &Path,
+    value: &JsonValue,
+    prefer_declaration_files: bool,
+) {
     match value {
         JsonValue::String(path) => {
             if path.is_empty() {
                 return;
             }
 
-            push_unique_path(entries, resolve_path(root, path))
+            let resolved = resolve_package_entry_path(root, path, prefer_declaration_files)
+                .unwrap_or_else(|| resolve_path(root, path));
+            push_unique_path(entries, resolved)
         }
         JsonValue::Array(values) => {
             for nested in values {
-                collect_exports(entries, root, nested);
+                collect_exports(entries, root, nested, prefer_declaration_files);
             }
         }
         JsonValue::Object(values) => {
-            for nested in values.values() {
-                collect_exports(entries, root, nested);
+            for (key, nested) in values.iter() {
+                collect_exports(
+                    entries,
+                    root,
+                    nested,
+                    prefer_declaration_files || key == "types",
+                );
             }
         }
         JsonValue::Null | JsonValue::Bool(_) | JsonValue::Number(_) => {}
     }
 }
 
-fn add_entry_value(entries: &mut Vec<PathBuf>, root: &Path, value: Option<&JsonValue>) {
+fn add_entry_value(
+    entries: &mut Vec<PathBuf>,
+    root: &Path,
+    value: Option<&JsonValue>,
+    prefer_declaration_files: bool,
+) {
     let Some(value) = value.and_then(JsonValue::as_str) else {
         return;
     };
 
-    push_unique_path(entries, resolve_path(root, value));
+    let resolved = resolve_package_entry_path(root, value, prefer_declaration_files)
+        .unwrap_or_else(|| resolve_path(root, value));
+    push_unique_path(entries, resolved);
+}
+
+fn resolve_package_entry_path(
+    root: &Path,
+    value: &str,
+    prefer_declaration_files: bool,
+) -> Option<PathBuf> {
+    let resolved = resolve_path(root, value);
+    let extensions = package_entry_extensions(prefer_declaration_files);
+
+    if resolved.exists() {
+        if resolved.is_dir() {
+            return resolve_package_entry_directory(&resolved, extensions);
+        }
+
+        return Some(resolved);
+    }
+
+    if resolved.extension().is_none() {
+        for extension in extensions {
+            let candidate = PathBuf::from(format!("{}{}", resolved.to_string_lossy(), extension));
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+
+    None
+}
+
+fn resolve_package_entry_directory(directory: &Path, extensions: &[&str]) -> Option<PathBuf> {
+    for extension in extensions {
+        let candidate = directory.join(format!("index{extension}"));
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+
+    None
+}
+
+fn package_entry_extensions(prefer_declaration_files: bool) -> &'static [&'static str] {
+    if prefer_declaration_files {
+        PACKAGE_TYPE_ENTRY_EXTENSIONS
+    } else {
+        PACKAGE_ENTRY_EXTENSIONS
+    }
 }
 
 fn extract_string_array(value: Option<&JsonValue>) -> Vec<String> {

--- a/crates/kratos-core/src/entrypoints.rs
+++ b/crates/kratos-core/src/entrypoints.rs
@@ -57,28 +57,31 @@ fn to_project_path(file_path: &Path, root: &Path) -> String {
 }
 
 fn is_next_app_route(relative_path: &str) -> bool {
-    if !relative_path.starts_with("app/") {
-        return false;
-    }
+    let segments = relative_path.split('/').collect::<Vec<_>>();
 
-    let nested = &relative_path["app/".len()..];
-    if !nested.contains('/') {
-        return false;
-    }
-
-    let file_name = relative_path.rsplit('/').next().unwrap_or(relative_path);
-    let Some((stem, extension)) = file_name.rsplit_once('.') else {
-        return false;
-    };
-
-    if extension.is_empty() || extension.contains('.') || stem.contains('.') {
-        return false;
-    }
-
-    matches!(
-        stem,
-        "page" | "route" | "layout" | "loading" | "error" | "not-found"
-    )
+    has_supported_segment(&segments, "app")
+        && segments.len() >= 2
+        && matches_file_stem(
+            segments.last().copied().unwrap_or_default(),
+            &[
+                "page",
+                "route",
+                "layout",
+                "loading",
+                "error",
+                "not-found",
+                "default",
+                "template",
+                "global-error",
+                "robots",
+                "sitemap",
+                "icon",
+                "apple-icon",
+                "opengraph-image",
+                "twitter-image",
+                "manifest",
+            ],
+        )
 }
 
 #[cfg(test)]
@@ -88,24 +91,97 @@ mod tests {
     use std::path::PathBuf;
 
     #[test]
-    fn next_app_route_requires_nested_segment_for_js_parity() {
+    fn next_app_route_supports_root_src_and_nested_package_paths() {
         let root = PathBuf::from("/tmp/kratos-entrypoints");
         let config = ProjectConfig::new(root.clone());
 
         let root_level = detect_entrypoint_kind(&root.join("app/page.tsx"), &config)
             .expect("entrypoint detection should succeed");
+        let src_root_level = detect_entrypoint_kind(&root.join("src/app/page.tsx"), &config)
+            .expect("entrypoint detection should succeed");
         let nested = detect_entrypoint_kind(&root.join("app/home/page.tsx"), &config)
             .expect("entrypoint detection should succeed");
+        let template = detect_entrypoint_kind(&root.join("app/template.tsx"), &config)
+            .expect("entrypoint detection should succeed");
+        let global_error = detect_entrypoint_kind(&root.join("src/app/global-error.tsx"), &config)
+            .expect("entrypoint detection should succeed");
+        let parallel_default =
+            detect_entrypoint_kind(&root.join("app/@modal/default.tsx"), &config)
+                .expect("entrypoint detection should succeed");
+        let robots = detect_entrypoint_kind(&root.join("app/robots.ts"), &config)
+            .expect("entrypoint detection should succeed");
+        let opengraph = detect_entrypoint_kind(&root.join("app/opengraph-image.tsx"), &config)
+            .expect("entrypoint detection should succeed");
+        let package_root = detect_entrypoint_kind(&root.join("packages/web/app/page.tsx"), &config)
+            .expect("entrypoint detection should succeed");
+        let nested_package = detect_entrypoint_kind(
+            &root.join("packages/web/src/app/settings/page.tsx"),
+            &config,
+        )
+        .expect("entrypoint detection should succeed");
         let nested_test = detect_entrypoint_kind(&root.join("app/home/page.test.tsx"), &config)
             .expect("entrypoint detection should succeed");
         let nested_spec =
             detect_entrypoint_kind(&root.join("app/home/not-found.spec.tsx"), &config)
                 .expect("entrypoint detection should succeed");
 
-        assert_eq!(root_level, None);
+        assert_eq!(root_level, Some(EntrypointKind::NextAppRoute));
+        assert_eq!(src_root_level, Some(EntrypointKind::NextAppRoute));
         assert_eq!(nested, Some(EntrypointKind::NextAppRoute));
+        assert_eq!(template, Some(EntrypointKind::NextAppRoute));
+        assert_eq!(global_error, Some(EntrypointKind::NextAppRoute));
+        assert_eq!(parallel_default, Some(EntrypointKind::NextAppRoute));
+        assert_eq!(robots, Some(EntrypointKind::NextAppRoute));
+        assert_eq!(opengraph, Some(EntrypointKind::NextAppRoute));
+        assert_eq!(package_root, Some(EntrypointKind::NextAppRoute));
+        assert_eq!(nested_package, Some(EntrypointKind::NextAppRoute));
         assert_eq!(nested_test, None);
         assert_eq!(nested_spec, None);
+    }
+
+    #[test]
+    fn next_pages_route_supports_optional_src_prefix_and_nested_packages() {
+        let root = PathBuf::from("/tmp/kratos-entrypoints");
+        let config = ProjectConfig::new(root.clone());
+
+        let root_pages = detect_entrypoint_kind(&root.join("pages/index.tsx"), &config)
+            .expect("entrypoint detection should succeed");
+        let src_pages = detect_entrypoint_kind(&root.join("src/pages/index.tsx"), &config)
+            .expect("entrypoint detection should succeed");
+        let package_root =
+            detect_entrypoint_kind(&root.join("packages/web/pages/index.tsx"), &config)
+                .expect("entrypoint detection should succeed");
+        let nested_package =
+            detect_entrypoint_kind(&root.join("packages/web/src/pages/index.tsx"), &config)
+                .expect("entrypoint detection should succeed");
+        let dotted_page = detect_entrypoint_kind(&root.join("pages/home.page.tsx"), &config)
+            .expect("entrypoint detection should succeed");
+        let dotted_api = detect_entrypoint_kind(&root.join("src/pages/api.v1.ts"), &config)
+            .expect("entrypoint detection should succeed");
+
+        assert_eq!(root_pages, Some(EntrypointKind::NextPagesRoute));
+        assert_eq!(src_pages, Some(EntrypointKind::NextPagesRoute));
+        assert_eq!(package_root, Some(EntrypointKind::NextPagesRoute));
+        assert_eq!(nested_package, Some(EntrypointKind::NextPagesRoute));
+        assert_eq!(dotted_page, Some(EntrypointKind::NextPagesRoute));
+        assert_eq!(dotted_api, Some(EntrypointKind::NextPagesRoute));
+    }
+
+    #[test]
+    fn app_entry_supports_nested_package_src_paths() {
+        let root = PathBuf::from("/tmp/kratos-entrypoints");
+        let config = ProjectConfig::new(root.clone());
+
+        let root_entry = detect_entrypoint_kind(&root.join("src/main.ts"), &config)
+            .expect("entrypoint detection should succeed");
+        let nested_entry = detect_entrypoint_kind(&root.join("packages/cli/src/main.ts"), &config)
+            .expect("entrypoint detection should succeed");
+        let nested_non_src = detect_entrypoint_kind(&root.join("packages/cli/main.ts"), &config)
+            .expect("entrypoint detection should succeed");
+
+        assert_eq!(root_entry, Some(EntrypointKind::AppEntry));
+        assert_eq!(nested_entry, Some(EntrypointKind::AppEntry));
+        assert_eq!(nested_non_src, None);
     }
 
     #[test]
@@ -127,77 +203,23 @@ mod tests {
 }
 
 fn is_next_pages_route(relative_path: &str) -> bool {
-    relative_path.starts_with("pages/") && relative_path.rsplit('/').next().is_some()
+    let segments = relative_path.split('/').collect::<Vec<_>>();
+    has_supported_segment(&segments, "pages")
+        && segments.len() >= 2
+        && has_extension(segments.last().copied().unwrap_or_default())
 }
 
 fn is_app_entry(relative_path: &str) -> bool {
-    matches!(
-        relative_path,
-        "main.js"
-            | "main.jsx"
-            | "main.ts"
-            | "main.tsx"
-            | "main.mjs"
-            | "main.cjs"
-            | "main.mts"
-            | "main.cts"
-            | "index.js"
-            | "index.jsx"
-            | "index.ts"
-            | "index.tsx"
-            | "index.mjs"
-            | "index.cjs"
-            | "index.mts"
-            | "index.cts"
-            | "bootstrap.js"
-            | "bootstrap.jsx"
-            | "bootstrap.ts"
-            | "bootstrap.tsx"
-            | "bootstrap.mjs"
-            | "bootstrap.cjs"
-            | "bootstrap.mts"
-            | "bootstrap.cts"
-            | "cli.js"
-            | "cli.jsx"
-            | "cli.ts"
-            | "cli.tsx"
-            | "cli.mjs"
-            | "cli.cjs"
-            | "cli.mts"
-            | "cli.cts"
-            | "src/main.js"
-            | "src/main.jsx"
-            | "src/main.ts"
-            | "src/main.tsx"
-            | "src/main.mjs"
-            | "src/main.cjs"
-            | "src/main.mts"
-            | "src/main.cts"
-            | "src/index.js"
-            | "src/index.jsx"
-            | "src/index.ts"
-            | "src/index.tsx"
-            | "src/index.mjs"
-            | "src/index.cjs"
-            | "src/index.mts"
-            | "src/index.cts"
-            | "src/bootstrap.js"
-            | "src/bootstrap.jsx"
-            | "src/bootstrap.ts"
-            | "src/bootstrap.tsx"
-            | "src/bootstrap.mjs"
-            | "src/bootstrap.cjs"
-            | "src/bootstrap.mts"
-            | "src/bootstrap.cts"
-            | "src/cli.js"
-            | "src/cli.jsx"
-            | "src/cli.ts"
-            | "src/cli.tsx"
-            | "src/cli.mjs"
-            | "src/cli.cjs"
-            | "src/cli.mts"
-            | "src/cli.cts"
-    )
+    let segments = relative_path.split('/').collect::<Vec<_>>();
+    let Some(file_name) = segments.last().copied() else {
+        return false;
+    };
+
+    if !matches_file_stem(file_name, &["main", "index", "bootstrap", "cli"]) {
+        return false;
+    }
+
+    segments.len() == 1 || segments[segments.len() - 2] == "src"
 }
 
 fn is_tooling_entry(relative_path: &str) -> bool {
@@ -221,6 +243,43 @@ fn is_tooling_entry(relative_path: &str) -> bool {
             .strip_prefix(&format!("{tool}.config."))
             .is_some_and(|extension| !extension.is_empty() && !extension.contains('.'))
     })
+}
+
+fn has_supported_segment(segments: &[&str], name: &str) -> bool {
+    segments.iter().enumerate().any(|(index, segment)| {
+        *segment == name
+            && (index == 0
+                || segments[index - 1] == "src"
+                || is_package_root_segment(segments, index))
+    })
+}
+
+fn is_package_root_segment(segments: &[&str], index: usize) -> bool {
+    index >= 2 && matches!(segments[index - 2], "packages" | "apps")
+}
+
+fn matches_file_stem(file_name: &str, stems: &[&str]) -> bool {
+    let Some((stem, _extension)) = split_single_extension(file_name) else {
+        return false;
+    };
+
+    stems.iter().any(|candidate| *candidate == stem)
+}
+
+fn has_extension(file_name: &str) -> bool {
+    file_name
+        .rsplit_once('.')
+        .is_some_and(|(stem, extension)| !stem.is_empty() && !extension.is_empty())
+}
+
+fn split_single_extension(file_name: &str) -> Option<(&str, &str)> {
+    let (stem, extension) = file_name.rsplit_once('.')?;
+
+    if extension.is_empty() || extension.contains('.') || stem.contains('.') {
+        return None;
+    }
+
+    Some((stem, extension))
 }
 
 fn is_framework_entry(relative_path: &str) -> bool {

--- a/crates/kratos-core/src/error.rs
+++ b/crates/kratos-core/src/error.rs
@@ -25,7 +25,10 @@ impl Display for KratosError {
             Self::Json(message) => write!(f, "JSON error: {message}"),
             Self::Config(message) => write!(f, "Config error: {message}"),
             Self::InvalidReportVersion { expected, found } => {
-                write!(f, "Invalid report version: expected {expected}, found {found}")
+                write!(
+                    f,
+                    "Invalid report version: expected {expected}, found {found}"
+                )
             }
             Self::NotImplemented { feature } => {
                 write!(f, "Not implemented yet: {feature}")

--- a/crates/kratos-core/src/model.rs
+++ b/crates/kratos-core/src/model.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::path::PathBuf;
 
 pub const REPORT_V2: u32 = 2;
@@ -12,6 +13,7 @@ pub struct ProjectConfig {
     pub explicit_entries: Vec<PathBuf>,
     pub package_entries: Vec<PathBuf>,
     pub path_aliases: Vec<PathAlias>,
+    pub external_packages: BTreeSet<String>,
 }
 
 impl ProjectConfig {
@@ -25,6 +27,7 @@ impl ProjectConfig {
             explicit_entries: Vec::new(),
             package_entries: Vec::new(),
             path_aliases: Vec::new(),
+            external_packages: BTreeSet::new(),
         }
     }
 }

--- a/crates/kratos-core/src/report.rs
+++ b/crates/kratos-core/src/report.rs
@@ -61,18 +61,11 @@ pub fn parse_report_json(raw: &str) -> KratosResult<ReportV2> {
         .ok_or_else(|| KratosError::Json("Report is missing schemaVersion/version".to_string()))?
         as u32;
 
-    let project = value.get("project");
-    let root = project
-        .and_then(|project| project.get("root"))
-        .or_else(|| value.get("root"))
-        .and_then(Value::as_str)
-        .ok_or_else(|| KratosError::Json("Report is missing root".to_string()))?;
-    let config_path = project
-        .and_then(|project| project.get("configPath"))
-        .and_then(Value::as_str)
-        .map(Into::into);
+    let generated_at =
+        read_optional_string(Some(&value), "generatedAt", "generatedAt")?.map(str::to_string);
 
-    let (summary, finding_set, modules) = if version == REPORT_V2 {
+    let (root, config_path, summary, finding_set, modules) = if version == REPORT_V2 {
+        let project = read_required_object(value.get("project"), "project")?;
         let summary =
             parse_required_summary(read_required_object(value.get("summary"), "summary")?)?;
         let findings = read_required_object(value.get("findings"), "findings")?;
@@ -82,6 +75,9 @@ pub fn parse_report_json(raw: &str) -> KratosResult<ReportV2> {
         )?;
 
         (
+            read_required_string(project, "root", "project.root")?,
+            read_optional_string(value.get("project"), "configPath", "project.configPath")?
+                .map(Into::into),
             summary,
             crate::model::FindingSet {
                 broken_imports: parse_required_broken_imports(read_required_array(
@@ -117,8 +113,15 @@ pub fn parse_report_json(raw: &str) -> KratosResult<ReportV2> {
             .get("graph")
             .and_then(|graph| graph.get("modules"))
             .or_else(|| value.get("modules"));
+        let project = value.get("project");
 
         (
+            project
+                .and_then(|project| project.get("root"))
+                .or_else(|| value.get("root"))
+                .and_then(Value::as_str)
+                .ok_or_else(|| KratosError::Json("Report is missing root".to_string()))?,
+            read_optional_string(project, "configPath", "project.configPath")?.map(Into::into),
             parse_summary(value.get("summary")),
             crate::model::FindingSet {
                 broken_imports: parse_broken_imports(
@@ -141,11 +144,12 @@ pub fn parse_report_json(raw: &str) -> KratosResult<ReportV2> {
     };
 
     Ok(ReportV2 {
-        version,
-        generated_at: value
-            .get("generatedAt")
-            .and_then(Value::as_str)
-            .map(str::to_string),
+        version: if version < REPORT_V2 {
+            REPORT_V2
+        } else {
+            version
+        },
+        generated_at,
         root: root.into(),
         config_path,
         summary,
@@ -166,6 +170,7 @@ pub fn format_summary_report(report: &ReportV2, report_path: &Path) -> KratosRes
         format!("Orphan files: {}", report.summary.orphan_files),
         format!("Dead exports: {}", report.summary.dead_exports),
         format!("Unused imports: {}", report.summary.unused_imports),
+        format!("Route entrypoints: {}", report.summary.route_entrypoints),
         format!(
             "Deletion candidates: {}",
             report.summary.deletion_candidates
@@ -192,6 +197,18 @@ pub fn format_summary_report(report: &ReportV2, report_path: &Path) -> KratosRes
         &report.findings.dead_exports,
         |item| format!("{}#{}", path_to_string(&item.file), item.export_name),
     );
+    append_preview(
+        &mut lines,
+        "Route entrypoints",
+        &report.findings.route_entrypoints,
+        |item| {
+            format!(
+                "{} ({})",
+                path_to_string(&item.file),
+                entrypoint_kind_to_string(&item.kind)
+            )
+        },
+    );
 
     Ok(lines.join("\n"))
 }
@@ -217,6 +234,7 @@ pub fn format_markdown_report(report: &ReportV2, report_path: &Path) -> KratosRe
         format!("- Orphan files: {}", report.summary.orphan_files),
         format!("- Dead exports: {}", report.summary.dead_exports),
         format!("- Unused imports: {}", report.summary.unused_imports),
+        format!("- Route entrypoints: {}", report.summary.route_entrypoints),
         format!(
             "- Deletion candidates: {}",
             report.summary.deletion_candidates
@@ -252,6 +270,18 @@ pub fn format_markdown_report(report: &ReportV2, report_path: &Path) -> KratosRe
                 path_to_string(&item.file),
                 item.local,
                 item.source
+            )
+        },
+    );
+    push_markdown_section(
+        &mut lines,
+        "Route entrypoints",
+        &report.findings.route_entrypoints,
+        |item| {
+            format!(
+                "{} ({})",
+                path_to_string(&item.file),
+                entrypoint_kind_to_string(&item.kind)
             )
         },
     );
@@ -393,7 +423,7 @@ fn parse_broken_imports(value: Option<&Value>) -> Vec<BrokenImportFinding> {
                 kind: item
                     .get("kind")
                     .and_then(Value::as_str)
-                    .map(parse_import_kind)
+                    .and_then(parse_import_kind)
                     .unwrap_or(ImportKind::Unknown),
             })
         })
@@ -407,11 +437,6 @@ fn parse_required_broken_imports(values: &[Value]) -> KratosResult<Vec<BrokenImp
         .map(|(index, item)| {
             let object =
                 read_required_object(Some(item), &format!("findings.brokenImports[{index}]"))?;
-            let kind = read_required_string(
-                object,
-                "kind",
-                &format!("findings.brokenImports[{index}].kind"),
-            )?;
 
             Ok(BrokenImportFinding {
                 file: read_required_string(
@@ -426,7 +451,11 @@ fn parse_required_broken_imports(values: &[Value]) -> KratosResult<Vec<BrokenImp
                     &format!("findings.brokenImports[{index}].source"),
                 )?
                 .to_string(),
-                kind: parse_import_kind(kind),
+                kind: read_required_import_kind(
+                    object,
+                    "kind",
+                    &format!("findings.brokenImports[{index}].kind"),
+                )?,
             })
         })
         .collect()
@@ -441,7 +470,7 @@ fn parse_orphan_files(value: Option<&Value>) -> Vec<OrphanFileFinding> {
                 kind: item
                     .get("kind")
                     .and_then(Value::as_str)
-                    .map(parse_orphan_kind)
+                    .and_then(parse_orphan_kind)
                     .unwrap_or(OrphanKind::Module),
                 reason: item
                     .get("reason")
@@ -464,11 +493,6 @@ fn parse_required_orphan_files(values: &[Value]) -> KratosResult<Vec<OrphanFileF
         .map(|(index, item)| {
             let object =
                 read_required_object(Some(item), &format!("findings.orphanFiles[{index}]"))?;
-            let kind = read_required_string(
-                object,
-                "kind",
-                &format!("findings.orphanFiles[{index}].kind"),
-            )?;
 
             Ok(OrphanFileFinding {
                 file: read_required_string(
@@ -477,7 +501,11 @@ fn parse_required_orphan_files(values: &[Value]) -> KratosResult<Vec<OrphanFileF
                     &format!("findings.orphanFiles[{index}].file"),
                 )?
                 .into(),
-                kind: parse_orphan_kind(kind),
+                kind: read_required_orphan_kind(
+                    object,
+                    "kind",
+                    &format!("findings.orphanFiles[{index}].kind"),
+                )?,
                 reason: read_required_string(
                     object,
                     "reason",
@@ -875,24 +903,26 @@ fn parse_entrypoint_kind(value: &str) -> Option<EntrypointKind> {
     }
 }
 
-fn parse_import_kind(value: &str) -> ImportKind {
+fn parse_import_kind(value: &str) -> Option<ImportKind> {
     match value {
-        "static" => ImportKind::Static,
-        "side-effect" => ImportKind::SideEffect,
-        "reexport" => ImportKind::Reexport,
-        "reexport-all" => ImportKind::ReexportAll,
-        "reexport-namespace" => ImportKind::ReexportNamespace,
-        "require" => ImportKind::Require,
-        "dynamic" => ImportKind::Dynamic,
-        _ => ImportKind::Unknown,
+        "static" => Some(ImportKind::Static),
+        "side-effect" => Some(ImportKind::SideEffect),
+        "reexport" => Some(ImportKind::Reexport),
+        "reexport-all" => Some(ImportKind::ReexportAll),
+        "reexport-namespace" => Some(ImportKind::ReexportNamespace),
+        "require" => Some(ImportKind::Require),
+        "dynamic" => Some(ImportKind::Dynamic),
+        "unknown" => Some(ImportKind::Unknown),
+        _ => None,
     }
 }
 
-fn parse_orphan_kind(value: &str) -> OrphanKind {
+fn parse_orphan_kind(value: &str) -> Option<OrphanKind> {
     match value {
-        "orphan-component" => OrphanKind::Component,
-        "orphan-route-module" => OrphanKind::RouteModule,
-        _ => OrphanKind::Module,
+        "orphan-component" => Some(OrphanKind::Component),
+        "orphan-route-module" => Some(OrphanKind::RouteModule),
+        "orphan-module" => Some(OrphanKind::Module),
+        _ => None,
     }
 }
 
@@ -932,6 +962,24 @@ fn read_required_string<'a>(
         .get(key)
         .and_then(Value::as_str)
         .ok_or_else(|| KratosError::Json(format!("Report is missing required string `{path}`")))
+}
+
+fn read_optional_string<'a>(
+    value: Option<&'a Value>,
+    key: &str,
+    path: &str,
+) -> KratosResult<Option<&'a str>> {
+    let Some(object) = value.and_then(Value::as_object) else {
+        return Ok(None);
+    };
+
+    match object.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(string)) => Ok(Some(string)),
+        Some(_) => Err(KratosError::Json(format!(
+            "Report has invalid string field `{path}`"
+        ))),
+    }
 }
 
 fn read_required_usize(
@@ -976,6 +1024,26 @@ fn read_required_entrypoint_kind(
     let raw = read_required_string(value, key, path)?;
     parse_entrypoint_kind(raw)
         .ok_or_else(|| KratosError::Json(format!("Report has invalid entrypoint kind `{path}`")))
+}
+
+fn read_required_import_kind(
+    value: &serde_json::Map<String, Value>,
+    key: &str,
+    path: &str,
+) -> KratosResult<ImportKind> {
+    let raw = read_required_string(value, key, path)?;
+    parse_import_kind(raw)
+        .ok_or_else(|| KratosError::Json(format!("Report has invalid import kind `{path}`")))
+}
+
+fn read_required_orphan_kind(
+    value: &serde_json::Map<String, Value>,
+    key: &str,
+    path: &str,
+) -> KratosResult<OrphanKind> {
+    let raw = read_required_string(value, key, path)?;
+    parse_orphan_kind(raw)
+        .ok_or_else(|| KratosError::Json(format!("Report has invalid orphan kind `{path}`")))
 }
 
 fn read_optional_entrypoint_kind(

--- a/crates/kratos-core/src/resolve.rs
+++ b/crates/kratos-core/src/resolve.rs
@@ -47,7 +47,11 @@ pub fn resolve_import_target(
         return resolve_internal_path(&candidate, request);
     }
 
-    if let Some(base_url) = config.base_url.as_ref().map(|value| normalize_config_path(value)) {
+    if let Some(base_url) = config
+        .base_url
+        .as_ref()
+        .map(|value| normalize_config_path(value))
+    {
         let resolution = resolve_internal_path(&base_url.join(request), request)?;
 
         if resolution.kind != ImportResolutionKind::MissingInternal {
@@ -181,19 +185,18 @@ fn normalize_path(path: PathBuf) -> PathBuf {
             Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
             Component::RootDir => normalized.push(component.as_os_str()),
             Component::CurDir => {}
-            Component::ParentDir => {
-                match normalized.components().next_back() {
-                    Some(Component::Normal(_)) => {
-                        normalized.pop();
-                    }
-                    Some(Component::ParentDir) | None => {
-                        if !path.is_absolute() {
-                            normalized.push(component.as_os_str());
-                        }
-                    }
-                    Some(Component::Prefix(_)) | Some(Component::RootDir) | Some(Component::CurDir) => {}
+            Component::ParentDir => match normalized.components().next_back() {
+                Some(Component::Normal(_)) => {
+                    normalized.pop();
                 }
-            }
+                Some(Component::ParentDir) | None => {
+                    if !path.is_absolute() {
+                        normalized.push(component.as_os_str());
+                    }
+                }
+                Some(Component::Prefix(_)) | Some(Component::RootDir) | Some(Component::CurDir) => {
+                }
+            },
             Component::Normal(part) => normalized.push(part),
         }
     }

--- a/crates/kratos-core/src/resolve.rs
+++ b/crates/kratos-core/src/resolve.rs
@@ -1,6 +1,7 @@
 use std::path::{Component, Path, PathBuf};
 
 use crate::error::KratosResult;
+use crate::jsonc::{parse_loose_json, JsonValue};
 use crate::model::{ImportResolution, ImportResolutionKind, PathAlias, ProjectConfig};
 
 const SOURCE_EXTENSIONS: &[&str] = &[".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".mts", ".cts"];
@@ -57,6 +58,18 @@ pub fn resolve_import_target(
         if resolution.kind != ImportResolutionKind::MissingInternal {
             return Ok(resolution);
         }
+
+        if is_builtin_module(request) {
+            return Ok(external_import(request, None));
+        }
+
+        if !is_external_package(request, importer_path.as_path(), config) {
+            return Ok(unresolved_import(request));
+        }
+    }
+
+    if is_builtin_module(request) {
+        return Ok(external_import(request, None));
     }
 
     Ok(external_import(request, None))
@@ -165,6 +178,174 @@ fn external_import(source: &str, path: Option<PathBuf>) -> ImportResolution {
         source: source.to_string(),
         path,
     }
+}
+
+fn is_external_package(request: &str, importer_path: &Path, config: &ProjectConfig) -> bool {
+    if is_declared_external_package(request, config) {
+        return true;
+    }
+
+    let Some(package_name) = requested_package_name(request) else {
+        return false;
+    };
+
+    importer_declares_external_package(
+        importer_path,
+        &normalize_config_path(&config.root),
+        &package_name,
+    )
+}
+
+fn is_declared_external_package(request: &str, config: &ProjectConfig) -> bool {
+    let Some(package_name) = requested_package_name(request) else {
+        return false;
+    };
+
+    config.external_packages.contains(package_name.as_str())
+}
+
+fn importer_declares_external_package(
+    importer_path: &Path,
+    project_root: &Path,
+    package_name: &str,
+) -> bool {
+    let mut current = importer_path
+        .parent()
+        .unwrap_or(importer_path)
+        .to_path_buf();
+
+    loop {
+        if !current.starts_with(project_root) {
+            return false;
+        }
+
+        if current != project_root
+            && package_json_declares_dependency(&current.join("package.json"), package_name)
+        {
+            return true;
+        }
+
+        if current == project_root {
+            return false;
+        }
+
+        if !current.pop() {
+            return false;
+        }
+    }
+}
+
+fn package_json_declares_dependency(package_json_path: &Path, package_name: &str) -> bool {
+    let Ok(content) = std::fs::read_to_string(package_json_path) else {
+        return false;
+    };
+    let Ok(json) = parse_loose_json(&content) else {
+        return false;
+    };
+
+    dependency_map_contains(json.get("dependencies"), package_name)
+        || dependency_map_contains(json.get("devDependencies"), package_name)
+        || dependency_map_contains(json.get("peerDependencies"), package_name)
+        || dependency_map_contains(json.get("optionalDependencies"), package_name)
+}
+
+fn dependency_map_contains(value: Option<&JsonValue>, package_name: &str) -> bool {
+    value
+        .and_then(JsonValue::as_object)
+        .map(|packages| packages.get(package_name).is_some())
+        .unwrap_or(false)
+}
+
+fn requested_package_name(request: &str) -> Option<String> {
+    if request.is_empty()
+        || request.starts_with('.')
+        || request.starts_with('/')
+        || request.starts_with("node:")
+    {
+        return None;
+    }
+
+    if request.starts_with('@') {
+        let mut parts = request.split('/');
+        let scope = parts.next()?;
+        let package = parts.next()?;
+
+        if package.is_empty() {
+            return None;
+        }
+
+        return Some(format!("{scope}/{package}"));
+    }
+
+    request
+        .split('/')
+        .next()
+        .filter(|segment| !segment.is_empty())
+        .map(str::to_string)
+}
+
+fn is_builtin_module(request: &str) -> bool {
+    matches!(
+        requested_package_name(request).as_deref(),
+        Some(
+            "_http_agent"
+                | "_http_client"
+                | "_http_common"
+                | "_http_incoming"
+                | "_http_outgoing"
+                | "_http_server"
+                | "_stream_duplex"
+                | "_stream_passthrough"
+                | "_stream_readable"
+                | "_stream_transform"
+                | "_stream_wrap"
+                | "_stream_writable"
+                | "_tls_common"
+                | "_tls_wrap"
+                | "assert"
+                | "async_hooks"
+                | "buffer"
+                | "child_process"
+                | "cluster"
+                | "console"
+                | "constants"
+                | "crypto"
+                | "dgram"
+                | "diagnostics_channel"
+                | "dns"
+                | "domain"
+                | "events"
+                | "fs"
+                | "http"
+                | "http2"
+                | "https"
+                | "inspector"
+                | "module"
+                | "net"
+                | "os"
+                | "path"
+                | "perf_hooks"
+                | "process"
+                | "punycode"
+                | "querystring"
+                | "readline"
+                | "repl"
+                | "stream"
+                | "string_decoder"
+                | "sys"
+                | "timers"
+                | "tls"
+                | "trace_events"
+                | "tty"
+                | "url"
+                | "util"
+                | "v8"
+                | "vm"
+                | "wasi"
+                | "worker_threads"
+                | "zlib"
+        )
+    )
 }
 
 fn is_source_path(path: &Path) -> bool {

--- a/crates/kratos-core/tests/analyze_demo_app.rs
+++ b/crates/kratos-core/tests/analyze_demo_app.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use kratos_core::analyze::analyze_project;
 use kratos_core::model::{EntrypointKind, OrphanKind};
@@ -111,9 +112,227 @@ fn analyze_demo_app_matches_expected_graph_and_findings() {
     );
 }
 
+#[test]
+fn analyze_project_detects_root_and_src_next_routes() {
+    let project = TestProject::new("next-routes");
+    project.write(
+        "app/page.tsx",
+        "export default function RootPage() { return null; }\n",
+    );
+    project.write(
+        "app/template.tsx",
+        "export default function RootTemplate({ children }: { children: unknown }) { return children; }\n",
+    );
+    project.write(
+        "app/@modal/default.tsx",
+        "export default function ModalDefault() { return null; }\n",
+    );
+    project.write(
+        "src/app/dashboard/page.tsx",
+        "export default function DashboardPage() { return null; }\n",
+    );
+    project.write(
+        "src/app/global-error.tsx",
+        "export default function GlobalError() { return null; }\n",
+    );
+    project.write(
+        "src/pages/index.tsx",
+        "export default function IndexPage() { return null; }\n",
+    );
+
+    let report = analyze_project(project.root()).expect("project should analyze");
+    let mut route_files = report
+        .findings
+        .route_entrypoints
+        .iter()
+        .map(|item| {
+            item.file
+                .strip_prefix(project.root())
+                .unwrap_or(&item.file)
+                .to_path_buf()
+        })
+        .collect::<Vec<_>>();
+    route_files.sort();
+
+    assert_eq!(report.summary.entrypoints, 6);
+    assert_eq!(report.summary.route_entrypoints, 6);
+    assert_eq!(
+        route_files,
+        vec![
+            PathBuf::from("app/@modal/default.tsx"),
+            PathBuf::from("app/page.tsx"),
+            PathBuf::from("app/template.tsx"),
+            PathBuf::from("src/app/dashboard/page.tsx"),
+            PathBuf::from("src/app/global-error.tsx"),
+            PathBuf::from("src/pages/index.tsx"),
+        ]
+    );
+}
+
+#[test]
+fn analyze_project_detects_nested_package_entrypoints() {
+    let project = TestProject::new("nested-package-entrypoints");
+    project.write(
+        "packages/web/app/page.tsx",
+        "export default function RootPackagePage() { return null; }\n",
+    );
+    project.write(
+        "packages/web/pages/index.tsx",
+        "export default function RootLegacyPage() { return null; }\n",
+    );
+    project.write(
+        "packages/web/src/app/page.tsx",
+        "export default function WebPage() { return null; }\n",
+    );
+    project.write(
+        "packages/web/src/pages/index.tsx",
+        "export default function LegacyPage() { return null; }\n",
+    );
+    project.write("packages/cli/src/main.ts", "export const main = true;\n");
+
+    let report = analyze_project(project.root()).expect("project should analyze");
+    let mut route_files = report
+        .findings
+        .route_entrypoints
+        .iter()
+        .map(|item| {
+            item.file
+                .strip_prefix(project.root())
+                .unwrap_or(&item.file)
+                .to_path_buf()
+        })
+        .collect::<Vec<_>>();
+    route_files.sort();
+
+    assert_eq!(report.summary.entrypoints, 5);
+    assert_eq!(report.summary.route_entrypoints, 4);
+    assert_eq!(
+        route_files,
+        vec![
+            PathBuf::from("packages/web/app/page.tsx"),
+            PathBuf::from("packages/web/pages/index.tsx"),
+            PathBuf::from("packages/web/src/app/page.tsx"),
+            PathBuf::from("packages/web/src/pages/index.tsx"),
+        ]
+    );
+}
+
+#[test]
+fn analyze_project_reports_dead_helpers_in_route_entrypoints() {
+    let project = TestProject::new("route-dead-helpers");
+    project.write(
+        "app/page.tsx",
+        r#"export default function Page() { return null; }
+export const generateMetadata = () => ({ title: "ok" });
+export const helper = 1;
+"#,
+    );
+
+    let report = analyze_project(project.root()).expect("project should analyze");
+
+    assert_eq!(report.summary.entrypoints, 1);
+    assert_eq!(report.summary.route_entrypoints, 1);
+    assert_eq!(report.summary.dead_exports, 1);
+    assert_eq!(report.findings.dead_exports.len(), 1);
+    assert_eq!(
+        report.findings.dead_exports[0].file,
+        project.root().join("app/page.tsx")
+    );
+    assert_eq!(report.findings.dead_exports[0].export_name, "helper");
+}
+
+#[test]
+fn analyze_project_skips_next_metadata_helpers_for_metadata_files() {
+    let project = TestProject::new("metadata-helpers");
+    project.write(
+        "app/opengraph-image.tsx",
+        r#"export function generateImageMetadata() {
+  return [{ id: "1", contentType: "image/png", size: { width: 1200, height: 630 } }];
+}
+export default function Image() { return null; }
+export const helper = 1;
+"#,
+    );
+
+    let report = analyze_project(project.root()).expect("project should analyze");
+
+    assert_eq!(report.summary.entrypoints, 1);
+    assert_eq!(report.summary.route_entrypoints, 1);
+    assert_eq!(report.summary.dead_exports, 1);
+    assert_eq!(report.findings.dead_exports.len(), 1);
+    assert_eq!(
+        report.findings.dead_exports[0].file,
+        project.root().join("app/opengraph-image.tsx")
+    );
+    assert_eq!(report.findings.dead_exports[0].export_name, "helper");
+}
+
+#[test]
+fn analyze_project_reports_missing_base_url_imports_as_broken() {
+    let project = TestProject::new("missing-baseurl");
+    project.write(
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "baseUrl": "src"
+  }
+}
+"#,
+    );
+    project.write(
+        "src/main.ts",
+        "import { missing } from \"shared/missing\";\nexport const main = missing;\n",
+    );
+    project.write("src/shared/index.ts", "export const shared = true;\n");
+
+    let report = analyze_project(project.root()).expect("project should analyze");
+
+    assert_eq!(report.summary.broken_imports, 1);
+    assert_eq!(report.findings.broken_imports.len(), 1);
+    assert_eq!(report.findings.broken_imports[0].source, "shared/missing");
+    assert_eq!(
+        report.findings.broken_imports[0].file,
+        project.root().join("src/main.ts")
+    );
+}
+
 fn repo_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../..")
         .canonicalize()
         .expect("repo root should resolve")
+}
+
+struct TestProject {
+    root: PathBuf,
+}
+
+impl TestProject {
+    fn new(prefix: &str) -> Self {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after unix epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("kratos-analyze-{prefix}-{unique}"));
+        std::fs::create_dir_all(&root).expect("temp project should be created");
+        Self { root }
+    }
+
+    fn root(&self) -> &Path {
+        &self.root
+    }
+
+    fn write(&self, relative_path: &str, contents: &str) {
+        let file_path = self.root.join(relative_path);
+        if let Some(parent) = file_path.parent() {
+            std::fs::create_dir_all(parent).expect("parent directory should be created");
+        }
+        std::fs::write(file_path, contents).expect("file should be written");
+    }
+}
+
+impl Drop for TestProject {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
 }

--- a/crates/kratos-core/tests/config_and_discovery.rs
+++ b/crates/kratos-core/tests/config_and_discovery.rs
@@ -69,7 +69,10 @@ fn load_project_config_parses_comments_and_collects_entries() {
         .ignored_directories
         .iter()
         .any(|entry| entry == "custom-cache"));
-    assert_eq!(config.explicit_entries, vec![project.root().join("src/main.ts")]);
+    assert_eq!(
+        config.explicit_entries,
+        vec![project.root().join("src/main.ts")]
+    );
     assert_eq!(config.path_aliases[0].alias, "@deep/*");
     assert_eq!(config.path_aliases[1].alias, "@/*");
     assert!(config
@@ -88,7 +91,9 @@ fn load_project_config_parses_comments_and_collects_entries() {
         .package_entries
         .contains(&project.root().join("dist/cli.js")));
     assert!(
-        !config.package_entries.contains(&project.root().to_path_buf()),
+        !config
+            .package_entries
+            .contains(&project.root().to_path_buf()),
         "empty export targets should be ignored"
     );
 }
@@ -156,11 +161,17 @@ fn resolve_import_target_uses_paths_base_url_and_directory_fallbacks() {
 
     let exact_alias = resolve_import_target("@cfg", &importer, &config).expect("exact alias");
     assert_eq!(exact_alias.kind, ImportResolutionKind::Source);
-    assert_eq!(exact_alias.path, Some(project.root().join("src/config/index.ts")));
+    assert_eq!(
+        exact_alias.path,
+        Some(project.root().join("src/config/index.ts"))
+    );
 
     let base_url = resolve_import_target("shared", &importer, &config).expect("baseUrl resolves");
     assert_eq!(base_url.kind, ImportResolutionKind::Source);
-    assert_eq!(base_url.path, Some(project.root().join("src/shared/index.ts")));
+    assert_eq!(
+        base_url.path,
+        Some(project.root().join("src/shared/index.ts"))
+    );
 
     let middle_wildcard =
         resolve_import_target("@view/home", &importer, &config).expect("middle wildcard");
@@ -178,7 +189,10 @@ fn resolve_import_target_uses_paths_base_url_and_directory_fallbacks() {
     let root_relative =
         resolve_import_target("/lib/root-entry", &importer, &config).expect("root relative");
     assert_eq!(root_relative.kind, ImportResolutionKind::Source);
-    assert_eq!(root_relative.path, Some(project.root().join("lib/root-entry.ts")));
+    assert_eq!(
+        root_relative.path,
+        Some(project.root().join("lib/root-entry.ts"))
+    );
 
     let builtin = resolve_import_target("node:path", &importer, &config).expect("builtin");
     assert_eq!(builtin.kind, ImportResolutionKind::External);
@@ -225,7 +239,10 @@ fn resolve_import_target_preserves_same_length_alias_insertion_order() {
     let resolution =
         resolve_import_target("@foobar", &importer, &config).expect("alias should resolve");
     assert_eq!(resolution.kind, ImportResolutionKind::Source);
-    assert_eq!(resolution.path, Some(project.root().join("src/preferred/bar.ts")));
+    assert_eq!(
+        resolution.path,
+        Some(project.root().join("src/preferred/bar.ts"))
+    );
 }
 
 #[test]
@@ -254,12 +271,18 @@ fn resolve_import_target_honors_wildcard_alias_suffix() {
     let preferred =
         resolve_import_target("@fooquxbaz", &importer, &config).expect("suffix alias resolves");
     assert_eq!(preferred.kind, ImportResolutionKind::Source);
-    assert_eq!(preferred.path, Some(project.root().join("src/preferred/qux.ts")));
+    assert_eq!(
+        preferred.path,
+        Some(project.root().join("src/preferred/qux.ts"))
+    );
 
     let fallback =
         resolve_import_target("@fooquxbar", &importer, &config).expect("suffix alias resolves");
     assert_eq!(fallback.kind, ImportResolutionKind::Source);
-    assert_eq!(fallback.path, Some(project.root().join("src/fallback/qux.ts")));
+    assert_eq!(
+        fallback.path,
+        Some(project.root().join("src/fallback/qux.ts"))
+    );
 
     let missing =
         resolve_import_target("@fooquxnope", &importer, &config).expect("suffix mismatch");
@@ -312,7 +335,10 @@ fn load_project_config_normalizes_relative_root_for_discovery_and_resolution() {
     let root_relative =
         resolve_import_target("/app/root-entry", &importer, &config).expect("root relative");
     assert_eq!(root_relative.kind, ImportResolutionKind::Source);
-    assert_eq!(root_relative.path, Some(project.root().join("app/root-entry.ts")));
+    assert_eq!(
+        root_relative.path,
+        Some(project.root().join("app/root-entry.ts"))
+    );
 }
 
 #[test]
@@ -334,7 +360,10 @@ fn load_project_config_normalizes_dot_segments_in_base_url_and_alias_targets() {
     let config = load_project_config(project.root()).expect("config should load");
     assert_eq!(config.base_url, Some(project.root().join("src")));
     assert_eq!(config.path_aliases.len(), 1);
-    assert_eq!(config.path_aliases[0].target, project.root().join("src/shared"));
+    assert_eq!(
+        config.path_aliases[0].target,
+        project.root().join("src/shared")
+    );
 }
 
 #[test]
@@ -369,8 +398,8 @@ fn resolve_import_target_accepts_relative_importer_paths() {
 
 #[test]
 fn parse_loose_json_rejects_control_characters_and_supports_surrogate_pairs() {
-    let parsed = parse_loose_json(r#"{ "emoji": "\uD83D\uDE00" }"#)
-        .expect("surrogate pair should parse");
+    let parsed =
+        parse_loose_json(r#"{ "emoji": "\uD83D\uDE00" }"#).expect("surrogate pair should parse");
     let emoji = parsed
         .get("emoji")
         .and_then(JsonValue::as_str)
@@ -386,8 +415,8 @@ fn parse_loose_json_rejects_control_characters_and_supports_surrogate_pairs() {
         "unexpected error: {invalid}"
     );
 
-    let leading_zero = parse_loose_json(r#"{"count":01}"#)
-        .expect_err("leading-zero numbers should be rejected");
+    let leading_zero =
+        parse_loose_json(r#"{"count":01}"#).expect_err("leading-zero numbers should be rejected");
     assert!(
         leading_zero
             .to_string()
@@ -502,7 +531,8 @@ fn load_project_config_rejects_non_string_array_items() {
 "#,
     );
 
-    let config = load_project_config(project.root()).expect("non-array alias targets should be ignored");
+    let config =
+        load_project_config(project.root()).expect("non-array alias targets should be ignored");
     assert!(config.path_aliases.is_empty());
 }
 

--- a/crates/kratos-core/tests/config_and_discovery.rs
+++ b/crates/kratos-core/tests/config_and_discovery.rs
@@ -205,6 +205,323 @@ fn resolve_import_target_uses_paths_base_url_and_directory_fallbacks() {
     let missing = resolve_import_target("./missing", &importer, &config).expect("missing");
     assert_eq!(missing.kind, ImportResolutionKind::MissingInternal);
     assert_eq!(missing.path, None);
+
+    let missing_base_url =
+        resolve_import_target("shared/missing", &importer, &config).expect("missing baseUrl");
+    assert_eq!(missing_base_url.kind, ImportResolutionKind::MissingInternal);
+    assert_eq!(missing_base_url.path, None);
+}
+
+#[test]
+fn resolve_import_target_keeps_declared_external_packages_external() {
+    let project = TestProject::new("declared-external-packages");
+    project.write(
+        "package.json",
+        r#"{
+  "dependencies": {
+    "react": "^18.0.0",
+    "@scope/pkg": "^1.0.0"
+  }
+}
+"#,
+    );
+    project.write(
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "baseUrl": "src"
+  }
+}
+"#,
+    );
+    project.write("src/app/main.ts", "export const main = true;\n");
+    project.write("src/react/index.ts", "export const fakeReact = true;\n");
+    project.write(
+        "src/@scope/pkg/index.ts",
+        "export const fakeScoped = true;\n",
+    );
+
+    let config = load_project_config(project.root()).expect("config should load");
+    let importer = project.root().join("src/app/main.ts");
+
+    assert!(config.external_packages.contains("react"));
+    assert!(config.external_packages.contains("@scope/pkg"));
+
+    let react =
+        resolve_import_target("react/jsx-runtime", &importer, &config).expect("react resolves");
+    assert_eq!(react.kind, ImportResolutionKind::External);
+    assert_eq!(react.path, None);
+
+    let scoped =
+        resolve_import_target("@scope/pkg/runtime", &importer, &config).expect("scope resolves");
+    assert_eq!(scoped.kind, ImportResolutionKind::External);
+    assert_eq!(scoped.path, None);
+}
+
+#[test]
+fn resolve_import_target_marks_file_backed_base_url_subpaths_as_missing_internal() {
+    let project = TestProject::new("file-backed-baseurl");
+    project.write(
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "baseUrl": "src"
+  }
+}
+"#,
+    );
+    project.write("src/app/main.ts", "export const main = true;\n");
+    project.write("src/helpers.ts", "export const FLAG = true;\n");
+
+    let config = load_project_config(project.root()).expect("config should load");
+    let importer = project.root().join("src/app/main.ts");
+
+    let missing =
+        resolve_import_target("helpers/foo", &importer, &config).expect("missing subpath");
+    assert_eq!(missing.kind, ImportResolutionKind::MissingInternal);
+    assert_eq!(missing.path, None);
+}
+
+#[test]
+fn resolve_import_target_marks_directory_backed_base_url_subpaths_as_missing_internal() {
+    let project = TestProject::new("directory-backed-baseurl");
+    project.write(
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "baseUrl": "src"
+  }
+}
+"#,
+    );
+    project.write("src/app/main.ts", "export const main = true;\n");
+    project.write("src/shared/placeholder.txt", "shadow directory\n");
+
+    let config = load_project_config(project.root()).expect("config should load");
+    let importer = project.root().join("src/app/main.ts");
+
+    let missing =
+        resolve_import_target("shared/missing", &importer, &config).expect("missing subpath");
+    assert_eq!(missing.kind, ImportResolutionKind::MissingInternal);
+    assert_eq!(missing.path, None);
+}
+
+#[test]
+fn resolve_import_target_marks_base_url_misses_without_internal_signal_as_missing_internal() {
+    let project = TestProject::new("baseurl-miss-without-signal");
+    project.write(
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "baseUrl": "src"
+  }
+}
+"#,
+    );
+    project.write("src/app/main.ts", "export const main = true;\n");
+
+    let config = load_project_config(project.root()).expect("config should load");
+    let importer = project.root().join("src/app/main.ts");
+
+    let missing = resolve_import_target("utils/missing", &importer, &config).expect("missing");
+    assert_eq!(missing.kind, ImportResolutionKind::MissingInternal);
+    assert_eq!(missing.path, None);
+}
+
+#[test]
+fn resolve_import_target_keeps_node_builtins_external_with_base_url() {
+    let project = TestProject::new("builtin-baseurl");
+    project.write(
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "baseUrl": "src"
+  }
+}
+"#,
+    );
+    project.write("src/app/main.ts", "export const main = true;\n");
+
+    let config = load_project_config(project.root()).expect("config should load");
+    let importer = project.root().join("src/app/main.ts");
+
+    let fs = resolve_import_target("fs", &importer, &config).expect("fs should stay external");
+    assert_eq!(fs.kind, ImportResolutionKind::External);
+    assert_eq!(fs.path, None);
+
+    let path =
+        resolve_import_target("path/posix", &importer, &config).expect("path should stay external");
+    assert_eq!(path.kind, ImportResolutionKind::External);
+    assert_eq!(path.path, None);
+}
+
+#[test]
+fn resolve_import_target_allows_base_url_to_shadow_node_builtins() {
+    let project = TestProject::new("shadow-builtin");
+    project.write(
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "baseUrl": "src"
+  }
+}
+"#,
+    );
+    project.write("src/app/main.ts", "export const main = true;\n");
+    project.write("src/fs.ts", "export const shadowed = true;\n");
+
+    let config = load_project_config(project.root()).expect("config should load");
+    let importer = project.root().join("src/app/main.ts");
+
+    let resolution = resolve_import_target("fs", &importer, &config).expect("fs should resolve");
+    assert_eq!(resolution.kind, ImportResolutionKind::Source);
+    assert_eq!(resolution.path, Some(project.root().join("src/fs.ts")));
+}
+
+#[test]
+fn resolve_import_target_allows_base_url_files_to_shadow_declared_packages() {
+    let project = TestProject::new("shadowed-dependency");
+    project.write(
+        "package.json",
+        r#"{
+  "dependencies": {
+    "react": "^18.0.0"
+  }
+}
+"#,
+    );
+    project.write(
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "baseUrl": "src"
+  }
+}
+"#,
+    );
+    project.write("src/app/main.ts", "export const main = true;\n");
+    project.write("src/react.ts", "export const shadowed = true;\n");
+
+    let config = load_project_config(project.root()).expect("config should load");
+    let importer = project.root().join("src/app/main.ts");
+
+    let resolution = resolve_import_target("react", &importer, &config).expect("react resolves");
+    assert_eq!(resolution.kind, ImportResolutionKind::Source);
+    assert_eq!(resolution.path, Some(project.root().join("src/react.ts")));
+}
+
+#[test]
+fn resolve_import_target_uses_nested_package_dependencies_for_base_url_misses() {
+    let project = TestProject::new("nested-package-dependencies");
+    project.write(
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "baseUrl": "src"
+  }
+}
+"#,
+    );
+    project.write(
+        "packages/ui/package.json",
+        r#"{
+  "dependencies": {
+    "react": "^18.0.0",
+    "@scope/pkg": "^1.0.0"
+  }
+}
+"#,
+    );
+    project.write("packages/ui/src/app/main.ts", "export const main = true;\n");
+
+    let config = load_project_config(project.root()).expect("config should load");
+    let importer = project.root().join("packages/ui/src/app/main.ts");
+
+    let react =
+        resolve_import_target("react/jsx-runtime", &importer, &config).expect("react resolves");
+    assert_eq!(react.kind, ImportResolutionKind::External);
+    assert_eq!(react.path, None);
+
+    let scoped =
+        resolve_import_target("@scope/pkg/runtime", &importer, &config).expect("scope resolves");
+    assert_eq!(scoped.kind, ImportResolutionKind::External);
+    assert_eq!(scoped.path, None);
+}
+
+#[test]
+fn load_project_config_resolves_extensionless_and_directory_package_entries() {
+    let project = TestProject::new("package-entry-resolution");
+    project.write(
+        "package.json",
+        r#"{
+  "main": "./src/index",
+  "bin": "./src/cli",
+  "exports": {
+    ".": "./src/routes"
+  }
+}
+"#,
+    );
+    project.write("src/index.ts", "export const main = true;\n");
+    project.write("src/cli.ts", "export const cli = true;\n");
+    project.write("src/routes/index.ts", "export const route = true;\n");
+
+    let config = load_project_config(project.root()).expect("config should load");
+
+    assert!(config
+        .package_entries
+        .contains(&project.root().join("src/index.ts")));
+    assert!(config
+        .package_entries
+        .contains(&project.root().join("src/cli.ts")));
+    assert!(config
+        .package_entries
+        .contains(&project.root().join("src/routes/index.ts")));
+}
+
+#[test]
+fn load_project_config_prefers_declaration_files_for_types_entries() {
+    let project = TestProject::new("types-entry-resolution");
+    project.write(
+        "package.json",
+        r#"{
+  "types": "./dist/index",
+  "exports": {
+    ".": {
+      "types": "./dist/types"
+    }
+  }
+}
+"#,
+    );
+    project.write("dist/index.ts", "export const runtime = true;\n");
+    project.write("dist/index.d.ts", "export declare const runtime: true;\n");
+    project.write("dist/types.ts", "export const typesRuntime = true;\n");
+    project.write(
+        "dist/types.d.ts",
+        "export declare const typesRuntime: true;\n",
+    );
+
+    let config = load_project_config(project.root()).expect("config should load");
+
+    assert!(config
+        .package_entries
+        .contains(&project.root().join("dist/index.d.ts")));
+    assert!(config
+        .package_entries
+        .contains(&project.root().join("dist/types.d.ts")));
+    assert!(
+        !config
+            .package_entries
+            .contains(&project.root().join("dist/index.ts")),
+        "types entry should not prefer runtime source files over declarations"
+    );
+    assert!(
+        !config
+            .package_entries
+            .contains(&project.root().join("dist/types.ts")),
+        "exports.types should not prefer runtime source files over declarations"
+    );
 }
 
 #[test]
@@ -286,7 +603,7 @@ fn resolve_import_target_honors_wildcard_alias_suffix() {
 
     let missing =
         resolve_import_target("@fooquxnope", &importer, &config).expect("suffix mismatch");
-    assert_eq!(missing.kind, ImportResolutionKind::External);
+    assert_eq!(missing.kind, ImportResolutionKind::MissingInternal);
     assert_eq!(missing.path, None);
 }
 

--- a/crates/kratos-core/tests/report_v2.rs
+++ b/crates/kratos-core/tests/report_v2.rs
@@ -221,6 +221,258 @@ fn report_v2_rejects_truncated_required_sections() {
 }
 
 #[test]
+fn report_v2_rejects_invalid_metadata_field_types() {
+    let invalid_generated_at = r#"{
+      "schemaVersion": 2,
+      "generatedAt": true,
+      "project": {
+        "root": "/tmp/kratos",
+        "configPath": null
+      },
+      "summary": {
+        "filesScanned": 0,
+        "entrypoints": 0,
+        "brokenImports": 0,
+        "orphanFiles": 0,
+        "deadExports": 0,
+        "unusedImports": 0,
+        "routeEntrypoints": 0,
+        "deletionCandidates": 0
+      },
+      "findings": {
+        "brokenImports": [],
+        "orphanFiles": [],
+        "deadExports": [],
+        "unusedImports": [],
+        "routeEntrypoints": [],
+        "deletionCandidates": []
+      },
+      "graph": {
+        "modules": []
+      }
+    }"#;
+    let invalid_config_path = r#"{
+      "schemaVersion": 2,
+      "generatedAt": "2026-04-19T00:00:00Z",
+      "project": {
+        "root": "/tmp/kratos",
+        "configPath": { "bad": true }
+      },
+      "summary": {
+        "filesScanned": 0,
+        "entrypoints": 0,
+        "brokenImports": 0,
+        "orphanFiles": 0,
+        "deadExports": 0,
+        "unusedImports": 0,
+        "routeEntrypoints": 0,
+        "deletionCandidates": 0
+      },
+      "findings": {
+        "brokenImports": [],
+        "orphanFiles": [],
+        "deadExports": [],
+        "unusedImports": [],
+        "routeEntrypoints": [],
+        "deletionCandidates": []
+      },
+      "graph": {
+        "modules": []
+      }
+    }"#;
+
+    let generated_at_error =
+        parse_report_json(invalid_generated_at).expect_err("invalid generatedAt should fail");
+    let config_path_error =
+        parse_report_json(invalid_config_path).expect_err("invalid configPath should fail");
+
+    assert!(
+        generated_at_error.to_string().contains("generatedAt"),
+        "expected generatedAt error, got: {generated_at_error}"
+    );
+    assert!(
+        config_path_error.to_string().contains("project.configPath"),
+        "expected configPath error, got: {config_path_error}"
+    );
+}
+
+#[test]
+fn report_v2_rejects_invalid_required_enum_values() {
+    let invalid_import_kind = r#"{
+      "schemaVersion": 2,
+      "generatedAt": "2026-04-19T00:00:00Z",
+      "project": {
+        "root": "/tmp/kratos",
+        "configPath": null
+      },
+      "summary": {
+        "filesScanned": 0,
+        "entrypoints": 0,
+        "brokenImports": 1,
+        "orphanFiles": 0,
+        "deadExports": 0,
+        "unusedImports": 0,
+        "routeEntrypoints": 0,
+        "deletionCandidates": 0
+      },
+      "findings": {
+        "brokenImports": [
+          {
+            "file": "/tmp/kratos/src/main.ts",
+            "source": "shared/missing",
+            "kind": "bogus"
+          }
+        ],
+        "orphanFiles": [],
+        "deadExports": [],
+        "unusedImports": [],
+        "routeEntrypoints": [],
+        "deletionCandidates": []
+      },
+      "graph": {
+        "modules": []
+      }
+    }"#;
+    let invalid_orphan_kind = r#"{
+      "schemaVersion": 2,
+      "generatedAt": "2026-04-19T00:00:00Z",
+      "project": {
+        "root": "/tmp/kratos",
+        "configPath": null
+      },
+      "summary": {
+        "filesScanned": 0,
+        "entrypoints": 0,
+        "brokenImports": 0,
+        "orphanFiles": 1,
+        "deadExports": 0,
+        "unusedImports": 0,
+        "routeEntrypoints": 0,
+        "deletionCandidates": 0
+      },
+      "findings": {
+        "brokenImports": [],
+        "orphanFiles": [
+          {
+            "file": "/tmp/kratos/src/package.ts",
+            "kind": "bogus",
+            "reason": "bad",
+            "confidence": 0.5
+          }
+        ],
+        "deadExports": [],
+        "unusedImports": [],
+        "routeEntrypoints": [],
+        "deletionCandidates": []
+      },
+      "graph": {
+        "modules": []
+      }
+    }"#;
+
+    let import_error =
+        parse_report_json(invalid_import_kind).expect_err("invalid import kind should fail");
+    let orphan_error =
+        parse_report_json(invalid_orphan_kind).expect_err("invalid orphan kind should fail");
+
+    assert!(
+        import_error
+            .to_string()
+            .contains("findings.brokenImports[0].kind"),
+        "expected broken import kind error, got: {import_error}"
+    );
+    assert!(
+        orphan_error
+            .to_string()
+            .contains("findings.orphanFiles[0].kind"),
+        "expected orphan kind error, got: {orphan_error}"
+    );
+}
+
+#[test]
+fn legacy_report_parses_into_renderable_v2_report() {
+    let legacy_report = r#"{
+      "version": 1,
+      "generatedAt": "2026-04-19T00:00:00Z",
+      "root": "/tmp/kratos",
+      "summary": {
+        "filesScanned": 1,
+        "entrypoints": 1,
+        "brokenImports": 0,
+        "orphanFiles": 0,
+        "deadExports": 0,
+        "unusedImports": 0,
+        "routeEntrypoints": 0,
+        "deletionCandidates": 0
+      },
+      "findings": {
+        "brokenImports": [],
+        "orphanFiles": [],
+        "deadExports": [],
+        "unusedImports": [],
+        "routeEntrypoints": [],
+        "deletionCandidates": []
+      },
+      "modules": [
+        {
+          "file": "/tmp/kratos/src/main.ts",
+          "relativePath": "src/main.ts",
+          "entrypointKind": "app-entry",
+          "importedByCount": 0,
+          "importCount": 0,
+          "exportCount": 0
+        }
+      ]
+    }"#;
+
+    let parsed = parse_report_json(legacy_report).expect("legacy report should parse");
+    let report_path = Path::new("/tmp/kratos/.kratos/latest-report.json");
+
+    assert_eq!(parsed.version, 2);
+    validate_report_version(&parsed).expect("legacy report should be canonicalized to v2");
+    serialize_report_pretty(&parsed).expect("legacy report should serialize");
+    format_summary_report(&parsed, report_path).expect("legacy report should format as summary");
+    format_markdown_report(&parsed, report_path).expect("legacy report should format as markdown");
+}
+
+#[test]
+fn report_v2_requires_project_root_field() {
+    let invalid_root_shape = r#"{
+      "schemaVersion": 2,
+      "generatedAt": "2026-04-19T00:00:00Z",
+      "root": "/tmp/kratos",
+      "summary": {
+        "filesScanned": 0,
+        "entrypoints": 0,
+        "brokenImports": 0,
+        "orphanFiles": 0,
+        "deadExports": 0,
+        "unusedImports": 0,
+        "routeEntrypoints": 0,
+        "deletionCandidates": 0
+      },
+      "findings": {
+        "brokenImports": [],
+        "orphanFiles": [],
+        "deadExports": [],
+        "unusedImports": [],
+        "routeEntrypoints": [],
+        "deletionCandidates": []
+      },
+      "graph": {
+        "modules": []
+      }
+    }"#;
+
+    let error = parse_report_json(invalid_root_shape)
+        .expect_err("v2 reports without project.root should fail");
+    assert!(
+        error.to_string().contains("project"),
+        "expected project root error, got: {error}"
+    );
+}
+
+#[test]
 fn report_v2_preserves_non_null_config_path() {
     let repo_root = repo_root();
     let demo_root = repo_root.join("fixtures/demo-app");

--- a/fixtures/parity/demo-app/report-markdown.md
+++ b/fixtures/parity/demo-app/report-markdown.md
@@ -12,6 +12,7 @@
 - Orphan files: 2
 - Dead exports: 3
 - Unused imports: 0
+- Route entrypoints: 1
 - Deletion candidates: 2
 
 ## Broken imports
@@ -32,6 +33,10 @@
 ## Unused imports
 
 - None
+
+## Route entrypoints
+
+- <ROOT>/pages/home.tsx (next-pages-route)
 
 ## Deletion candidates
 

--- a/fixtures/parity/demo-app/report-summary.txt
+++ b/fixtures/parity/demo-app/report-summary.txt
@@ -7,6 +7,7 @@ Broken imports: 1
 Orphan files: 2
 Dead exports: 3
 Unused imports: 0
+Route entrypoints: 1
 Deletion candidates: 2
 
 Saved report: <REPORT>
@@ -22,3 +23,6 @@ Dead exports:
 - <ROOT>/src/components/DeadWidget.tsx#DeadWidget
 - <ROOT>/src/lib/broken.ts#brokenFeature
 - <ROOT>/src/lib/math.ts#multiply
+
+Route entrypoints:
+- <ROOT>/pages/home.tsx (next-pages-route)


### PR DESCRIPTION
## 배경

Kratos의 Rust 전환에서 이 PR은 `PR 3A` 범위를 계속 담고 있습니다.
이번 follow-up에서는 Rust 빌드 산출물 `target/`이 계속 로컬 unstaged로 남는 문제를 줄이기 위해 저장소 ignore 규칙을 보강했습니다.

## 변경 사항

- `kratos-core`에 실제 엔트리포인트 판별과 그래프 분석을 구현했습니다.
  - explicit/package entry
  - Next `pages/` route
  - JS baseline parity 기준의 `app/` route 판별
  - orphan file, dead export, unused import, deletion candidate 계산
- `ReportV2` JSON 직렬화/파싱과 summary/markdown formatter를 구현했습니다.
- Report V2 roundtrip에서 모듈 count, orphan confidence, `project.configPath`가 보존되도록 보강했습니다.
- `schemaVersion: 2` 리포트 파서는 잘린 JSON을 조용히 빈 리포트처럼 받아들이지 않도록 required section/field 검증을 추가했습니다.
- demo fixture parity를 검증하는 Rust 테스트를 추가했습니다.
  - `analyze_demo_app.rs`
  - `report_v2.rs`
- follow-up: Rust 빌드 산출물 `target/`을 `.gitignore`에 추가했습니다.

## 검증

- `cargo test -p kratos-core --test analyze_demo_app`
- `cargo test -p kratos-core --test report_v2`
- `cargo test -p kratos-core`
- `npm test`
- `cargo test --workspace`
- `git check-ignore -v target`
- `git status --short --ignored`
- 독립 fresh-session 리뷰 loop 완료
  - 엔트리포인트 과검출 수정
  - `project.configPath` roundtrip 보강
  - parity 계약 기준 최종 `APPROVE`

## 브랜치 / 워크트리

- 대상 브랜치: `codex/graph-analysis-report-v2`
- 현재 워크트리: `/Users/pjw/workspace/kratos`
- 포함된 source branch / worktree: 없음

## 이슈 연결

- 별도 이슈 연결 없음

## 리스크 또는 확인 포인트

- `target/` ignore는 저장소 공용 규칙으로 추가했지만, `TODO.md`와 `PR_DESCRIPTION.md`는 로컬 전용 파일이라 `.git/info/exclude`에만 남겨두었습니다.
- 다음 단계인 `PR 3B`에서 clean 로직이 이 리포트 계약을 실제로 소비하게 되므로, report schema drift가 없도록 이어서 검증하는 편이 좋습니다.
