### PR TITLE
[codex] Rust clean safety와 Report V2 소비

### DIFF
--- a/crates/kratos-core/src/clean.rs
+++ b/crates/kratos-core/src/clean.rs
@@ -1,5 +1,11 @@
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
 use crate::error::{KratosError, KratosResult};
-use crate::model::ReportV2;
+use crate::model::{ReportV2, REPORT_V2};
+use crate::report::parse_report_json;
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct CleanOutcome {
@@ -7,6 +13,173 @@ pub struct CleanOutcome {
     pub skipped_files: usize,
 }
 
-pub fn clean_from_report(_report: &ReportV2, _apply: bool) -> KratosResult<CleanOutcome> {
-    Err(KratosError::not_implemented("clean::clean_from_report"))
+pub fn clean_from_report_path(
+    report_path: impl AsRef<Path>,
+    apply: bool,
+) -> KratosResult<CleanOutcome> {
+    let report = load_clean_report(report_path)?;
+    clean_from_report(&report, apply)
+}
+
+pub fn load_clean_report(report_path: impl AsRef<Path>) -> KratosResult<ReportV2> {
+    let raw = std::fs::read_to_string(report_path)?;
+    let value: Value =
+        serde_json::from_str(&raw).map_err(|error| KratosError::Json(error.to_string()))?;
+    let version = value
+        .get("schemaVersion")
+        .or_else(|| value.get("version"))
+        .and_then(Value::as_u64)
+        .ok_or_else(|| KratosError::Json("Report is missing schemaVersion/version".to_string()))?
+        as u32;
+
+    if version != REPORT_V2 {
+        return Err(KratosError::InvalidReportVersion {
+            expected: REPORT_V2,
+            found: version,
+        });
+    }
+
+    parse_report_json(&raw)
+}
+
+pub fn clean_from_report(report: &ReportV2, apply: bool) -> KratosResult<CleanOutcome> {
+    if report.version != REPORT_V2 {
+        return Err(KratosError::InvalidReportVersion {
+            expected: REPORT_V2,
+            found: report.version,
+        });
+    }
+
+    if !apply {
+        return Ok(CleanOutcome {
+            deleted_files: 0,
+            skipped_files: report.findings.deletion_candidates.len(),
+        });
+    }
+
+    let report_root_path = resolve_path(&report.root);
+    let deletion_root = realpath_or_fallback(&report.root);
+    let mut outcome = CleanOutcome::default();
+
+    for candidate in &report.findings.deletion_candidates {
+        let candidate_path = resolve_path(&candidate.file);
+
+        if !is_within_directory(&report_root_path, &candidate_path) {
+            outcome.skipped_files += 1;
+            continue;
+        }
+
+        if !file_exists(&candidate_path) {
+            outcome.skipped_files += 1;
+            continue;
+        }
+
+        let candidate_parent_path = candidate_path
+            .parent()
+            .unwrap_or(report_root_path.as_path());
+        let candidate_parent = realpath_or_fallback(candidate_parent_path);
+
+        if !is_within_directory(&deletion_root, &candidate_parent) {
+            outcome.skipped_files += 1;
+            continue;
+        }
+
+        match std::fs::remove_file(&candidate_path) {
+            Ok(()) => {
+                remove_empty_directories(candidate_parent_path, &report_root_path)?;
+                outcome.deleted_files += 1;
+            }
+            Err(error) if error.kind() == ErrorKind::NotFound => {
+                outcome.skipped_files += 1;
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
+
+    Ok(outcome)
+}
+
+fn file_exists(path: &Path) -> bool {
+    std::fs::metadata(path).is_ok()
+}
+
+fn realpath_or_fallback(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| resolve_path(path))
+}
+
+fn remove_empty_directories(start_dir: &Path, stop_at: &Path) -> KratosResult<()> {
+    let boundary = resolve_path(stop_at);
+    let mut current = resolve_path(start_dir);
+
+    while is_within_directory(&boundary, &current) && current != boundary {
+        let mut entries = match std::fs::read_dir(&current) {
+            Ok(entries) => entries,
+            Err(_) => return Ok(()),
+        };
+
+        if entries.next().is_some() {
+            return Ok(());
+        }
+
+        if std::fs::remove_dir(&current).is_err() {
+            return Ok(());
+        }
+
+        let Some(parent) = current.parent() else {
+            return Ok(());
+        };
+        current = parent.to_path_buf();
+    }
+
+    Ok(())
+}
+
+fn is_within_directory(root: &Path, candidate: &Path) -> bool {
+    let normalized_root = resolve_path(root);
+    let normalized_candidate = resolve_path(candidate);
+
+    normalized_candidate == normalized_root || normalized_candidate.starts_with(&normalized_root)
+}
+
+fn resolve_path(path: &Path) -> PathBuf {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join(path)
+    };
+
+    normalize_path(absolute)
+}
+
+fn normalize_path(path: PathBuf) -> PathBuf {
+    let mut normalized = PathBuf::new();
+
+    for component in path.components() {
+        match component {
+            std::path::Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            std::path::Component::RootDir => normalized.push(component.as_os_str()),
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                let can_pop = matches!(
+                    normalized.components().next_back(),
+                    Some(std::path::Component::Normal(_))
+                );
+
+                if can_pop {
+                    normalized.pop();
+                } else {
+                    normalized.push("..");
+                }
+            }
+            std::path::Component::Normal(segment) => normalized.push(segment),
+        }
+    }
+
+    if normalized.as_os_str().is_empty() {
+        PathBuf::from(".")
+    } else {
+        normalized
+    }
 }

--- a/crates/kratos-core/tests/clean_safety.rs
+++ b/crates/kratos-core/tests/clean_safety.rs
@@ -1,0 +1,202 @@
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use kratos_core::clean::{clean_from_report, clean_from_report_path};
+use kratos_core::error::KratosError;
+use kratos_core::model::{DeletionCandidateFinding, ReportV2};
+use kratos_core::report::serialize_report_pretty;
+
+#[test]
+fn clean_rejects_deletion_candidates_outside_report_root() {
+    let temp_root = temp_dir("clean-outside-root");
+    let report_root = temp_root.join("app");
+    let outside_root = temp_root.join("application");
+    let outside_file = outside_root.join("should-not-delete.ts");
+
+    std::fs::create_dir_all(&report_root).expect("report root should exist");
+    std::fs::create_dir_all(&outside_root).expect("outside root should exist");
+    std::fs::write(&outside_file, "export const keep = true;\n").expect("outside file writes");
+
+    let report = report_with_candidate(&report_root, &outside_file);
+    let outcome = clean_from_report(&report, true).expect("clean should succeed");
+
+    assert!(outside_file.exists());
+    assert_eq!(outcome.deleted_files, 0);
+    assert_eq!(outcome.skipped_files, 1);
+}
+
+#[test]
+fn clean_rejects_symlink_escape_candidates() {
+    let temp_root = temp_dir("clean-symlink-escape");
+    let report_root = temp_root.join("app");
+    let outside_root = temp_root.join("outside");
+    let outside_file = outside_root.join("target.ts");
+    let symlink_path = report_root.join("link");
+
+    std::fs::create_dir_all(&report_root).expect("report root should exist");
+    std::fs::create_dir_all(&outside_root).expect("outside root should exist");
+    std::fs::write(&outside_file, "export const keep = true;\n").expect("outside file writes");
+    symlink_dir(&outside_root, &symlink_path);
+
+    let report = report_with_candidate(&report_root, &symlink_path.join("target.ts"));
+    let outcome = clean_from_report(&report, true).expect("clean should succeed");
+
+    assert!(outside_file.exists());
+    assert_eq!(outcome.deleted_files, 0);
+    assert_eq!(outcome.skipped_files, 1);
+}
+
+#[test]
+fn clean_skips_dangling_symlink_candidates() {
+    let temp_root = temp_dir("clean-dangling-symlink");
+    let report_root = temp_root.join("app");
+    let dangling_link = report_root.join("dangling.ts");
+
+    std::fs::create_dir_all(&report_root).expect("report root should exist");
+    symlink_file(Path::new("missing-target.ts"), &dangling_link);
+
+    let report = report_with_candidate(&report_root, &dangling_link);
+    let outcome = clean_from_report(&report, true).expect("clean should skip dangling symlinks");
+
+    assert!(
+        std::fs::symlink_metadata(&dangling_link).is_ok(),
+        "dangling symlink should remain untouched"
+    );
+    assert_eq!(outcome.deleted_files, 0);
+    assert_eq!(outcome.skipped_files, 1);
+}
+
+#[test]
+fn clean_allows_symlinked_project_root_and_removes_empty_directories() {
+    let temp_root = temp_dir("clean-symlink-root");
+    let real_root = temp_root.join("real-app");
+    let symlink_root = temp_root.join("linked-app");
+    let nested_dir = real_root.join("orphan");
+    let dead_file = nested_dir.join("dead.ts");
+
+    std::fs::create_dir_all(&nested_dir).expect("nested dir should exist");
+    std::fs::write(&dead_file, "export const dead = true;\n").expect("dead file writes");
+    symlink_dir(&real_root, &symlink_root);
+
+    let report = report_with_candidate(&symlink_root, &symlink_root.join("orphan/dead.ts"));
+    let outcome = clean_from_report(&report, true).expect("clean should succeed");
+
+    assert!(!dead_file.exists());
+    assert!(!nested_dir.exists());
+    assert_eq!(outcome.deleted_files, 1);
+    assert_eq!(outcome.skipped_files, 0);
+}
+
+#[test]
+fn clean_ignores_cleanup_failures_after_successful_delete() {
+    let temp_root = temp_dir("clean-best-effort-cleanup");
+    let report_root = temp_root.join("app");
+    let real_nested_dir = report_root.join("real-nested");
+    let symlink_nested_dir = report_root.join("symlink-nested");
+    let dead_file = real_nested_dir.join("dead.ts");
+
+    std::fs::create_dir_all(&real_nested_dir).expect("real nested dir should exist");
+    std::fs::write(&dead_file, "export const dead = true;\n").expect("dead file writes");
+    symlink_dir(&real_nested_dir, &symlink_nested_dir);
+
+    let report = report_with_candidate(&report_root, &symlink_nested_dir.join("dead.ts"));
+    let outcome = clean_from_report(&report, true).expect("clean should stay best-effort");
+
+    assert!(!dead_file.exists());
+    assert_eq!(outcome.deleted_files, 1);
+    assert_eq!(outcome.skipped_files, 0);
+}
+
+#[test]
+fn clean_rejects_invalid_report_version_from_file() {
+    let temp_root = temp_dir("clean-invalid-version");
+    let report_path = temp_root.join("latest-report.json");
+
+    std::fs::create_dir_all(&temp_root).expect("temp root should exist");
+    std::fs::write(
+        &report_path,
+        format!(
+            "{{\"version\":1,\"root\":\"{}\",\"findings\":{{\"deletionCandidates\":[]}}}}",
+            temp_root.display()
+        ),
+    )
+    .expect("report writes");
+
+    let error =
+        clean_from_report_path(&report_path, true).expect_err("v1 reports should be rejected");
+
+    match error {
+        KratosError::InvalidReportVersion { expected, found } => {
+            assert_eq!(expected, 2);
+            assert_eq!(found, 1);
+        }
+        other => panic!("expected invalid report version error, got {other}"),
+    }
+}
+
+#[test]
+fn clean_from_report_path_reads_v2_report_and_deletes_candidate() {
+    let temp_root = temp_dir("clean-report-path-v2");
+    let report_root = temp_root.join("app");
+    let dead_file = report_root.join("dead.ts");
+    let report_path = report_root.join(".kratos/latest-report.json");
+
+    std::fs::create_dir_all(report_path.parent().expect("report dir should exist"))
+        .expect("report dir should exist");
+    std::fs::write(&dead_file, "export const dead = true;\n").expect("dead file writes");
+
+    let report = report_with_candidate(&report_root, &dead_file);
+    let serialized = serialize_report_pretty(&report).expect("report should serialize");
+    std::fs::write(&report_path, serialized).expect("report should write");
+
+    let outcome =
+        clean_from_report_path(&report_path, true).expect("clean_from_report_path should work");
+
+    assert!(!dead_file.exists());
+    assert_eq!(outcome.deleted_files, 1);
+    assert_eq!(outcome.skipped_files, 0);
+}
+
+fn report_with_candidate(root: &Path, candidate: &Path) -> ReportV2 {
+    let mut report = ReportV2::new(root.to_path_buf());
+    report
+        .findings
+        .deletion_candidates
+        .push(DeletionCandidateFinding {
+            file: candidate.to_path_buf(),
+            reason: "test".to_string(),
+            confidence: 1.0,
+            safe: true,
+        });
+    report
+}
+
+fn temp_dir(label: &str) -> PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be valid")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!("kratos-{label}-{unique}"));
+    std::fs::create_dir_all(&path).expect("temp dir should be created");
+    path
+}
+
+#[cfg(unix)]
+fn symlink_dir(target: &Path, link: &Path) {
+    std::os::unix::fs::symlink(target, link).expect("directory symlink should be created");
+}
+
+#[cfg(unix)]
+fn symlink_file(target: &Path, link: &Path) {
+    std::os::unix::fs::symlink(target, link).expect("file symlink should be created");
+}
+
+#[cfg(windows)]
+fn symlink_dir(target: &Path, link: &Path) {
+    std::os::windows::fs::symlink_dir(target, link).expect("directory symlink should be created");
+}
+
+#[cfg(windows)]
+fn symlink_file(target: &Path, link: &Path) {
+    std::os::windows::fs::symlink_file(target, link).expect("file symlink should be created");
+}


### PR DESCRIPTION
## 배경
- Rust migration의 `PR 3B` 범위로 `kratos-core`의 clean safety 로직이 아직 stub 상태였습니다.
- JS baseline이 갖고 있던 삭제 guardrail과 report version 제약을 Rust core에서도 직접 보장할 필요가 있었습니다.

## 변경 사항
- `crates/kratos-core/src/clean.rs`
  - v2 report 전용 `clean_from_report_path` / `load_clean_report` 구현
  - `InvalidReportVersion` 반환으로 v1 report 차단
  - apply/dry-run 처리 구현
  - report root boundary 체크와 symlink escape 차단 구현
  - successful delete 이후 empty-directory cleanup을 best-effort로 처리
- `crates/kratos-core/tests/clean_safety.rs`
  - outside root deletion reject
  - symlink escape reject
  - symlinked project root allow
  - invalid report version reject
  - cleanup failure after successful delete non-fatal regression

## 검증
- `cargo test -p kratos-core --test clean_safety`
- `cargo test -p kratos-core`
- `cargo test --workspace`
- `npm test`
- `npm run smoke`

## 브랜치 / 워크트리
- 대상 브랜치: `codex/rust-clean-safety-v2`
- 현재 워크트리: `/Users/pjw/workspace/kratos`
- 포함된 source worktree: 없음
- 포함된 source branch: 없음
