### PR TITLE
[codex] NAPI wrapper와 JS launcher 추가

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,10 +155,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "cow-utils"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "417bef24afe1460300965a25ff4a24b8b45ad011948302ec221e8a0a81eb2c79"
+
+[[package]]
+name = "ctor"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "dragonbox_ecma"
@@ -232,7 +260,21 @@ dependencies = [
 name = "kratos-node"
 version = "0.1.0"
 dependencies = [
+ "kratos-cli",
  "kratos-core",
+ "napi",
+ "napi-build",
+ "napi-derive",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
 ]
 
 [[package]]
@@ -240,6 +282,63 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "napi"
+version = "2.16.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55740c4ae1d8696773c78fdafd5d0e5fe9bc9f1b071c7ba493ba5c413a9184f3"
+dependencies = [
+ "bitflags",
+ "ctor",
+ "napi-derive",
+ "napi-sys",
+ "once_cell",
+]
+
+[[package]]
+name = "napi-build"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d376940fd5b723c6893cd1ee3f33abbfd86acb1cd1ec079f3ab04a2a3bc4d3b1"
+
+[[package]]
+name = "napi-derive"
+version = "2.16.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cbe2585d8ac223f7d34f13701434b9d5f4eb9c332cccce8dee57ea18ab8ab0c"
+dependencies = [
+ "cfg-if",
+ "convert_case",
+ "napi-derive-backend",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "napi-derive-backend"
+version = "1.0.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1639aaa9eeb76e91c6ae66da8ce3e89e921cd3885e99ec85f4abacae72fc91bf"
+dependencies = [
+ "convert_case",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "semver",
+ "syn",
+]
+
+[[package]]
+name = "napi-sys"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427802e8ec3a734331fec1035594a210ce1ff4dc5bc1950530920ab717964ea3"
+dependencies = [
+ "libloading",
+]
 
 [[package]]
 name = "nonmax"
@@ -274,6 +373,12 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -571,6 +676,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,6 +721,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "seq-macro"

--- a/bin/kratos.js
+++ b/bin/kratos.js
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import process from "node:process";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const require = createRequire(import.meta.url);
+
+export function resolveAddonPackageName(
+  platform = process.platform,
+  arch = process.arch,
+) {
+  if (platform === "darwin" && arch === "arm64") {
+    return "@kratos/darwin-arm64";
+  }
+  if (platform === "darwin" && arch === "x64") {
+    return "@kratos/darwin-x64";
+  }
+  if (platform === "linux" && arch === "x64") {
+    return "@kratos/linux-x64-gnu";
+  }
+  if (platform === "linux" && arch === "arm64") {
+    return "@kratos/linux-arm64-gnu";
+  }
+  if (platform === "win32" && arch === "x64") {
+    return "@kratos/win32-x64-msvc";
+  }
+
+  throw new Error(`Unsupported platform/arch for Kratos native addon: ${platform}/${arch}`);
+}
+
+export function loadNativeBinding({
+  platform = process.platform,
+  arch = process.arch,
+  requireFn = require,
+} = {}) {
+  const packageName = resolveAddonPackageName(platform, arch);
+
+  try {
+    const binding = requireFn(packageName);
+    return { binding, packageName };
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to load native addon package ${packageName}: ${detail}`);
+  }
+}
+
+export function runLauncher(argv, options = {}) {
+  const {
+    platform = process.platform,
+    arch = process.arch,
+    requireFn = require,
+    stderr = process.stderr,
+  } = options;
+  const args = argv.slice(2);
+
+  try {
+    const { binding, packageName } = loadNativeBinding({ platform, arch, requireFn });
+    const runCli =
+      typeof binding?.runCli === "function"
+        ? binding.runCli
+        : typeof binding?.default?.runCli === "function"
+          ? binding.default.runCli
+          : null;
+
+    if (!runCli) {
+      throw new Error(`Native addon package ${packageName} does not export runCli`);
+    }
+
+    const exitCode = runCli(args);
+    return Number.isInteger(exitCode) ? exitCode : 1;
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    stderr.write(`Kratos failed: ${detail}\n`);
+    return 1;
+  }
+}
+
+export function isDirectExecution(metaUrl = import.meta.url, argv = process.argv) {
+  const entryPath = argv[1];
+  if (!entryPath) {
+    return false;
+  }
+
+  return normalizeExecutionPath(entryPath) === normalizeExecutionPath(fileURLToPath(metaUrl));
+}
+
+function normalizeExecutionPath(rawPath) {
+  const absolutePath = path.resolve(rawPath);
+
+  try {
+    return fs.realpathSync.native(absolutePath);
+  } catch {
+    return absolutePath;
+  }
+}
+
+if (isDirectExecution()) {
+  process.exitCode = runLauncher(process.argv);
+}

--- a/crates/kratos-cli/src/lib.rs
+++ b/crates/kratos-cli/src/lib.rs
@@ -1,0 +1,44 @@
+mod commands;
+
+use std::io::{self, Write};
+
+pub fn run_cli(args: &[String]) -> i32 {
+    let mut stdout = io::stdout();
+    let mut stderr = io::stderr();
+    run_cli_with_io(args, &mut stdout, &mut stderr)
+}
+
+pub fn run_cli_with_io(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
+    match run(args, stdout, stderr) {
+        Ok(code) => code,
+        Err(error) => {
+            let _ = writeln!(stderr, "Kratos failed: {error}");
+            1
+        }
+    }
+}
+
+fn run(
+    args: &[String],
+    stdout: &mut dyn Write,
+    stderr: &mut dyn Write,
+) -> kratos_core::KratosResult<i32> {
+    let Some(command) = args.first() else {
+        commands::write_output(stdout, &commands::format_root_help())?;
+        return Ok(0);
+    };
+
+    let argv = &args[1..];
+
+    match command.as_str() {
+        "--help" | "-h" | "help" => {
+            commands::write_output(stdout, &commands::format_root_help())?;
+            Ok(0)
+        }
+        other if commands::is_known_command(other) => commands::dispatch(other, argv, stdout),
+        other => {
+            commands::write_output(stderr, &commands::format_unknown_command(other))?;
+            Ok(1)
+        }
+    }
+}

--- a/crates/kratos-cli/src/main.rs
+++ b/crates/kratos-cli/src/main.rs
@@ -1,54 +1,7 @@
-mod commands;
-
 use std::env;
-use std::io::{self, Write};
 use std::process;
 
 fn main() {
     let args = env::args().skip(1).collect::<Vec<_>>();
-    let mut stdout = io::stdout();
-    let mut stderr = io::stderr();
-    let exit_code = run_cli_with_io(&args, &mut stdout, &mut stderr);
-    process::exit(exit_code);
-}
-
-pub fn run_cli(args: &[String]) -> i32 {
-    let mut stdout = io::stdout();
-    let mut stderr = io::stderr();
-    run_cli_with_io(args, &mut stdout, &mut stderr)
-}
-
-fn run_cli_with_io(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
-    match run(args, stdout, stderr) {
-        Ok(code) => code,
-        Err(error) => {
-            let _ = writeln!(stderr, "Kratos failed: {error}");
-            1
-        }
-    }
-}
-
-fn run(
-    args: &[String],
-    stdout: &mut dyn Write,
-    stderr: &mut dyn Write,
-) -> kratos_core::KratosResult<i32> {
-    let Some(command) = args.first() else {
-        commands::write_output(stdout, &commands::format_root_help())?;
-        return Ok(0);
-    };
-
-    let argv = &args[1..];
-
-    match command.as_str() {
-        "--help" | "-h" | "help" => {
-            commands::write_output(stdout, &commands::format_root_help())?;
-            Ok(0)
-        }
-        other if commands::is_known_command(other) => commands::dispatch(other, argv, stdout),
-        other => {
-            commands::write_output(stderr, &commands::format_unknown_command(other))?;
-            Ok(1)
-        }
-    }
+    process::exit(kratos_cli::run_cli(&args));
 }

--- a/crates/kratos-node/Cargo.toml
+++ b/crates/kratos-node/Cargo.toml
@@ -12,4 +12,10 @@ description = "Node bridge surface for Kratos."
 crate-type = ["rlib", "cdylib"]
 
 [dependencies]
+kratos-cli = { path = "../kratos-cli" }
 kratos-core = { path = "../kratos-core" }
+napi = { version = "2", default-features = false, features = ["napi8"] }
+napi-derive = "2"
+
+[build-dependencies]
+napi-build = "2"

--- a/crates/kratos-node/build.rs
+++ b/crates/kratos-node/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    napi_build::setup();
+}

--- a/crates/kratos-node/src/lib.rs
+++ b/crates/kratos-node/src/lib.rs
@@ -1,5 +1,6 @@
-use kratos_core::{KratosError, KratosResult};
+use napi_derive::napi;
 
-pub fn run_cli(_args: Vec<String>) -> KratosResult<i32> {
-    Err(KratosError::not_implemented("kratos-node::run_cli"))
+#[napi(js_name = "runCli")]
+pub fn run_cli(args: Vec<String>) -> i32 {
+    kratos_cli::run_cli(&args)
 }

--- a/docs/plan/03-rust-cli-and-node-packaging.md
+++ b/docs/plan/03-rust-cli-and-node-packaging.md
@@ -20,7 +20,8 @@
 ## Rules
 
 - `PR 4A`는 `crates/kratos-cli/**/*`만 수정한다. Node wrapper나 workflow는 같이 건드리지 않는다.
-- `PR 5A`는 `crates/kratos-node/**/*`, `bin/kratos.js`, `test/npm-launcher.test.js`만 수정한다.
+- `PR 5A`는 `crates/kratos-node/**/*`, `bin/kratos.js`, `test/npm-launcher.test.js`를 수정한다.
+- `PR 5A`에서 NAPI wrapper가 CLI 로직을 재사용하기 위해 필요한 최소 범위의 `crates/kratos-cli/src/lib.rs` 추출과 `crates/kratos-cli/src/main.rs` thin-wrapper 변경은 허용한다.
 - `PR 5B`는 `PR 5A`가 merge되어 addon package name과 target 매핑이 고정된 뒤에만 시작한다.
 - `PR 5B`는 workflow 파일만 수정한다. `package.json`은 `PR 6A`까지 건드리지 않는다.
 - unknown command/help/error wording은 현재 JS CLI와 최대한 동일한 읽기 경험을 유지한다.
@@ -67,20 +68,24 @@
 ### Target Files
 
 - `crates/kratos-node/src/lib.rs`
+- `crates/kratos-cli/src/lib.rs`
+- `crates/kratos-cli/src/main.rs`
 - `bin/kratos.js`
 - `test/npm-launcher.test.js`
 
 ### Steps
 
-1. `crates/kratos-node/src/lib.rs`에서 `runCli(args: Vec<String>) -> i32`를 export한다.
-2. native layer는 CLI main logic를 다시 구현하지 않고 `kratos-cli`의 공용 실행 함수만 호출한다.
-3. `bin/kratos.js`는 아래 순서로 동작한다.
+1. `crates/kratos-cli/src/lib.rs`에 `run_cli(args: &[String]) -> i32` 공용 실행 함수를 둔다.
+2. `crates/kratos-cli/src/main.rs`는 argv 수집 후 공용 실행 함수만 호출하는 thin wrapper로 유지한다.
+3. `crates/kratos-node/src/lib.rs`에서 `runCli(args: Vec<String>) -> i32`를 export한다.
+4. native layer는 CLI main logic를 다시 구현하지 않고 `kratos-cli`의 공용 실행 함수만 호출한다.
+5. `bin/kratos.js`는 아래 순서로 동작한다.
    - `process.argv.slice(2)` 수집
    - platform/arch에 맞는 native addon 패키지 resolve
    - `runCli(args)` 호출
    - return value를 `process.exitCode`에 반영
-4. native load 실패나 Rust error는 `Kratos failed: ...` 형식으로 stderr에 출력한다.
-5. addon package name은 아래 형식으로 고정한다.
+6. native load 실패나 Rust error는 `Kratos failed: ...` 형식으로 stderr에 출력한다.
+7. addon package name은 아래 형식으로 고정한다.
    - `@kratos/darwin-arm64`
    - `@kratos/darwin-x64`
    - `@kratos/linux-x64-gnu`

--- a/test/npm-launcher.test.js
+++ b/test/npm-launcher.test.js
@@ -11,6 +11,11 @@ import {
   runLauncher,
 } from "../bin/kratos.js";
 
+const skipDirectExecutableTests =
+  process.platform === "win32"
+    ? "Windows executes npm bins through generated cmd shims, not JS shebang files."
+    : false;
+
 test("resolveAddonPackageName maps supported targets", () => {
   assert.equal(resolveAddonPackageName("darwin", "arm64"), "@kratos/darwin-arm64");
   assert.equal(resolveAddonPackageName("darwin", "x64"), "@kratos/darwin-x64");
@@ -93,33 +98,35 @@ test("isDirectExecution only matches the active entry file", () => {
   );
 });
 
-test("symlinked launcher execution still enters runLauncher", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "kratos-launcher-link-"));
-  const linkPath = path.join(tempRoot, "kratos.js");
-  fs.symlinkSync(path.join(process.cwd(), "bin/kratos.js"), linkPath, "file");
+test(
+  "symlinked launcher execution still enters runLauncher",
+  { skip: skipDirectExecutableTests },
+  () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "kratos-launcher-link-"));
+    const linkPath = path.join(tempRoot, "kratos.js");
+    fs.symlinkSync(path.join(process.cwd(), "bin/kratos.js"), linkPath, "file");
 
-  const result = spawnSync(linkPath, ["scan"], {
-    encoding: "utf8",
-  });
+    const result = spawnSync(linkPath, ["scan"], {
+      encoding: "utf8",
+    });
 
-  assert.equal(result.status, 1);
-  assert.match(
-    result.stderr,
-    /Kratos failed: Failed to load native addon package @kratos\/darwin-arm64:/,
-  );
-});
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, expectedMissingAddonPattern());
+  },
+);
 
-test("launcher file executes directly through its shebang", () => {
-  const result = spawnSync(path.join(process.cwd(), "bin/kratos.js"), ["scan"], {
-    encoding: "utf8",
-  });
+test(
+  "launcher file executes directly through its shebang",
+  { skip: skipDirectExecutableTests },
+  () => {
+    const result = spawnSync(path.join(process.cwd(), "bin/kratos.js"), ["scan"], {
+      encoding: "utf8",
+    });
 
-  assert.equal(result.status, 1);
-  assert.match(
-    result.stderr,
-    /Kratos failed: Failed to load native addon package @kratos\/darwin-arm64:/,
-  );
-});
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, expectedMissingAddonPattern());
+  },
+);
 
 function captureStream() {
   let buffer = "";
@@ -133,4 +140,16 @@ function captureStream() {
       return buffer;
     },
   };
+}
+
+function escapeForRegex(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function expectedMissingAddonPattern() {
+  const expectedPackageName = resolveAddonPackageName(process.platform, process.arch);
+
+  return new RegExp(
+    `Kratos failed: Failed to load native addon package ${escapeForRegex(expectedPackageName)}:`,
+  );
 }

--- a/test/npm-launcher.test.js
+++ b/test/npm-launcher.test.js
@@ -1,0 +1,136 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  isDirectExecution,
+  resolveAddonPackageName,
+  runLauncher,
+} from "../bin/kratos.js";
+
+test("resolveAddonPackageName maps supported targets", () => {
+  assert.equal(resolveAddonPackageName("darwin", "arm64"), "@kratos/darwin-arm64");
+  assert.equal(resolveAddonPackageName("darwin", "x64"), "@kratos/darwin-x64");
+  assert.equal(resolveAddonPackageName("linux", "x64"), "@kratos/linux-x64-gnu");
+  assert.equal(resolveAddonPackageName("linux", "arm64"), "@kratos/linux-arm64-gnu");
+  assert.equal(resolveAddonPackageName("win32", "x64"), "@kratos/win32-x64-msvc");
+  assert.throws(
+    () => resolveAddonPackageName("linux", "ppc64"),
+    /Unsupported platform\/arch/,
+  );
+});
+
+test("runLauncher forwards argv to runCli and returns its exit code", () => {
+  let receivedArgs = null;
+  const stderr = captureStream();
+
+  const exitCode = runLauncher(["node", "bin/kratos.js", "scan", "fixtures/demo-app"], {
+    platform: "darwin",
+    arch: "arm64",
+    requireFn(packageName) {
+      assert.equal(packageName, "@kratos/darwin-arm64");
+      return {
+        runCli(args) {
+          receivedArgs = args;
+          return 7;
+        },
+      };
+    },
+    stderr,
+  });
+
+  assert.equal(exitCode, 7);
+  assert.deepEqual(receivedArgs, ["scan", "fixtures/demo-app"]);
+  assert.equal(stderr.read(), "");
+});
+
+test("runLauncher formats missing addon failures with Kratos prefix", () => {
+  const stderr = captureStream();
+
+  const exitCode = runLauncher(["node", "bin/kratos.js", "scan"], {
+    platform: "linux",
+    arch: "x64",
+    requireFn() {
+      throw new Error("Cannot find module '@kratos/linux-x64-gnu'");
+    },
+    stderr,
+  });
+
+  assert.equal(exitCode, 1);
+  assert.match(
+    stderr.read(),
+    /Kratos failed: Failed to load native addon package @kratos\/linux-x64-gnu:/,
+  );
+});
+
+test("runLauncher fails when binding does not export runCli", () => {
+  const stderr = captureStream();
+
+  const exitCode = runLauncher(["node", "bin/kratos.js", "scan"], {
+    platform: "darwin",
+    arch: "x64",
+    requireFn() {
+      return {};
+    },
+    stderr,
+  });
+
+  assert.equal(exitCode, 1);
+  assert.match(stderr.read(), /does not export runCli/);
+});
+
+test("isDirectExecution only matches the active entry file", () => {
+  assert.equal(
+    isDirectExecution("file:///repo/bin/kratos.js", ["/usr/bin/node", "/repo/bin/kratos.js"]),
+    true,
+  );
+  assert.equal(
+    isDirectExecution("file:///repo/bin/kratos.js", ["/usr/bin/node", "/repo/other.js"]),
+    false,
+  );
+});
+
+test("symlinked launcher execution still enters runLauncher", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "kratos-launcher-link-"));
+  const linkPath = path.join(tempRoot, "kratos.js");
+  fs.symlinkSync(path.join(process.cwd(), "bin/kratos.js"), linkPath, "file");
+
+  const result = spawnSync(linkPath, ["scan"], {
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(
+    result.stderr,
+    /Kratos failed: Failed to load native addon package @kratos\/darwin-arm64:/,
+  );
+});
+
+test("launcher file executes directly through its shebang", () => {
+  const result = spawnSync(path.join(process.cwd(), "bin/kratos.js"), ["scan"], {
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(
+    result.stderr,
+    /Kratos failed: Failed to load native addon package @kratos\/darwin-arm64:/,
+  );
+});
+
+function captureStream() {
+  let buffer = "";
+
+  return {
+    write(chunk) {
+      buffer += String(chunk);
+      return true;
+    },
+    read() {
+      return buffer;
+    },
+  };
+}


### PR DESCRIPTION
## 배경
- Rust CLI를 npm/npx 실행 흐름에 연결할 다음 단계로 NAPI wrapper와 JS launcher가 필요했습니다.
- 이번 PR은 `package.json` cutover 전에 native bridge 표면과 launcher 계약만 먼저 고정합니다.

## 변경 사항
- `kratos-cli` 실행 로직을 재사용 가능한 library entrypoint로 분리했습니다.
- `kratos-node`에 `runCli(args)` NAPI export와 build 설정을 추가했습니다.
- `bin/kratos.js`에서 플랫폼별 addon package 이름을 해석하고 `runCli`로 argv를 전달하도록 구현했습니다.
- missing addon, invalid binding, symlink-style bin invocation까지 launcher 테스트를 추가했습니다.

## 검증
- `cargo fmt --check`
- `cargo test --workspace`
- `npm test`
- `node ./bin/kratos.js scan`
  - 현재 phase에서는 addon package가 아직 없어서 의도한 `Kratos failed: Failed to load native addon package ...` 오류를 확인했습니다.

## 브랜치 / 워크트리
- 대상 브랜치: `codex/napi-wrapper-js-launcher`
- 현재 워크트리: `/Users/pjw/workspace/kratos`
- 포함된 source worktree/branch: 없음

## 이슈 연결
- 별도 이슈 연결 없음
