### PR TITLE
chore: 0.2.0 stable 승격 준비

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kratos",
-  "version": "0.2.0-alpha.1",
+  "version": "0.2.0",
   "description": "Destroy dead code ruthlessly.",
   "author": "JeremyDev87",
   "type": "module",
@@ -47,11 +47,11 @@
     "analysis"
   ],
   "optionalDependencies": {
-    "@kratos/darwin-arm64": "0.2.0-alpha.1",
-    "@kratos/darwin-x64": "0.2.0-alpha.1",
-    "@kratos/linux-x64-gnu": "0.2.0-alpha.1",
-    "@kratos/linux-arm64-gnu": "0.2.0-alpha.1",
-    "@kratos/win32-x64-msvc": "0.2.0-alpha.1"
+    "@kratos/darwin-arm64": "0.2.0",
+    "@kratos/darwin-x64": "0.2.0",
+    "@kratos/linux-x64-gnu": "0.2.0",
+    "@kratos/linux-arm64-gnu": "0.2.0",
+    "@kratos/win32-x64-msvc": "0.2.0"
   },
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
## 배경 / Background

- `Verification Gate 7B`를 current `master` 기준으로 잠근 뒤 stable promotion 준비 단계로 넘어갔습니다.
- `Release Prep 8A`는 `package.json`만 건드리는 version-only slice로 제한됩니다.

## 변경 사항 / Changes

- root package version을 `0.2.0-alpha.1`에서 `0.2.0`으로 올렸습니다.
- root `optionalDependencies`의 native addon 버전도 모두 `0.2.0`으로 맞췄습니다.

## 검증 / Verification

- `node -p "require('./package.json').version"`
- `node ./scripts/release-plan.mjs v0.2.0`
- `npm run verify`

## 브랜치 / 워크트리 / Branches and worktrees

- 대상 브랜치: `codex/release-prep-8a`
- 작업 경로: `/Users/pjw/workspace/kratos`
- 별도 worktree 사용 없음

## 리스크 또는 확인 포인트 / Risks or follow-ups

- stable tag / publish는 아직 실행하지 않았습니다.
- release 실행 전 최종 확인과 배포 여부 결정이 필요합니다.
