### PR TITLE
[codex] Rust CLI scan/report/clean 구현

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -34,6 +84,52 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
@@ -62,6 +158,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd8e701084c37e7ef62d3f9e453b618130cbc0ef3573847785952a3ac3f746bf"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,6 +179,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,7 +210,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 name = "kratos-cli"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "kratos-core",
+ "serde_json",
 ]
 
 [[package]]
@@ -148,6 +274,12 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "owo-colors"
@@ -497,6 +629,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -521,6 +654,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -593,6 +732,27 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "zmij"

--- a/crates/kratos-cli/Cargo.toml
+++ b/crates/kratos-cli/Cargo.toml
@@ -9,4 +9,6 @@ repository.workspace = true
 description = "Rust CLI surface for Kratos."
 
 [dependencies]
+clap = { version = "4.5.41", features = ["derive"] }
 kratos-core = { path = "../kratos-core" }
+serde_json = { version = "1", features = ["preserve_order"] }

--- a/crates/kratos-cli/src/commands/clean.rs
+++ b/crates/kratos-cli/src/commands/clean.rs
@@ -1,6 +1,12 @@
-use kratos_core::{KratosError, KratosResult};
+use std::fs;
+use std::io::Write;
 
-use super::CommandSpec;
+use clap::Parser;
+use kratos_core::clean::clean_from_report;
+use kratos_core::report::parse_report_json;
+use kratos_core::KratosResult;
+
+use super::{canonicalize_clean_args, resolve_report_input, write_output, CommandSpec};
 
 pub const NAME: &str = "clean";
 pub const SPEC: CommandSpec = CommandSpec {
@@ -9,6 +15,53 @@ pub const SPEC: CommandSpec = CommandSpec {
     usage: &["kratos clean [report-path-or-root] [--apply]"],
 };
 
-pub fn run(_args: &[String]) -> KratosResult<i32> {
-    Err(KratosError::not_implemented("kratos-cli::clean"))
+#[derive(Debug, Parser)]
+#[command(disable_help_flag = true, disable_version_flag = true)]
+struct CleanArgs {
+    #[arg(allow_hyphen_values = true)]
+    input: Option<String>,
+    #[arg(long)]
+    apply: bool,
+}
+
+pub fn run(args: &[String], stdout: &mut dyn Write) -> KratosResult<i32> {
+    let args = parse_args(args)?;
+    let cwd = std::env::current_dir()?;
+    let report_path = resolve_report_input(args.input.as_deref(), &cwd);
+    let raw = fs::read_to_string(&report_path)?;
+    let report = parse_report_json(&raw)?;
+    let candidates = &report.findings.deletion_candidates;
+
+    if candidates.is_empty() {
+        write_output(stdout, "Kratos clean found no deletion candidates.")?;
+        return Ok(0);
+    }
+
+    if !args.apply {
+        let mut lines = vec!["Kratos clean dry run.".to_string(), String::new()];
+        for candidate in candidates {
+            lines.push(format!(
+                "- {} ({})",
+                candidate.file.display(),
+                candidate.reason
+            ));
+        }
+        lines.push(String::new());
+        lines.push("Re-run with --apply to delete these files.".to_string());
+        write_output(stdout, &lines.join("\n"))?;
+        return Ok(0);
+    }
+
+    let outcome = clean_from_report(&report, true)?;
+    write_output(
+        stdout,
+        &format!("Kratos clean deleted {} file(s).", outcome.deleted_files),
+    )?;
+    Ok(0)
+}
+
+fn parse_args(args: &[String]) -> KratosResult<CleanArgs> {
+    let canonical = canonicalize_clean_args(args);
+    CleanArgs::try_parse_from(std::iter::once(NAME).chain(canonical.iter().map(String::as_str)))
+        .map_err(|error| kratos_core::KratosError::Config(error.to_string().trim().to_string()))
 }

--- a/crates/kratos-cli/src/commands/mod.rs
+++ b/crates/kratos-cli/src/commands/mod.rs
@@ -2,7 +2,11 @@ pub mod clean;
 pub mod report;
 pub mod scan;
 
-use kratos_core::{KratosError, KratosResult};
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use kratos_core::{EntrypointKind, KratosError, KratosResult, ReportV2};
 
 #[derive(Clone, Copy)]
 pub struct CommandSpec {
@@ -12,63 +16,512 @@ pub struct CommandSpec {
 }
 
 pub const COMMANDS: &[CommandSpec] = &[scan::SPEC, report::SPEC, clean::SPEC];
+pub const DEFAULT_REPORT_RELATIVE_PATH: &str = ".kratos/latest-report.json";
 
-pub fn dispatch(command: &str, args: &[String]) -> KratosResult<i32> {
+pub fn dispatch(command: &str, args: &[String], stdout: &mut dyn Write) -> KratosResult<i32> {
     match command {
-        scan::NAME => dispatch_command(scan::SPEC, scan::run, args),
-        report::NAME => dispatch_command(report::SPEC, report::run, args),
-        clean::NAME => dispatch_command(clean::SPEC, clean::run, args),
+        scan::NAME => dispatch_command(scan::SPEC, scan::run, args, stdout),
+        report::NAME => dispatch_command(report::SPEC, report::run, args, stdout),
+        clean::NAME => dispatch_command(clean::SPEC, clean::run, args, stdout),
         _ => Err(KratosError::Config(format!("Unknown command: {command}"))),
     }
 }
 
+pub fn is_known_command(command: &str) -> bool {
+    COMMANDS.iter().any(|entry| entry.name == command)
+}
+
 pub fn format_root_help() -> String {
     let mut lines = vec![
-        "Kratos (Rust preview)".to_string(),
+        "Kratos".to_string(),
         "Destroy dead code ruthlessly.".to_string(),
         String::new(),
         "Usage:".to_string(),
-        "  kratos <command> [options]".to_string(),
-        String::new(),
-        "Commands:".to_string(),
     ];
 
     for command in COMMANDS {
-        lines.push(format!("  {:<7} {}", command.name, command.summary));
+        for usage in command.usage {
+            lines.push(format!("  {usage}"));
+        }
     }
 
-    lines.push(String::new());
-    lines.push("Use `kratos <command> --help` for command details.".to_string());
+    lines.extend([String::new(), "Commands:".to_string()]);
+
+    let max_name_length = COMMANDS
+        .iter()
+        .map(|command| command.name.len())
+        .max()
+        .unwrap_or(0);
+    for command in COMMANDS {
+        lines.push(format!(
+            "  {:<width$}  {}",
+            command.name,
+            command.summary,
+            width = max_name_length
+        ));
+    }
+
     lines.join("\n")
 }
 
 pub fn format_command_help(spec: CommandSpec) -> String {
     let mut lines = vec![
-        format!("kratos {}", spec.name),
+        "Kratos".to_string(),
+        "Destroy dead code ruthlessly.".to_string(),
+        String::new(),
+        format!("{} command", spec.name),
         spec.summary.to_string(),
         String::new(),
+        "Usage:".to_string(),
     ];
 
     for usage in spec.usage {
-        lines.push(format!("Usage: {usage}"));
+        lines.push(format!("  {usage}"));
     }
 
+    lines.push(String::new());
+    lines.push("Run `kratos --help` to see every command.".to_string());
     lines.join("\n")
+}
+
+pub fn format_unknown_command(command: &str) -> String {
+    format!("Unknown command: {command}\n\n{}", format_root_help())
 }
 
 fn dispatch_command(
     spec: CommandSpec,
-    runner: fn(&[String]) -> KratosResult<i32>,
+    runner: fn(&[String], &mut dyn Write) -> KratosResult<i32>,
     args: &[String],
+    stdout: &mut dyn Write,
 ) -> KratosResult<i32> {
     if should_show_help(args) {
-        println!("{}", format_command_help(spec));
+        write_output(stdout, &format_command_help(spec))?;
         return Ok(0);
     }
 
-    runner(args)
+    runner(args, stdout)
 }
 
 fn should_show_help(args: &[String]) -> bool {
     args.iter().any(|arg| arg == "--help") || (args.len() == 1 && args[0] == "-h")
+}
+
+pub fn write_output(stream: &mut dyn Write, content: &str) -> KratosResult<()> {
+    stream.write_all(content.as_bytes())?;
+    if !content.ends_with('\n') {
+        stream.write_all(b"\n")?;
+    }
+    Ok(())
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ParsedCliOptions {
+    pub positionals: Vec<String>,
+    pub flags: BTreeMap<String, ParsedFlagValue>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ParsedFlagValue {
+    Present,
+    Value(String),
+}
+
+pub fn parse_cli_options(
+    args: &[String],
+    value_flags: &[&str],
+    boolean_flags: &[&str],
+) -> ParsedCliOptions {
+    let mut parsed = ParsedCliOptions::default();
+    let mut index = 0;
+
+    while index < args.len() {
+        let token = &args[index];
+
+        if !token.starts_with("--") {
+            parsed.positionals.push(token.clone());
+            index += 1;
+            continue;
+        }
+
+        let without_prefix = &token[2..];
+        let mut segments = without_prefix.splitn(2, '=');
+        let name = segments.next().unwrap_or_default().to_string();
+        let is_boolean_flag = boolean_flags.iter().any(|flag| *flag == name);
+        let expects_value = value_flags.iter().any(|flag| *flag == name);
+
+        if let Some(inline_value) = segments.next() {
+            parsed
+                .flags
+                .insert(name, ParsedFlagValue::Value(inline_value.to_string()));
+            index += 1;
+            continue;
+        }
+
+        if is_boolean_flag {
+            parsed.flags.insert(name, ParsedFlagValue::Present);
+            index += 1;
+            continue;
+        }
+
+        let next = args.get(index + 1);
+        if expects_value {
+            if let Some(next_token) = next {
+                if !next_token.starts_with("--") {
+                    parsed
+                        .flags
+                        .insert(name, ParsedFlagValue::Value(next_token.clone()));
+                    index += 2;
+                    continue;
+                }
+            }
+
+            parsed.flags.insert(name, ParsedFlagValue::Present);
+            index += 1;
+            continue;
+        }
+
+        if let Some(next_token) = next {
+            if !next_token.starts_with("--") {
+                parsed
+                    .flags
+                    .insert(name, ParsedFlagValue::Value(next_token.clone()));
+                index += 2;
+                continue;
+            }
+        }
+
+        parsed.flags.insert(name, ParsedFlagValue::Present);
+        index += 1;
+    }
+
+    parsed
+}
+
+pub fn canonicalize_scan_args(raw_args: &[String]) -> KratosResult<Vec<String>> {
+    let parsed = parse_cli_options(raw_args, &["output"], &["json"]);
+    let mut args = Vec::new();
+
+    if let Some(root) = parsed.positionals.first() {
+        args.push(root.clone());
+    }
+
+    if let Some(value) = parsed.flags.get("output").and_then(flag_value_as_string) {
+        if !value.is_empty() {
+            args.push("--output".to_string());
+            args.push(value.to_string());
+        }
+    } else if matches!(parsed.flags.get("output"), Some(ParsedFlagValue::Present)) {
+        return Err(KratosError::Config(
+            "--output requires a path value".to_string(),
+        ));
+    }
+
+    if is_enabled_boolean_flag(parsed.flags.get("json")) {
+        args.push("--json".to_string());
+    }
+
+    Ok(args)
+}
+
+pub fn canonicalize_report_args(raw_args: &[String]) -> Vec<String> {
+    let parsed = parse_cli_options(raw_args, &["format"], &[]);
+    let mut args = Vec::new();
+
+    if let Some(input) = parsed.positionals.first() {
+        args.push(input.clone());
+    }
+
+    if let Some(value) = parsed.flags.get("format").and_then(flag_value_as_string) {
+        if !value.is_empty() {
+            args.push("--format".to_string());
+            args.push(value.to_string());
+        }
+    }
+
+    args
+}
+
+pub fn canonicalize_clean_args(raw_args: &[String]) -> Vec<String> {
+    let parsed = parse_cli_options(raw_args, &[], &["apply"]);
+    let mut args = Vec::new();
+
+    if let Some(input) = parsed.positionals.first() {
+        args.push(input.clone());
+    }
+
+    if is_enabled_boolean_flag(parsed.flags.get("apply")) {
+        args.push("--apply".to_string());
+    }
+
+    args
+}
+
+pub fn resolve_report_input(input: Option<&str>, cwd: &Path) -> PathBuf {
+    match input {
+        None => normalize_path(cwd.join(DEFAULT_REPORT_RELATIVE_PATH)),
+        Some(raw) => {
+            let absolute = resolve_input_path(cwd, raw);
+            if absolute.to_string_lossy().ends_with(".json") {
+                absolute
+            } else {
+                normalize_path(absolute.join(DEFAULT_REPORT_RELATIVE_PATH))
+            }
+        }
+    }
+}
+
+pub fn resolve_input_path(base: &Path, input: &str) -> PathBuf {
+    let path = Path::new(input);
+    if path.is_absolute() {
+        normalize_path(path.to_path_buf())
+    } else {
+        normalize_path(base.join(path))
+    }
+}
+
+pub fn format_summary_report(report: &ReportV2, report_path: &Path, title: &str) -> String {
+    let mut lines = vec![
+        title.to_string(),
+        String::new(),
+        format!("Root: {}", path_to_string(&report.root)),
+        format!("Files scanned: {}", report.summary.files_scanned),
+        format!("Entrypoints: {}", report.summary.entrypoints),
+        format!("Broken imports: {}", report.summary.broken_imports),
+        format!("Orphan files: {}", report.summary.orphan_files),
+        format!("Dead exports: {}", report.summary.dead_exports),
+        format!("Unused imports: {}", report.summary.unused_imports),
+        format!("Route entrypoints: {}", report.summary.route_entrypoints),
+        format!(
+            "Deletion candidates: {}",
+            report.summary.deletion_candidates
+        ),
+        String::new(),
+        format!("Saved report: {}", path_to_string(report_path)),
+    ];
+
+    append_preview(
+        &mut lines,
+        "Broken imports",
+        &report.findings.broken_imports,
+        |item| format!("{} -> {}", path_to_string(&item.file), item.source),
+    );
+    append_preview(
+        &mut lines,
+        "Orphan files",
+        &report.findings.orphan_files,
+        |item| path_to_string(&item.file),
+    );
+    append_preview(
+        &mut lines,
+        "Dead exports",
+        &report.findings.dead_exports,
+        |item| format!("{}#{}", path_to_string(&item.file), item.export_name),
+    );
+    append_preview(
+        &mut lines,
+        "Route entrypoints",
+        &report.findings.route_entrypoints,
+        |item| {
+            format!(
+                "{} ({})",
+                path_to_string(&item.file),
+                entrypoint_kind_to_string(&item.kind)
+            )
+        },
+    );
+
+    lines.join("\n")
+}
+
+pub fn format_markdown_report(report: &ReportV2, report_path: &Path) -> String {
+    let mut lines = vec![
+        "# Kratos Report".to_string(),
+        String::new(),
+        format!(
+            "- Generated: {}",
+            report.generated_at.as_deref().unwrap_or("undefined")
+        ),
+        format!("- Root: {}", path_to_string(&report.root)),
+        format!("- Report: {}", path_to_string(report_path)),
+        String::new(),
+        "## Summary".to_string(),
+        String::new(),
+        format!("- Files scanned: {}", report.summary.files_scanned),
+        format!("- Entrypoints: {}", report.summary.entrypoints),
+        format!("- Broken imports: {}", report.summary.broken_imports),
+        format!("- Orphan files: {}", report.summary.orphan_files),
+        format!("- Dead exports: {}", report.summary.dead_exports),
+        format!("- Unused imports: {}", report.summary.unused_imports),
+        format!("- Route entrypoints: {}", report.summary.route_entrypoints),
+        format!(
+            "- Deletion candidates: {}",
+            report.summary.deletion_candidates
+        ),
+        String::new(),
+    ];
+
+    push_markdown_section(
+        &mut lines,
+        "Broken imports",
+        &report.findings.broken_imports,
+        |item| format!("{} -> `{}`", path_to_string(&item.file), item.source),
+    );
+    push_markdown_section(
+        &mut lines,
+        "Orphan files",
+        &report.findings.orphan_files,
+        |item| format!("{} ({})", path_to_string(&item.file), item.reason),
+    );
+    push_markdown_section(
+        &mut lines,
+        "Dead exports",
+        &report.findings.dead_exports,
+        |item| format!("{} -> `{}`", path_to_string(&item.file), item.export_name),
+    );
+    push_markdown_section(
+        &mut lines,
+        "Unused imports",
+        &report.findings.unused_imports,
+        |item| {
+            format!(
+                "{} -> `{}` from `{}`",
+                path_to_string(&item.file),
+                item.local,
+                item.source
+            )
+        },
+    );
+    push_markdown_section(
+        &mut lines,
+        "Route entrypoints",
+        &report.findings.route_entrypoints,
+        |item| {
+            format!(
+                "{} ({})",
+                path_to_string(&item.file),
+                entrypoint_kind_to_string(&item.kind)
+            )
+        },
+    );
+    push_markdown_section(
+        &mut lines,
+        "Deletion candidates",
+        &report.findings.deletion_candidates,
+        |item| {
+            format!(
+                "{} ({}, confidence {})",
+                path_to_string(&item.file),
+                item.reason,
+                item.confidence
+            )
+        },
+    );
+
+    lines.join("\n")
+}
+
+fn path_to_string(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}
+
+fn entrypoint_kind_to_string(kind: &EntrypointKind) -> &'static str {
+    match kind {
+        EntrypointKind::UserEntry => "user-entry",
+        EntrypointKind::PackageEntry => "package-entry",
+        EntrypointKind::NextAppRoute => "next-app-route",
+        EntrypointKind::NextPagesRoute => "next-pages-route",
+        EntrypointKind::AppEntry => "app-entry",
+        EntrypointKind::ToolingEntry => "tooling-entry",
+        EntrypointKind::FrameworkEntry => "framework-entry",
+    }
+}
+
+fn append_preview<T>(
+    lines: &mut Vec<String>,
+    label: &str,
+    items: &[T],
+    render: impl Fn(&T) -> String,
+) {
+    if items.is_empty() {
+        return;
+    }
+
+    lines.push(String::new());
+    lines.push(format!("{label}:"));
+
+    for item in items.iter().take(5) {
+        lines.push(format!("- {}", render(item)));
+    }
+
+    if items.len() > 5 {
+        lines.push(format!("- ...and {} more", items.len() - 5));
+    }
+}
+
+fn push_markdown_section<T>(
+    lines: &mut Vec<String>,
+    title: &str,
+    items: &[T],
+    render: impl Fn(&T) -> String,
+) {
+    lines.push(format!("## {title}"));
+    lines.push(String::new());
+
+    if items.is_empty() {
+        lines.push("- None".to_string());
+        lines.push(String::new());
+        return;
+    }
+
+    for item in items {
+        lines.push(format!("- {}", render(item)));
+    }
+
+    lines.push(String::new());
+}
+
+fn normalize_path(path: PathBuf) -> PathBuf {
+    let mut normalized = PathBuf::new();
+
+    for component in path.components() {
+        match component {
+            std::path::Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            std::path::Component::RootDir => normalized.push(component.as_os_str()),
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                let can_pop = matches!(
+                    normalized.components().next_back(),
+                    Some(std::path::Component::Normal(_))
+                );
+
+                if can_pop {
+                    normalized.pop();
+                } else {
+                    normalized.push("..");
+                }
+            }
+            std::path::Component::Normal(segment) => normalized.push(segment),
+        }
+    }
+
+    if normalized.as_os_str().is_empty() {
+        PathBuf::from(".")
+    } else {
+        normalized
+    }
+}
+
+fn flag_value_as_string(value: &ParsedFlagValue) -> Option<&str> {
+    match value {
+        ParsedFlagValue::Present => None,
+        ParsedFlagValue::Value(raw) => Some(raw.as_str()),
+    }
+}
+
+fn is_enabled_boolean_flag(value: Option<&ParsedFlagValue>) -> bool {
+    match value {
+        Some(ParsedFlagValue::Present) => true,
+        Some(ParsedFlagValue::Value(raw)) => !raw.is_empty(),
+        None => false,
+    }
 }

--- a/crates/kratos-cli/src/commands/report.rs
+++ b/crates/kratos-cli/src/commands/report.rs
@@ -1,6 +1,15 @@
-use kratos_core::{KratosError, KratosResult};
+use std::fs;
+use std::io::Write;
 
-use super::CommandSpec;
+use clap::Parser;
+use kratos_core::report::parse_report_json;
+use kratos_core::{KratosError, KratosResult};
+use serde_json::Value;
+
+use super::{
+    canonicalize_report_args, format_markdown_report, format_summary_report, resolve_report_input,
+    write_output, CommandSpec,
+};
 
 pub const NAME: &str = "report";
 pub const SPEC: CommandSpec = CommandSpec {
@@ -9,6 +18,53 @@ pub const SPEC: CommandSpec = CommandSpec {
     usage: &["kratos report [report-path-or-root] [--format summary|json|md]"],
 };
 
-pub fn run(_args: &[String]) -> KratosResult<i32> {
-    Err(KratosError::not_implemented("kratos-cli::report"))
+#[derive(Debug, Parser)]
+#[command(disable_help_flag = true, disable_version_flag = true)]
+struct ReportArgs {
+    #[arg(allow_hyphen_values = true)]
+    input: Option<String>,
+    #[arg(long, allow_hyphen_values = true)]
+    format: Option<String>,
+}
+
+pub fn run(args: &[String], stdout: &mut dyn Write) -> KratosResult<i32> {
+    let args = parse_args(args)?;
+    let cwd = std::env::current_dir()?;
+    let report_path = resolve_report_input(args.input.as_deref(), &cwd);
+    let raw = fs::read_to_string(&report_path)?;
+    let raw_json: Value =
+        serde_json::from_str(&raw).map_err(|error| KratosError::Json(error.to_string()))?;
+    let format = args.format.as_deref().unwrap_or("summary");
+
+    match format {
+        "summary" => {
+            let report = parse_report_json(&raw)?;
+            write_output(
+                stdout,
+                &format_summary_report(&report, &report_path, "Kratos report."),
+            )?
+        }
+        "json" => write_output(
+            stdout,
+            &serde_json::to_string_pretty(&raw_json)
+                .map_err(|error| KratosError::Json(error.to_string()))?,
+        )?,
+        "md" => {
+            let report = parse_report_json(&raw)?;
+            write_output(stdout, &format_markdown_report(&report, &report_path))?
+        }
+        other => {
+            return Err(KratosError::Config(format!(
+                "Invalid report format: {other}"
+            )))
+        }
+    }
+
+    Ok(0)
+}
+
+fn parse_args(args: &[String]) -> KratosResult<ReportArgs> {
+    let canonical = canonicalize_report_args(args);
+    ReportArgs::try_parse_from(std::iter::once(NAME).chain(canonical.iter().map(String::as_str)))
+        .map_err(|error| KratosError::Config(error.to_string().trim().to_string()))
 }

--- a/crates/kratos-cli/src/commands/scan.rs
+++ b/crates/kratos-cli/src/commands/scan.rs
@@ -1,6 +1,16 @@
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use clap::Parser;
+use kratos_core::analyze::analyze_project;
+use kratos_core::report::serialize_report_pretty;
 use kratos_core::{KratosError, KratosResult};
 
-use super::CommandSpec;
+use super::{
+    canonicalize_scan_args, format_summary_report, resolve_input_path, write_output, CommandSpec,
+    DEFAULT_REPORT_RELATIVE_PATH,
+};
 
 pub const NAME: &str = "scan";
 pub const SPEC: CommandSpec = CommandSpec {
@@ -9,6 +19,54 @@ pub const SPEC: CommandSpec = CommandSpec {
     usage: &["kratos scan [root] [--output path] [--json]"],
 };
 
-pub fn run(_args: &[String]) -> KratosResult<i32> {
-    Err(KratosError::not_implemented("kratos-cli::scan"))
+#[derive(Debug, Parser)]
+#[command(disable_help_flag = true, disable_version_flag = true)]
+struct ScanArgs {
+    #[arg(allow_hyphen_values = true)]
+    root: Option<String>,
+    #[arg(long, allow_hyphen_values = true)]
+    output: Option<String>,
+    #[arg(long)]
+    json: bool,
+}
+
+pub fn run(args: &[String], stdout: &mut dyn Write) -> KratosResult<i32> {
+    let args = parse_args(args)?;
+    let cwd = std::env::current_dir()?;
+    let root = match args.root.as_deref() {
+        Some(raw) => resolve_input_path(&cwd, raw),
+        None => cwd,
+    };
+    let output_path = resolve_output_path(&root, args.output.as_deref());
+    let report = analyze_project(&root)?;
+    let serialized = serialize_report_pretty(&report)?;
+
+    if let Some(parent) = output_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(&output_path, format!("{serialized}\n"))?;
+
+    if args.json {
+        write_output(stdout, &serialized)?;
+        return Ok(0);
+    }
+
+    write_output(
+        stdout,
+        &format_summary_report(&report, &output_path, "Kratos scan complete."),
+    )?;
+    Ok(0)
+}
+
+fn parse_args(args: &[String]) -> KratosResult<ScanArgs> {
+    let canonical = canonicalize_scan_args(args)?;
+    ScanArgs::try_parse_from(std::iter::once(NAME).chain(canonical.iter().map(String::as_str)))
+        .map_err(|error| KratosError::Config(error.to_string().trim().to_string()))
+}
+
+fn resolve_output_path(root: &Path, output_flag: Option<&str>) -> PathBuf {
+    match output_flag {
+        Some(raw) => resolve_input_path(root, raw),
+        None => resolve_input_path(root, DEFAULT_REPORT_RELATIVE_PATH),
+    }
 }

--- a/crates/kratos-cli/src/main.rs
+++ b/crates/kratos-cli/src/main.rs
@@ -1,37 +1,54 @@
 mod commands;
 
 use std::env;
+use std::io::{self, Write};
 use std::process;
 
-use kratos_core::KratosResult;
-
 fn main() {
-    let exit_code = match run() {
+    let args = env::args().skip(1).collect::<Vec<_>>();
+    let mut stdout = io::stdout();
+    let mut stderr = io::stderr();
+    let exit_code = run_cli_with_io(&args, &mut stdout, &mut stderr);
+    process::exit(exit_code);
+}
+
+pub fn run_cli(args: &[String]) -> i32 {
+    let mut stdout = io::stdout();
+    let mut stderr = io::stderr();
+    run_cli_with_io(args, &mut stdout, &mut stderr)
+}
+
+fn run_cli_with_io(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
+    match run(args, stdout, stderr) {
         Ok(code) => code,
         Err(error) => {
-            eprintln!("Kratos (Rust preview) failed: {error}");
+            let _ = writeln!(stderr, "Kratos failed: {error}");
             1
         }
-    };
-
-    if exit_code != 0 {
-        process::exit(exit_code);
     }
 }
 
-fn run() -> KratosResult<i32> {
-    let mut args = env::args().skip(1);
-    let Some(command) = args.next() else {
-        println!("{}", commands::format_root_help());
+fn run(
+    args: &[String],
+    stdout: &mut dyn Write,
+    stderr: &mut dyn Write,
+) -> kratos_core::KratosResult<i32> {
+    let Some(command) = args.first() else {
+        commands::write_output(stdout, &commands::format_root_help())?;
         return Ok(0);
     };
-    let argv: Vec<String> = args.collect();
+
+    let argv = &args[1..];
 
     match command.as_str() {
         "--help" | "-h" | "help" => {
-            println!("{}", commands::format_root_help());
+            commands::write_output(stdout, &commands::format_root_help())?;
             Ok(0)
         }
-        other => commands::dispatch(other, &argv),
+        other if commands::is_known_command(other) => commands::dispatch(other, argv, stdout),
+        other => {
+            commands::write_output(stderr, &commands::format_unknown_command(other))?;
+            Ok(1)
+        }
     }
 }

--- a/crates/kratos-cli/tests/cli_smoke.rs
+++ b/crates/kratos-cli/tests/cli_smoke.rs
@@ -1,0 +1,410 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[test]
+fn root_help_matches_expected_shape() {
+    let output = run_cli(&[]);
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "Kratos\nDestroy dead code ruthlessly.\n\nUsage:\n  kratos scan [root] [--output path] [--json]\n  kratos report [report-path-or-root] [--format summary|json|md]\n  kratos clean [report-path-or-root] [--apply]\n\nCommands:\n  scan    Analyze a codebase and save the latest report.\n  report  Print a saved report in summary, json, or markdown form.\n  clean   Show deletion candidates or delete them with --apply.\n"
+    );
+}
+
+#[test]
+fn unknown_command_returns_help_and_exit_code_one() {
+    let output = run_cli(&["nope"]);
+
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        "Unknown command: nope\n\nKratos\nDestroy dead code ruthlessly.\n\nUsage:\n  kratos scan [root] [--output path] [--json]\n  kratos report [report-path-or-root] [--format summary|json|md]\n  kratos clean [report-path-or-root] [--apply]\n\nCommands:\n  scan    Analyze a codebase and save the latest report.\n  report  Print a saved report in summary, json, or markdown form.\n  clean   Show deletion candidates or delete them with --apply.\n"
+    );
+}
+
+#[test]
+fn scan_report_and_clean_work_for_demo_fixture() {
+    let project_root = copy_demo_app("cli-smoke");
+    let report_path = project_root.join(".kratos/latest-report.json");
+
+    let scan = run_cli(&["scan", project_root.to_str().expect("path should be utf8")]);
+    assert!(scan.status.success());
+    let scan_stdout = String::from_utf8_lossy(&scan.stdout);
+    assert!(scan_stdout.contains("Kratos scan complete."));
+    assert!(scan_stdout.contains("Files scanned: 5"));
+    assert!(scan_stdout.contains("Broken imports: 1"));
+    assert!(scan_stdout.contains("Route entrypoints: 1"));
+    assert!(scan_stdout.contains("Deletion candidates: 2"));
+    assert!(report_path.exists());
+
+    let report = run_cli(&[
+        "report",
+        report_path.to_str().expect("path should be utf8"),
+        "--format",
+        "md",
+    ]);
+    assert!(report.status.success());
+    let report_stdout = String::from_utf8_lossy(&report.stdout);
+    assert!(report_stdout.contains("# Kratos Report"));
+    assert!(report_stdout.contains("- Route entrypoints: 1"));
+    assert!(report_stdout.contains("## Broken imports"));
+    assert!(report_stdout.contains("## Route entrypoints"));
+    assert!(report_stdout.contains("DeadWidget"));
+
+    let clean = run_cli(&["clean", report_path.to_str().expect("path should be utf8")]);
+    assert!(clean.status.success());
+    let clean_stdout = String::from_utf8_lossy(&clean.stdout);
+    assert!(clean_stdout.contains("Kratos clean dry run."));
+    assert!(clean_stdout.contains("Re-run with --apply to delete these files."));
+}
+
+#[test]
+fn clean_accepts_legacy_v1_reports_through_cli() {
+    let project_root = copy_demo_app("cli-clean-v1-report");
+    let source_report = repo_root().join("fixtures/parity/demo-app/latest-report.v1.json");
+    let report_path = project_root.join("latest-report.v1.json");
+    let report_body = std::fs::read_to_string(&source_report)
+        .expect("source report should read")
+        .replace(
+            "<ROOT>",
+            project_root.to_str().expect("path should be utf8"),
+        );
+    std::fs::write(&report_path, report_body).expect("legacy report should write");
+
+    let dry_run = run_cli_in_dir(
+        &project_root,
+        &["clean", report_path.to_str().expect("path should be utf8")],
+    );
+    assert!(dry_run.status.success());
+    assert!(String::from_utf8_lossy(&dry_run.stdout).contains("Kratos clean dry run."));
+
+    let apply = run_cli_in_dir(
+        &project_root,
+        &[
+            "clean",
+            "--apply",
+            report_path.to_str().expect("path should be utf8"),
+        ],
+    );
+    assert!(apply.status.success());
+    assert!(String::from_utf8_lossy(&apply.stdout).contains("Kratos clean deleted 2 file(s)."));
+    assert!(!project_root.join("src/components/DeadWidget.tsx").exists());
+    assert!(!project_root.join("src/lib/broken.ts").exists());
+}
+
+fn run_cli(args: &[&str]) -> std::process::Output {
+    run_cli_in_dir(&repo_root(), args)
+}
+
+#[test]
+fn unknown_flags_and_surplus_positionals_match_js_baseline() {
+    let project_root = copy_demo_app("cli-js-baseline");
+    let report_path = project_root.join(".kratos/latest-report.json");
+
+    let scan = run_cli_in_dir(&project_root, &["scan", "--bogus"]);
+    assert!(scan.status.success());
+    assert!(report_path.exists());
+    assert!(
+        !project_root.join("--bogus").exists(),
+        "unknown flag should not redirect scan root"
+    );
+
+    let report = run_cli_in_dir(
+        &project_root,
+        &[
+            "report",
+            report_path.to_str().expect("path should be utf8"),
+            "extra",
+        ],
+    );
+    assert!(report.status.success());
+    assert!(String::from_utf8_lossy(&report.stdout).contains("Kratos report."));
+
+    let clean = run_cli_in_dir(&project_root, &["clean", "--bogus"]);
+    assert!(clean.status.success());
+    assert!(String::from_utf8_lossy(&clean.stdout).contains("Kratos clean dry run."));
+}
+
+#[test]
+fn invalid_report_format_is_an_error_per_plan_contract() {
+    let project_root = copy_demo_app("cli-invalid-format");
+    let report_path = project_root.join(".kratos/latest-report.json");
+
+    let scan = run_cli_in_dir(&project_root, &["scan"]);
+    assert!(scan.status.success());
+    assert!(report_path.exists());
+
+    let report = run_cli_in_dir(
+        &project_root,
+        &[
+            "report",
+            report_path.to_str().expect("path should be utf8"),
+            "--format",
+            "bogus",
+        ],
+    );
+    assert_eq!(report.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&report.stderr)
+        .contains("Kratos failed: Config error: Invalid report format: bogus"));
+
+    let hyphenated_report = run_cli_in_dir(
+        &project_root,
+        &[
+            "report",
+            report_path.to_str().expect("path should be utf8"),
+            "--format",
+            "-foo",
+        ],
+    );
+    assert_eq!(hyphenated_report.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&hyphenated_report.stderr)
+        .contains("Kratos failed: Config error: Invalid report format: -foo"));
+}
+
+#[test]
+fn report_json_pretty_prints_the_parsed_input_shape() {
+    let project_root = copy_demo_app("cli-json-report");
+    let source_report = repo_root().join("fixtures/parity/demo-app/latest-report.v1.json");
+    let minified_report = project_root.join("latest-report.v1.min.json");
+    let source_value: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(&source_report).expect("source report should read"),
+    )
+    .expect("source report should parse");
+    std::fs::write(
+        &minified_report,
+        serde_json::to_string(&source_value).expect("minified report should serialize"),
+    )
+    .expect("minified report should write");
+
+    let output = run_cli_in_dir(
+        &project_root,
+        &[
+            "report",
+            minified_report.to_str().expect("path should be utf8"),
+            "--format",
+            "json",
+        ],
+    );
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.starts_with("{\n"));
+    assert!(stdout.contains("\n  \"version\": 1,"));
+    assert!(stdout.contains("\n  \"summary\": {"));
+}
+
+#[test]
+fn report_json_accepts_arbitrary_json_and_empty_or_missing_format_falls_back_to_summary() {
+    let project_root = copy_demo_app("cli-report-json-any");
+    let arbitrary_json = project_root.join("arbitrary.json");
+    std::fs::write(&arbitrary_json, "{\"hello\":\"world\",\"ok\":true}\n")
+        .expect("arbitrary json should write");
+
+    let json_output = run_cli_in_dir(
+        &project_root,
+        &[
+            "report",
+            arbitrary_json.to_str().expect("path should be utf8"),
+            "--format",
+            "json",
+        ],
+    );
+    assert!(json_output.status.success());
+    let json_stdout = String::from_utf8_lossy(&json_output.stdout);
+    assert!(json_stdout.starts_with("{\n"));
+    assert!(json_stdout.contains("\n  \"hello\": \"world\","));
+
+    let report_path = project_root.join(".kratos/latest-report.json");
+    let scan = run_cli_in_dir(&project_root, &["scan"]);
+    assert!(scan.status.success());
+    assert!(report_path.exists());
+
+    let bare_format = run_cli_in_dir(
+        &project_root,
+        &[
+            "report",
+            report_path.to_str().expect("path should be utf8"),
+            "--format",
+        ],
+    );
+    assert!(bare_format.status.success());
+    assert!(String::from_utf8_lossy(&bare_format.stdout).contains("Kratos report."));
+
+    let empty_inline_format = run_cli_in_dir(
+        &project_root,
+        &[
+            "report",
+            report_path.to_str().expect("path should be utf8"),
+            "--format=",
+        ],
+    );
+    assert!(empty_inline_format.status.success());
+    assert!(String::from_utf8_lossy(&empty_inline_format.stdout).contains("Kratos report."));
+}
+
+#[test]
+fn report_markdown_uses_undefined_for_missing_generated_at() {
+    let project_root = copy_demo_app("cli-report-md-missing-generated");
+    let report_path = project_root.join("report-no-generated.json");
+    std::fs::write(
+        &report_path,
+        "{\"schemaVersion\":2,\"project\":{\"root\":\"/tmp/demo\",\"configPath\":null},\"summary\":{\"filesScanned\":0,\"entrypoints\":0,\"brokenImports\":0,\"orphanFiles\":0,\"deadExports\":0,\"unusedImports\":0,\"routeEntrypoints\":0,\"deletionCandidates\":0},\"findings\":{\"brokenImports\":[],\"orphanFiles\":[],\"deadExports\":[],\"unusedImports\":[],\"routeEntrypoints\":[],\"deletionCandidates\":[]},\"graph\":{\"modules\":[]}}\n",
+    )
+    .expect("report should write");
+
+    let output = run_cli_in_dir(
+        &project_root,
+        &[
+            "report",
+            report_path.to_str().expect("path should be utf8"),
+            "--format",
+            "md",
+        ],
+    );
+
+    assert!(output.status.success());
+    assert!(String::from_utf8_lossy(&output.stdout).contains("- Generated: undefined"));
+}
+
+#[test]
+fn scan_output_empty_string_defaults_and_missing_value_errors() {
+    let project_root = copy_demo_app("cli-output-edge");
+    let report_path = project_root.join(".kratos/latest-report.json");
+
+    let empty_output = run_cli_in_dir(&project_root, &["scan", "--output="]);
+    assert!(empty_output.status.success());
+    assert!(report_path.exists());
+
+    let missing_output = run_cli_in_dir(&project_root, &["scan", "--output", "--json"]);
+    assert_eq!(missing_output.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&missing_output.stderr)
+        .contains("Kratos failed: Config error: --output requires a path value"));
+    assert!(
+        !project_root.join("--json").exists(),
+        "missing output value should not create a stray report file"
+    );
+}
+
+#[test]
+fn boolean_flags_do_not_consume_following_positionals() {
+    let project_root = copy_demo_app("cli-boolean-positional");
+    let report_path = project_root.join(".kratos/latest-report.json");
+
+    let scan = run_cli(&[
+        "scan",
+        "--json",
+        project_root.to_str().expect("path should be utf8"),
+    ]);
+    assert!(scan.status.success());
+    assert!(String::from_utf8_lossy(&scan.stdout)
+        .contains(&format!("\"root\": \"{}\"", project_root.display())));
+
+    let prepare_report = run_cli_in_dir(&project_root, &["scan"]);
+    assert!(prepare_report.status.success());
+    assert!(report_path.exists());
+
+    let clean = run_cli_in_dir(
+        &project_root,
+        &[
+            "clean",
+            "--apply",
+            report_path.to_str().expect("path should be utf8"),
+        ],
+    );
+    assert!(clean.status.success());
+    assert!(String::from_utf8_lossy(&clean.stdout).contains("Kratos clean deleted 2 file(s)."));
+    assert!(!project_root.join("src/components/DeadWidget.tsx").exists());
+    assert!(!project_root.join("src/lib/broken.ts").exists());
+}
+
+#[test]
+fn empty_inline_boolean_flags_stay_falsey_like_js() {
+    let project_root = copy_demo_app("cli-inline-empty-bools");
+    let report_path = project_root.join(".kratos/latest-report.json");
+
+    let scan = run_cli_in_dir(
+        &project_root,
+        &[
+            "scan",
+            "--json=",
+            project_root.to_str().expect("path should be utf8"),
+        ],
+    );
+    assert!(scan.status.success());
+    let scan_stdout = String::from_utf8_lossy(&scan.stdout);
+    assert!(scan_stdout.contains("Kratos scan complete."));
+    assert!(!scan_stdout.trim_start().starts_with('{'));
+
+    let prepare_report = run_cli_in_dir(&project_root, &["scan"]);
+    assert!(prepare_report.status.success());
+    assert!(report_path.exists());
+
+    let clean = run_cli_in_dir(
+        &project_root,
+        &[
+            "clean",
+            "--apply=",
+            report_path.to_str().expect("path should be utf8"),
+        ],
+    );
+    assert!(clean.status.success());
+    let clean_stdout = String::from_utf8_lossy(&clean.stdout);
+    assert!(clean_stdout.contains("Kratos clean dry run."));
+    assert!(project_root.join("src/components/DeadWidget.tsx").exists());
+    assert!(project_root.join("src/lib/broken.ts").exists());
+}
+
+fn run_cli_in_dir(cwd: &Path, args: &[&str]) -> std::process::Output {
+    Command::new(cli_binary())
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .expect("cli command should run")
+}
+
+fn cli_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_kratos-cli"))
+}
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("workspace root should exist")
+        .to_path_buf()
+}
+
+fn copy_demo_app(label: &str) -> PathBuf {
+    let destination = temp_dir(label).join("demo-app");
+    copy_directory(&repo_root().join("fixtures/demo-app"), &destination);
+    destination
+}
+
+fn copy_directory(source: &Path, destination: &Path) {
+    std::fs::create_dir_all(destination).expect("destination directory should exist");
+
+    for entry in std::fs::read_dir(source).expect("source directory should be readable") {
+        let entry = entry.expect("directory entry should load");
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        let file_type = entry.file_type().expect("file type should load");
+
+        if file_type.is_dir() {
+            copy_directory(&source_path, &destination_path);
+        } else if file_type.is_file() {
+            std::fs::copy(&source_path, &destination_path).expect("file should copy");
+        }
+    }
+}
+
+fn temp_dir(label: &str) -> PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be valid")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!("kratos-cli-{label}-{unique}"));
+    std::fs::create_dir_all(&path).expect("temp dir should be created");
+    path
+}


### PR DESCRIPTION
## 배경
- Rust migration Phase 4의 `PR 4A`로 `kratos-core` 위에 실제 Rust CLI를 올립니다.
- 기존 JS CLI의 공개 명령 UX를 최대한 유지하면서 `scan / report / clean` 명령을 Rust에서 실행 가능하게 만드는 것이 목표입니다.

## 변경 사항
- `clap` 기반 Rust CLI entry를 추가하고 root help / unknown command / command help 흐름을 정리했습니다.
- `scan`, `report`, `clean` 명령이 `kratos-core`를 직접 호출하도록 구현했습니다.
- JS baseline과 어긋나던 인자 파싱 edge case를 보정했습니다.
  - unknown `--flag` / surplus positional 처리
  - `scan --output=` 및 bare `--output`
  - `scan --json <root>`, `clean --apply <report>`처럼 boolean flag 뒤 positional 유지
- `crates/kratos-cli/tests/cli_smoke.rs`에 CLI smoke / 회귀 케이스를 추가했습니다.

## 검증
- `cargo test --workspace`
- `npm test`
- `cargo run -q -p kratos-cli -- scan --json ./fixtures/demo-app`
- review loop 중 추가 확인
  - `cargo run -q -p kratos-cli -- scan --bogus`
  - `cargo run -q -p kratos-cli -- report fixtures/parity/demo-app/latest-report.v1.json extra`
  - `cargo run -q -p kratos-cli -- scan --output=`
  - `cargo run -q -p kratos-cli -- scan --output --json`

## 브랜치 / 워크트리
- 대상 브랜치: `codex/rust-cli-pr4a`
- 현재 워크트리: `/Users/pjw/workspace/kratos`
- 포함된 source branch/worktree: 없음

## 이슈 연결
- 없음
