### PR TITLE
ci: addon npm publish lane과 검증 gate 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,30 +86,40 @@ jobs:
           - runner: macos-14
             platform: darwin
             arch: arm64
+            node_os: darwin
+            node_cpu: arm64
             target: aarch64-apple-darwin
             os_family: macos
             built_library: target/aarch64-apple-darwin/release/libkratos_node.dylib
           - runner: macos-15-intel
             platform: darwin
             arch: x64
+            node_os: darwin
+            node_cpu: x64
             target: x86_64-apple-darwin
             os_family: macos
             built_library: target/x86_64-apple-darwin/release/libkratos_node.dylib
           - runner: ubuntu-latest
             platform: linux
             arch: x64
+            node_os: linux
+            node_cpu: x64
             target: x86_64-unknown-linux-gnu
             os_family: linux
             built_library: target/x86_64-unknown-linux-gnu/release/libkratos_node.so
           - runner: ubuntu-24.04-arm
             platform: linux
             arch: arm64
+            node_os: linux
+            node_cpu: arm64
             target: aarch64-unknown-linux-gnu
             os_family: linux
             built_library: target/aarch64-unknown-linux-gnu/release/libkratos_node.so
           - runner: windows-latest
             platform: win32
             arch: x64
+            node_os: win32
+            node_cpu: x64
             target: x86_64-pc-windows-msvc
             os_family: windows
             built_library: target/x86_64-pc-windows-msvc/release/kratos_node.dll
@@ -136,11 +146,13 @@ jobs:
           package_name=$(node --input-type=module -e "import { resolveAddonPackageName } from './bin/kratos.js'; console.log(resolveAddonPackageName('${{ matrix.platform }}', '${{ matrix.arch }}'));")
           package_slug=${package_name#@kratos/}
           archive_name="${package_slug}-ci-${{ matrix.target }}.tar.gz"
+          package_version=$(node -p "require('./package.json').version")
 
           {
             echo "package_name=$package_name"
             echo "package_slug=$package_slug"
             echo "archive_name=$archive_name"
+            echo "package_version=$package_version"
           } >> "$GITHUB_OUTPUT"
 
       - name: Build native addon library
@@ -149,7 +161,7 @@ jobs:
       - name: Package native addon archive
         shell: bash
         run: |
-          staging_dir="dist/${{ steps.addon.outputs.package_slug }}"
+          staging_dir="dist/native/${{ steps.addon.outputs.package_slug }}"
           mkdir -p "$staging_dir"
 
           cp "${{ matrix.built_library }}" "$staging_dir/kratos.node"
@@ -171,3 +183,70 @@ jobs:
           test "$(cat "$extract_dir/RELEASE_TAG")" = "ci-smoke"
 
           node -e "const addon=require(process.argv[1]); const runCli=typeof addon.runCli==='function'?addon.runCli:typeof addon.default?.runCli==='function'?addon.default.runCli:null; if (!runCli) throw new Error('runCli missing');" "$extract_dir/kratos.node"
+
+      - name: Stage addon npm package
+        shell: bash
+        env:
+          PACKAGE_DIR: dist/npm/${{ steps.addon.outputs.package_slug }}
+          PACKAGE_NAME: ${{ steps.addon.outputs.package_name }}
+          PACKAGE_VERSION: ${{ steps.addon.outputs.package_version }}
+          PACKAGE_OS: ${{ matrix.node_os }}
+          PACKAGE_CPU: ${{ matrix.node_cpu }}
+        run: |
+          mkdir -p "$PACKAGE_DIR"
+          cp "${{ matrix.built_library }}" "$PACKAGE_DIR/kratos.node"
+
+          node --input-type=module <<'NODE'
+          import fs from "node:fs";
+
+          const packageJsonPath = `${process.env.PACKAGE_DIR}/package.json`;
+          const pkg = {
+            name: process.env.PACKAGE_NAME,
+            version: process.env.PACKAGE_VERSION,
+            description: `Prebuilt native addon for ${process.env.PACKAGE_NAME}.`,
+            license: "MIT",
+            homepage: "https://github.com/JeremyDev87/kratos#readme",
+            repository: {
+              type: "git",
+              url: "git+https://github.com/JeremyDev87/kratos.git",
+            },
+            main: "./kratos.node",
+            files: ["kratos.node"],
+            os: [process.env.PACKAGE_OS],
+            cpu: [process.env.PACKAGE_CPU],
+            engines: {
+              node: ">=18",
+            },
+            publishConfig: {
+              access: "public",
+            },
+          };
+
+          fs.writeFileSync(packageJsonPath, JSON.stringify(pkg, null, 2) + "\n");
+          NODE
+
+      - name: Pack addon npm package
+        id: addon_pack
+        shell: bash
+        env:
+          PACKAGE_DIR: dist/npm/${{ steps.addon.outputs.package_slug }}
+        run: |
+          mkdir -p dist/npm-tarballs
+          tarball=$(npm pack "$PACKAGE_DIR" --pack-destination dist/npm-tarballs --cache ./.npm-cache)
+          echo "tarball=dist/npm-tarballs/$tarball" >> "$GITHUB_OUTPUT"
+
+      - name: Smoke addon npm package
+        shell: bash
+        run: |
+          smoke_dir=$(mktemp -d)
+          tarball_path="$GITHUB_WORKSPACE/${{ steps.addon_pack.outputs.tarball }}"
+
+          if command -v cygpath >/dev/null 2>&1; then
+            tarball_path=$(cygpath -m "$tarball_path")
+          fi
+
+          pushd "$smoke_dir" >/dev/null
+          npm init -y >/dev/null 2>&1
+          npm install "$tarball_path" --cache "$GITHUB_WORKSPACE/.npm-cache" --no-package-lock >/dev/null
+          node -e "const addon=require(process.argv[1]); const runCli=typeof addon.runCli==='function'?addon.runCli:typeof addon.default?.runCli==='function'?addon.default.runCli:null; if (!runCli) throw new Error('runCli missing');" "${{ steps.addon.outputs.package_name }}"
+          popd >/dev/null

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,30 +115,40 @@ jobs:
           - runner: macos-14
             platform: darwin
             arch: arm64
+            node_os: darwin
+            node_cpu: arm64
             target: aarch64-apple-darwin
             os_family: macos
             built_library: target/aarch64-apple-darwin/release/libkratos_node.dylib
           - runner: macos-15-intel
             platform: darwin
             arch: x64
+            node_os: darwin
+            node_cpu: x64
             target: x86_64-apple-darwin
             os_family: macos
             built_library: target/x86_64-apple-darwin/release/libkratos_node.dylib
           - runner: ubuntu-latest
             platform: linux
             arch: x64
+            node_os: linux
+            node_cpu: x64
             target: x86_64-unknown-linux-gnu
             os_family: linux
             built_library: target/x86_64-unknown-linux-gnu/release/libkratos_node.so
           - runner: ubuntu-24.04-arm
             platform: linux
             arch: arm64
+            node_os: linux
+            node_cpu: arm64
             target: aarch64-unknown-linux-gnu
             os_family: linux
             built_library: target/aarch64-unknown-linux-gnu/release/libkratos_node.so
           - runner: windows-latest
             platform: win32
             arch: x64
+            node_os: win32
+            node_cpu: x64
             target: x86_64-pc-windows-msvc
             os_family: windows
             built_library: target/x86_64-pc-windows-msvc/release/kratos_node.dll
@@ -182,7 +192,7 @@ jobs:
       - name: Package native addon artifact
         shell: bash
         run: |
-          staging_dir="dist/${{ steps.addon.outputs.package_slug }}"
+          staging_dir="dist/native/${{ steps.addon.outputs.package_slug }}"
           mkdir -p "$staging_dir"
 
           cp "${{ matrix.built_library }}" "$staging_dir/kratos.node"
@@ -205,12 +215,226 @@ jobs:
 
           node -e "const addon=require(process.argv[1]); const runCli=typeof addon.runCli==='function'?addon.runCli:typeof addon.default?.runCli==='function'?addon.default.runCli:null; if (!runCli) throw new Error('runCli missing');" "$extract_dir/kratos.node"
 
+      - name: Stage addon npm package
+        shell: bash
+        env:
+          PACKAGE_DIR: dist/npm/${{ steps.addon.outputs.package_slug }}
+          PACKAGE_NAME: ${{ steps.addon.outputs.package_name }}
+          PACKAGE_VERSION: ${{ needs.resolve.outputs.version }}
+          PACKAGE_OS: ${{ matrix.node_os }}
+          PACKAGE_CPU: ${{ matrix.node_cpu }}
+        run: |
+          mkdir -p "$PACKAGE_DIR"
+          cp "${{ matrix.built_library }}" "$PACKAGE_DIR/kratos.node"
+
+          node --input-type=module <<'NODE'
+          import fs from "node:fs";
+
+          const packageJsonPath = `${process.env.PACKAGE_DIR}/package.json`;
+          const pkg = {
+            name: process.env.PACKAGE_NAME,
+            version: process.env.PACKAGE_VERSION,
+            description: `Prebuilt native addon for ${process.env.PACKAGE_NAME}.`,
+            license: "MIT",
+            homepage: "https://github.com/JeremyDev87/kratos#readme",
+            repository: {
+              type: "git",
+              url: "git+https://github.com/JeremyDev87/kratos.git",
+            },
+            main: "./kratos.node",
+            files: ["kratos.node"],
+            os: [process.env.PACKAGE_OS],
+            cpu: [process.env.PACKAGE_CPU],
+            engines: {
+              node: ">=18",
+            },
+            publishConfig: {
+              access: "public",
+            },
+          };
+
+          fs.writeFileSync(packageJsonPath, JSON.stringify(pkg, null, 2) + "\n");
+          NODE
+
+      - name: Pack addon npm package
+        id: addon_pack
+        shell: bash
+        env:
+          PACKAGE_DIR: dist/npm/${{ steps.addon.outputs.package_slug }}
+        run: |
+          mkdir -p dist/npm-tarballs
+          tarball=$(npm pack "$PACKAGE_DIR" --pack-destination dist/npm-tarballs --cache ./.npm-cache)
+          echo "tarball=dist/npm-tarballs/$tarball" >> "$GITHUB_OUTPUT"
+
+      - name: Smoke addon npm package
+        shell: bash
+        run: |
+          smoke_dir=$(mktemp -d)
+          tarball_path="$GITHUB_WORKSPACE/${{ steps.addon_pack.outputs.tarball }}"
+
+          if command -v cygpath >/dev/null 2>&1; then
+            tarball_path=$(cygpath -m "$tarball_path")
+          fi
+
+          pushd "$smoke_dir" >/dev/null
+          npm init -y >/dev/null 2>&1
+          npm install "$tarball_path" --cache "$GITHUB_WORKSPACE/.npm-cache" --no-package-lock >/dev/null
+          node -e "const addon=require(process.argv[1]); const runCli=typeof addon.runCli==='function'?addon.runCli:typeof addon.default?.runCli==='function'?addon.default.runCli:null; if (!runCli) throw new Error('runCli missing');" "${{ steps.addon.outputs.package_name }}"
+          popd >/dev/null
+
       - name: Upload native addon artifact
         uses: actions/upload-artifact@v4
         with:
           name: native-${{ matrix.target }}
           path: ${{ steps.addon.outputs.archive_name }}
           if-no-files-found: error
+
+      - name: Upload addon npm package
+        uses: actions/upload-artifact@v4
+        with:
+          name: addon-npm-${{ matrix.target }}
+          path: ${{ steps.addon_pack.outputs.tarball }}
+          if-no-files-found: error
+
+  publish-addon-packages:
+    name: Publish Addon Packages
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs:
+      - resolve
+      - verify-node
+      - build-native-artifacts
+    env:
+      NPM_CONFIG_CACHE: .npm-cache
+
+    steps:
+      - name: Checkout tagged release ref
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.resolve.outputs.tag }}
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - name: Download addon npm tarballs
+        uses: actions/download-artifact@v4
+        with:
+          pattern: addon-npm-*
+          path: addon-packages
+          merge-multiple: true
+
+      - name: Detect npm auth mode
+        id: auth
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        shell: bash
+        run: |
+          if [ -n "$NPM_TOKEN" ]; then
+            echo "mode=token" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=trusted" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish addon packages with trusted publishing
+        if: ${{ steps.auth.outputs.mode == 'trusted' }}
+        shell: bash
+        env:
+          NPM_DIST_TAG: ${{ needs.resolve.outputs.npmDistTag }}
+        run: |
+          shopt -s nullglob
+          tarballs=(addon-packages/*.tgz)
+
+          if [ "${#tarballs[@]}" -eq 0 ]; then
+            echo "No addon npm tarballs were downloaded."
+            exit 1
+          fi
+
+          for tarball in "${tarballs[@]}"; do
+            metadata_file=$(mktemp addon-package-XXXXXX.json)
+            tar -xOf "$tarball" package/package.json > "$metadata_file"
+
+            package_name=$(node --input-type=module -e "import fs from 'node:fs'; const pkg = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); console.log(pkg.name);" "$metadata_file")
+            package_version=$(node --input-type=module -e "import fs from 'node:fs'; const pkg = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); console.log(pkg.version);" "$metadata_file")
+
+            rm -f "$metadata_file"
+
+            if npm view "${package_name}@${package_version}" version --registry=https://registry.npmjs.org >/tmp/npm-version.txt 2>/tmp/npm-view-error.txt; then
+              echo "Addon package ${package_name}@${package_version} already published, skipping."
+              continue
+            fi
+
+            lookup_state=$(node ./scripts/classify-npm-lookup-error.mjs /tmp/npm-view-error.txt)
+            if [ "$lookup_state" != "not-found" ]; then
+              cat /tmp/npm-view-error.txt
+              exit 1
+            fi
+
+            if npm publish "$tarball" --access public --tag "$NPM_DIST_TAG" >/tmp/npm-publish.txt 2>/tmp/npm-publish-error.txt; then
+              echo "Published ${package_name}@${package_version}"
+              continue
+            fi
+
+            publish_state=$(node ./scripts/classify-npm-publish-error.mjs /tmp/npm-publish-error.txt)
+            if [ "$publish_state" = "already-published" ]; then
+              echo "Addon package ${package_name}@${package_version} was already published during a rerun, continuing."
+            else
+              cat /tmp/npm-publish-error.txt
+              exit 1
+            fi
+          done
+
+      - name: Publish addon packages with token fallback
+        if: ${{ steps.auth.outputs.mode == 'token' }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_DIST_TAG: ${{ needs.resolve.outputs.npmDistTag }}
+        shell: bash
+        run: |
+          shopt -s nullglob
+          tarballs=(addon-packages/*.tgz)
+
+          if [ "${#tarballs[@]}" -eq 0 ]; then
+            echo "No addon npm tarballs were downloaded."
+            exit 1
+          fi
+
+          for tarball in "${tarballs[@]}"; do
+            metadata_file=$(mktemp addon-package-XXXXXX.json)
+            tar -xOf "$tarball" package/package.json > "$metadata_file"
+
+            package_name=$(node --input-type=module -e "import fs from 'node:fs'; const pkg = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); console.log(pkg.name);" "$metadata_file")
+            package_version=$(node --input-type=module -e "import fs from 'node:fs'; const pkg = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); console.log(pkg.version);" "$metadata_file")
+
+            rm -f "$metadata_file"
+
+            if npm view "${package_name}@${package_version}" version --registry=https://registry.npmjs.org >/tmp/npm-version.txt 2>/tmp/npm-view-error.txt; then
+              echo "Addon package ${package_name}@${package_version} already published, skipping."
+              continue
+            fi
+
+            lookup_state=$(node ./scripts/classify-npm-lookup-error.mjs /tmp/npm-view-error.txt)
+            if [ "$lookup_state" != "not-found" ]; then
+              cat /tmp/npm-view-error.txt
+              exit 1
+            fi
+
+            if npm publish "$tarball" --access public --tag "$NPM_DIST_TAG" >/tmp/npm-publish.txt 2>/tmp/npm-publish-error.txt; then
+              echo "Published ${package_name}@${package_version}"
+              continue
+            fi
+
+            publish_state=$(node ./scripts/classify-npm-publish-error.mjs /tmp/npm-publish-error.txt)
+            if [ "$publish_state" = "already-published" ]; then
+              echo "Addon package ${package_name}@${package_version} was already published during a rerun, continuing."
+            else
+              cat /tmp/npm-publish-error.txt
+              exit 1
+            fi
+          done
 
   publish-root-package:
     name: Publish Root Package
@@ -220,7 +444,7 @@ jobs:
       - resolve
       - verify-node
       - verify-rust
-      - build-native-artifacts
+      - publish-addon-packages
     env:
       NPM_CONFIG_CACHE: .npm-cache
 
@@ -361,6 +585,7 @@ jobs:
     needs:
       - resolve
       - build-native-artifacts
+      - publish-addon-packages
       - publish-root-package
     env:
       GH_TOKEN: ${{ github.token }}
@@ -376,6 +601,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           pattern: native-*
+          path: release-assets
+          merge-multiple: true
+
+      - name: Download addon npm tarballs
+        uses: actions/download-artifact@v4
+        with:
+          pattern: addon-npm-*
           path: release-assets
           merge-multiple: true
 

--- a/docs/plan/00-rust-migration-overview.md
+++ b/docs/plan/00-rust-migration-overview.md
@@ -33,7 +33,7 @@ Kratos를 현재의 Node/JS 구현에서 Rust 중심 구현으로 전환한다. 
 - config 파일 이름은 계속 `kratos.config.json`을 사용한다.
 - 현재 JS 구현은 baseline으로 유지하고, cutover 전까지 부분적으로 고치지 않는다.
 - `package.json`은 `PR 6A. Root Package Cutover And JS Runtime Removal` 전까지 건드리지 않고, 이후에는 stable promotion용 `Release Prep 8A. Version-Only Stable Promotion`에서만 다시 수정한다.
-- `.github/workflows/ci.yml`와 `.github/workflows/release.yml`는 `PR 5B. CI And Release Rewrite For Rust Artifacts`만 수정한다.
+- `.github/workflows/ci.yml`와 `.github/workflows/release.yml`는 `PR 5B. CI And Release Rewrite For Rust Artifacts`, `PR 5C. Addon npm Publish Lane Before Root Cutover`만 수정한다.
 - 다국어 README와 `CONTRIBUTING.md`는 `PR 7A. Docs Sync And Alpha Release Readiness` 전까지 수정하지 않는다.
 - Rust crate 구조는 `Cargo.toml` 워크스페이스 + `crates/kratos-core`, `crates/kratos-cli`, `crates/kratos-node`로 고정한다.
 - Rust parser는 `Oxc`로 고정한다. 다른 parser stack으로 갈아타는 작업은 본 계획 범위 밖이다.
@@ -89,6 +89,7 @@ Kratos를 현재의 Node/JS 구현에서 Rust 중심 구현으로 전환한다. 
 
 - `PR 5A. NAPI Wrapper And JS Launcher`
 - `PR 5B. CI And Release Rewrite For Rust Artifacts`
+- `PR 5C. Addon npm Publish Lane Before Root Cutover`
 
 ### Phase 6. Big-Bang Cutover
 

--- a/docs/plan/03-rust-cli-and-node-packaging.md
+++ b/docs/plan/03-rust-cli-and-node-packaging.md
@@ -23,7 +23,8 @@
 - `PR 5A`는 `crates/kratos-node/**/*`, `bin/kratos.js`, `test/npm-launcher.test.js`를 수정한다.
 - `PR 5A`에서 NAPI wrapper가 CLI 로직을 재사용하기 위해 필요한 최소 범위의 `crates/kratos-cli/src/lib.rs` 추출과 `crates/kratos-cli/src/main.rs` thin-wrapper 변경은 허용한다.
 - `PR 5B`는 `PR 5A`가 merge되어 addon package name과 target 매핑이 고정된 뒤에만 시작한다.
-- `PR 5B`는 workflow 파일만 수정한다. `package.json`은 `PR 6A`까지 건드리지 않는다.
+- `PR 5C`는 `PR 5B`가 merge되어 release lane이 정리된 뒤에만 시작한다.
+- `PR 5B`와 `PR 5C`는 workflow 파일만 수정한다. `package.json`은 `PR 6A`까지 건드리지 않는다.
 - unknown command/help/error wording은 현재 JS CLI와 최대한 동일한 읽기 경험을 유지한다.
 
 ## PR 4A. Rust CLI For Scan Report Clean
@@ -130,6 +131,38 @@
   - Rust workspace test
   - target build matrix
   - npm smoke install
+
+## PR 5C. Addon npm Publish Lane Before Root Cutover
+
+### Target Files
+
+- `.github/workflows/ci.yml`
+- `.github/workflows/release.yml`
+
+### Steps
+
+1. `PR 5A`에서 고정한 addon package name과 target 매핑으로 platform addon npm package tarball을 만든다.
+2. CI의 native packaging matrix는 raw native archive smoke에 더해 addon npm tarball을 실제 install/require 해 본다.
+3. release workflow는 target build job에서 addon npm tarball을 artifact로 업로드한다.
+4. release workflow에 별도 addon publish job을 추가하되 기존 verify gate 뒤에서 addon package를 먼저 publish하고, 그 다음 root package publish가 진행되게 만든다.
+5. rerun-safe하게 동작하도록 addon publish도 npm lookup/publish error classifier를 재사용한다.
+6. GitHub Release asset에는 raw native archive, addon npm tarball, root npm tarball을 함께 첨부한다.
+
+### Behavior Constraints
+
+- addon publish lane은 `PR 5B` 산출물 위에서만 확장한다. naming source of truth를 새로 만들지 않는다.
+- addon npm package는 각 target의 `os`/`cpu` 제한과 `kratos.node` payload만 포함한다.
+- addon publish job은 `verify-node`, `verify-rust`, target build 성공 뒤에만 진행된다.
+- release workflow에서 root package publish는 addon publish 성공 또는 already-published 판정 뒤에만 진행한다.
+- 이 PR도 `package.json`은 수정하지 않는다.
+
+### Validation
+
+- CI dry-run 관점에서 아래 경로가 모두 실행 가능해야 한다.
+  - raw native archive smoke
+  - addon npm tarball pack
+  - addon npm tarball install/require smoke
+  - addon publish before root publish
 
 ## Done Criteria
 


### PR DESCRIPTION
## 배경
- Rust cutover 전 단계에서 플랫폼 addon npm package publish 경로를 먼저 확보해야 했습니다.
- release workflow에서 addon publish가 `verify-node` 실패를 우회하지 않도록 gate 순서도 함께 고정했습니다.

## 변경 사항
- `ci.yml`의 native packaging matrix에 addon npm tarball pack/install smoke를 추가했습니다.
- `release.yml`에 addon npm tarball artifact upload, addon-first publish job, GitHub release asset 포함 흐름을 추가했습니다.
- `publish-addon-packages`가 `verify-node`와 native artifact build를 모두 기다리도록 release gate를 보강했습니다.
- Rust migration plan 문서에 `PR 5C. Addon npm Publish Lane Before Root Cutover`를 추가하고 PR 6A 선행조건을 반영했습니다.

## 검증
- `actionlint .github/workflows/ci.yml .github/workflows/release.yml`
- `npm test`
- `cargo test --workspace`
- `git diff --check`
- 로컬 호스트 target에서 addon tarball pack/install 후 `runCli(['--help'])` smoke
- `devils-advocate-review-loop` 2라운드
  - Round 1: addon publish가 `verify-node`를 우회할 수 있다는 High finding 1건 수용 후 수정
  - Round 2: 추가 blocker 없음 확인

## 브랜치 / 워크트리
- 대상 브랜치: `master`
- 현재 브랜치: `codex/addon-publish-lane`
- 현재 워크트리: `/Users/pjw/workspace/kratos`
- 포함된 추가 source 브랜치/워크트리: 없음

## 이슈 연결
- 별도 이슈 연결 없음

## 남은 리스크
- 실제 tagged GitHub Actions 실행은 아직 확인하지 않았습니다.
- 실제 npm publish / GitHub release는 정책상 이번 PR에서 실행하지 않았습니다.