### PR TITLE
ci: release drafter와 수동 bump 워크플로 추가

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,26 @@
+categories:
+  - title: "Features"
+    labels:
+      - "feat"
+      - "enhancement"
+  - title: "Bug Fixes"
+    labels:
+      - "bug"
+  - title: "Documentation"
+    labels:
+      - "documentation"
+  - title: "Tests"
+    labels:
+      - "test"
+  - title: "Maintenance"
+    labels:
+      - "chore"
+      - "ci"
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+template: |
+  ## Changes
+  $CHANGES
+
+  ## Notes
+  - This draft is updated automatically from the current `package.json` version on `master`.
+  - Actual tag and publish steps continue to use the `Release` workflow and `scripts/release-plan.mjs`.

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,3 +1,6 @@
+exclude-labels:
+  - "skip-changelog"
+
 categories:
   - title: "Features"
     labels:

--- a/.github/workflows/manual-release-bump.yml
+++ b/.github/workflows/manual-release-bump.yml
@@ -19,11 +19,13 @@ on:
         type: boolean
 
 permissions:
+  actions: write
   contents: write
+  issues: write
   pull-requests: write
 
 concurrency:
-  group: manual-release-bump-${{ inputs.base_ref }}-${{ inputs.tag }}
+  group: manual-release-bump-${{ inputs.base_ref }}-${{ startsWith(inputs.tag, 'v') && inputs.tag || format('v{0}', inputs.tag) }}
   cancel-in-progress: false
 
 jobs:
@@ -56,13 +58,9 @@ jobs:
           node ./scripts/release-plan.mjs "$tag" >> "$GITHUB_OUTPUT"
 
           current_version=$(node -p "require('./package.json').version")
-          if [ "$current_version" = "${tag#v}" ]; then
-            echo "package.json is already at version $current_version"
-            exit 1
-          fi
+          node --input-type=module -e "import { assertReleaseUpgrade } from './scripts/lib/release.mjs'; assertReleaseUpgrade(process.argv[1], process.argv[2]);" "$current_version" "${tag#v}"
 
-          branch_version=$(printf '%s' "${tag#v}" | tr '.+' '-' | tr -c '0-9A-Za-z-' '-')
-          branch="codex/manual-bump-v${branch_version}"
+          branch=$(node --input-type=module -e "import { createManualBumpBranchName } from './scripts/bump-release-version.mjs'; console.log(createManualBumpBranchName(process.argv[1], process.argv[2]));" "$tag" "${{ inputs.base_ref }}")
 
           {
             echo "currentVersion=$current_version"
@@ -73,7 +71,7 @@ jobs:
       - name: Apply version bump
         run: node ./scripts/bump-release-version.mjs "${{ steps.meta.outputs.tag }}"
 
-      - name: Verify changed files
+      - name: Verify changed files before package verification
         shell: bash
         run: |
           changed_files=$(git diff --name-only)
@@ -86,23 +84,63 @@ jobs:
       - name: Verify package
         run: npm run verify
 
+      - name: Verify changed files after package verification
+        shell: bash
+        run: |
+          changed_files=$(git diff --name-only)
+          if [ "$changed_files" != "package.json" ]; then
+            echo "Unexpected changed files after verification:"
+            printf '%s\n' "$changed_files"
+            exit 1
+          fi
+
       - name: Stop after dry run
         if: ${{ inputs.dry_run }}
         run: echo "Dry run requested; skipping branch push and PR creation."
+
+      - name: Configure git author
+        if: ${{ !inputs.dry_run }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Prepare bump branch
         if: ${{ !inputs.dry_run }}
         shell: bash
         run: |
+          lease_args=()
+
           if gh pr list --head "${{ steps.meta.outputs.branch }}" --state open --json number --jq 'length > 0' | grep -q true; then
             echo "An open PR already exists for branch ${{ steps.meta.outputs.branch }}"
             exit 1
           fi
 
-          git switch -c "${{ steps.meta.outputs.branch }}"
+          if git ls-remote --exit-code --heads origin "${{ steps.meta.outputs.branch }}" >/dev/null 2>&1; then
+            echo "Remote branch ${{ steps.meta.outputs.branch }} already exists; refreshing it with the verified bump commit."
+            git fetch origin "refs/heads/${{ steps.meta.outputs.branch }}:refs/remotes/origin/${{ steps.meta.outputs.branch }}"
+            lease_args+=(--force-with-lease="refs/heads/${{ steps.meta.outputs.branch }}:$(git rev-parse "refs/remotes/origin/${{ steps.meta.outputs.branch }}")")
+          fi
+
+          git switch -C "${{ steps.meta.outputs.branch }}"
           git add package.json
           git commit -m "${{ steps.meta.outputs.title }}"
-          git push -u origin "${{ steps.meta.outputs.branch }}"
+          git push "${lease_args[@]}" -u origin "${{ steps.meta.outputs.branch }}"
+
+      - name: Dispatch CI for bump branch
+        if: ${{ !inputs.dry_run }}
+        run: gh workflow run ci.yml --ref "${{ steps.meta.outputs.branch }}"
+
+      - name: Ensure skip-changelog label exists
+        if: ${{ !inputs.dry_run }}
+        shell: bash
+        run: |
+          if gh label list --search "skip-changelog" --json name --jq 'map(select(.name == "skip-changelog")) | length > 0' | grep -q true; then
+            exit 0
+          fi
+
+          gh label create "skip-changelog" \
+            --color "6E7781" \
+            --description "Exclude automated release prep PRs from release notes."
 
       - name: Create draft PR
         if: ${{ !inputs.dry_run }}
@@ -142,4 +180,4 @@ jobs:
             --head "${{ steps.meta.outputs.branch }}" \
             --title "${{ steps.meta.outputs.title }}" \
             --body-file pr-body.md \
-            --label chore
+            --label skip-changelog

--- a/.github/workflows/manual-release-bump.yml
+++ b/.github/workflows/manual-release-bump.yml
@@ -1,0 +1,145 @@
+name: Manual Release Bump
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Target release tag or version, for example v0.2.0 or 0.2.0-alpha.2
+        required: true
+        type: string
+      base_ref:
+        description: Base branch to update
+        required: false
+        default: master
+        type: string
+      dry_run:
+        description: Validate and prepare the bump without pushing a branch or opening a PR
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: manual-release-bump-${{ inputs.base_ref }}-${{ inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  bump_release_version:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.base_ref }}
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Resolve bump metadata
+        id: meta
+        shell: bash
+        run: |
+          tag="${{ inputs.tag }}"
+          if [[ "$tag" != v* ]]; then
+            tag="v$tag"
+          fi
+
+          node ./scripts/release-plan.mjs "$tag" >> "$GITHUB_OUTPUT"
+
+          current_version=$(node -p "require('./package.json').version")
+          if [ "$current_version" = "${tag#v}" ]; then
+            echo "package.json is already at version $current_version"
+            exit 1
+          fi
+
+          branch_version=$(printf '%s' "${tag#v}" | tr '.+' '-' | tr -c '0-9A-Za-z-' '-')
+          branch="codex/manual-bump-v${branch_version}"
+
+          {
+            echo "currentVersion=$current_version"
+            echo "branch=$branch"
+            echo "title=chore: ${tag#v} 수동 bump"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Apply version bump
+        run: node ./scripts/bump-release-version.mjs "${{ steps.meta.outputs.tag }}"
+
+      - name: Verify changed files
+        shell: bash
+        run: |
+          changed_files=$(git diff --name-only)
+          if [ "$changed_files" != "package.json" ]; then
+            echo "Unexpected changed files:"
+            printf '%s\n' "$changed_files"
+            exit 1
+          fi
+
+      - name: Verify package
+        run: npm run verify
+
+      - name: Stop after dry run
+        if: ${{ inputs.dry_run }}
+        run: echo "Dry run requested; skipping branch push and PR creation."
+
+      - name: Prepare bump branch
+        if: ${{ !inputs.dry_run }}
+        shell: bash
+        run: |
+          if gh pr list --head "${{ steps.meta.outputs.branch }}" --state open --json number --jq 'length > 0' | grep -q true; then
+            echo "An open PR already exists for branch ${{ steps.meta.outputs.branch }}"
+            exit 1
+          fi
+
+          git switch -c "${{ steps.meta.outputs.branch }}"
+          git add package.json
+          git commit -m "${{ steps.meta.outputs.title }}"
+          git push -u origin "${{ steps.meta.outputs.branch }}"
+
+      - name: Create draft PR
+        if: ${{ !inputs.dry_run }}
+        shell: bash
+        run: |
+          cat > pr-body.md <<EOF
+          ## 배경 / Background
+
+          - manual release bump workflow로 \`${{ steps.meta.outputs.currentVersion }}\`에서 \`${{ steps.meta.outputs.version }}\`으로 승격합니다.
+          - 실제 tag / publish는 이 PR merge 이후 별도 release workflow에서 진행합니다.
+
+          ## 변경 사항 / Changes
+
+          - root package version을 \`${{ steps.meta.outputs.currentVersion }}\`에서 \`${{ steps.meta.outputs.version }}\`으로 올렸습니다.
+          - root \`optionalDependencies\`의 native addon 버전도 모두 \`${{ steps.meta.outputs.version }}\`으로 맞췄습니다.
+
+          ## 검증 / Verification
+
+          - \`node ./scripts/release-plan.mjs ${{ steps.meta.outputs.tag }}\`
+          - \`node ./scripts/bump-release-version.mjs ${{ steps.meta.outputs.tag }}\`
+          - \`npm run verify\`
+
+          ## 브랜치 / 워크트리 / Branches and worktrees
+
+          - base: \`${{ inputs.base_ref }}\`
+          - branch: \`${{ steps.meta.outputs.branch }}\`
+
+          ## 리스크 또는 확인 포인트 / Risks or follow-ups
+
+          - stable tag / publish는 아직 실행하지 않았습니다.
+          - release 실행 전 최종 확인이 필요합니다.
+          EOF
+
+          gh pr create \
+            --draft \
+            --base "${{ inputs.base_ref }}" \
+            --head "${{ steps.meta.outputs.branch }}" \
+            --title "${{ steps.meta.outputs.title }}" \
+            --body-file pr-body.md \
+            --label chore

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,63 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Run without updating the draft release
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Resolve release draft metadata
+        id: meta
+        shell: bash
+        run: |
+          version=$(node -p "require('./package.json').version")
+          tag="v$version"
+
+          node ./scripts/release-plan.mjs "$tag" >> "$GITHUB_OUTPUT"
+
+          if [[ "$version" == *-* ]]; then
+            draft_tag="${tag}.draft"
+          else
+            draft_tag="${tag}-draft"
+          fi
+
+          {
+            echo "draftTag=$draft_tag"
+            echo "draftName=Draft $tag"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Update release draft
+        uses: release-drafter/release-drafter@6db134d15f3909ccc9eefd369f02bd1e9cffdf97 # v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          config-name: release-drafter.yml
+          tag: ${{ steps.meta.outputs.draftTag }}
+          name: ${{ steps.meta.outputs.draftName }}
+          version: ${{ steps.meta.outputs.version }}
+          prerelease: ${{ steps.meta.outputs.isPrerelease }}
+          dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,6 +6,11 @@ on:
       - master
   workflow_dispatch:
     inputs:
+      target_ref:
+        description: Branch to inspect when refreshing the draft manually
+        required: false
+        default: master
+        type: string
       dry_run:
         description: Run without updating the draft release
         required: false
@@ -23,6 +28,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.target_ref || github.ref_name }}
           fetch-depth: 0
 
       - name: Setup Node.js
@@ -39,16 +45,18 @@ jobs:
 
           node ./scripts/release-plan.mjs "$tag" >> "$GITHUB_OUTPUT"
 
-          if [[ "$version" == *-* ]]; then
-            draft_tag="${tag}.draft"
-          else
-            draft_tag="${tag}-draft"
-          fi
+          draft_tag="draft-${tag}"
 
           {
             echo "draftTag=$draft_tag"
             echo "draftName=Draft $tag"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Guard live draft updates to master
+        if: ${{ github.event_name == 'workflow_dispatch' && !inputs.dry_run && inputs.target_ref != 'master' }}
+        run: |
+          echo "Non-dry-run manual draft updates must target master."
+          exit 1
 
       - name: Update release draft
         uses: release-drafter/release-drafter@6db134d15f3909ccc9eefd369f02bd1e9cffdf97 # v6
@@ -56,6 +64,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           config-name: release-drafter.yml
+          commitish: ${{ github.event_name == 'workflow_dispatch' && inputs.target_ref || github.ref_name }}
           tag: ${{ steps.meta.outputs.draftTag }}
           name: ${{ steps.meta.outputs.draftName }}
           version: ${{ steps.meta.outputs.version }}

--- a/scripts/bump-release-version.mjs
+++ b/scripts/bump-release-version.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { resolveReleasePlan } from "./lib/release.mjs";
+
+export function normalizeReleaseTag(input) {
+  return input.startsWith("v") ? input : `v${input}`;
+}
+
+export function updatePackageManifest(pkg, version) {
+  const nextPkg = {
+    ...pkg,
+    version,
+  };
+
+  if (pkg.optionalDependencies && typeof pkg.optionalDependencies === "object") {
+    nextPkg.optionalDependencies = Object.fromEntries(
+      Object.entries(pkg.optionalDependencies).map(([name]) => [name, version]),
+    );
+  }
+
+  return nextPkg;
+}
+
+export async function bumpPackageVersion(input, packageJsonPath = "package.json") {
+  const normalizedTag = normalizeReleaseTag(input);
+  const plan = resolveReleasePlan(normalizedTag);
+  const manifestPath = path.resolve(packageJsonPath);
+  const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8"));
+  const nextManifest = updatePackageManifest(manifest, plan.version);
+
+  await fs.writeFile(manifestPath, `${JSON.stringify(nextManifest, null, 2)}\n`);
+
+  return {
+    manifestPath,
+    version: plan.version,
+    tag: plan.tag,
+    isPrerelease: plan.isPrerelease,
+  };
+}
+
+async function main() {
+  const input = process.argv[2];
+  const packageJsonPath = process.argv[3] ?? "package.json";
+
+  if (!input) {
+    console.error("Usage: node ./scripts/bump-release-version.mjs <tag-or-version> [package-json-path]");
+    process.exit(1);
+  }
+
+  const result = await bumpPackageVersion(input, packageJsonPath);
+
+  console.log(`tag=${result.tag}`);
+  console.log(`version=${result.version}`);
+  console.log(`isPrerelease=${result.isPrerelease}`);
+  console.log(`manifestPath=${result.manifestPath}`);
+}
+
+const isDirectExecution =
+  process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+
+if (isDirectExecution) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/scripts/bump-release-version.mjs
+++ b/scripts/bump-release-version.mjs
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 
 import fs from "node:fs/promises";
+import crypto from "node:crypto";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
-import { resolveReleasePlan } from "./lib/release.mjs";
+import { assertReleaseUpgrade, resolveReleasePlan } from "./lib/release.mjs";
 
 export function normalizeReleaseTag(input) {
   return input.startsWith("v") ? input : `v${input}`;
@@ -25,11 +26,32 @@ export function updatePackageManifest(pkg, version) {
   return nextPkg;
 }
 
+export function createManualBumpBranchName(input, baseRef = "master") {
+  const normalizedTag = normalizeReleaseTag(input);
+  const branchBase = baseRef
+    .replace(/[./+]/g, "-")
+    .replace(/[^0-9A-Za-z-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+  const branchVersion = normalizedTag
+    .slice(1)
+    .replace(/[.+]/g, "-")
+    .replace(/[^0-9A-Za-z-]/g, "-");
+  const branchHash = crypto
+    .createHash("sha256")
+    .update(`${baseRef}\0${normalizedTag}`)
+    .digest("hex")
+    .slice(0, 8);
+
+  return `codex/manual-bump-${branchBase}-v${branchVersion}-${branchHash}`;
+}
+
 export async function bumpPackageVersion(input, packageJsonPath = "package.json") {
   const normalizedTag = normalizeReleaseTag(input);
   const plan = resolveReleasePlan(normalizedTag);
   const manifestPath = path.resolve(packageJsonPath);
   const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8"));
+  assertReleaseUpgrade(manifest.version, plan.version);
   const nextManifest = updatePackageManifest(manifest, plan.version);
 
   await fs.writeFile(manifestPath, `${JSON.stringify(nextManifest, null, 2)}\n`);

--- a/scripts/lib/release.mjs
+++ b/scripts/lib/release.mjs
@@ -1,4 +1,5 @@
 const RELEASE_TAG_PATTERN = /^v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/;
+const RELEASE_VERSION_PATTERN = /^(?<major>[0-9]+)\.(?<minor>[0-9]+)\.(?<patch>[0-9]+)(?:-(?<prerelease>[0-9A-Za-z.-]+))?$/;
 
 export function resolveReleasePlan(tag) {
   if (!RELEASE_TAG_PATTERN.test(tag)) {
@@ -15,6 +16,94 @@ export function resolveReleasePlan(tag) {
     npmDistTag: isPrerelease ? "next" : "latest",
     githubReleaseType: isPrerelease ? "prerelease" : "release",
   };
+}
+
+function parseReleaseVersion(version) {
+  const match = RELEASE_VERSION_PATTERN.exec(version);
+
+  if (!match || !match.groups) {
+    throw new Error(`Version must look like 1.2.3 or 1.2.3-beta.1: ${version}`);
+  }
+
+  return {
+    major: Number(match.groups.major),
+    minor: Number(match.groups.minor),
+    patch: Number(match.groups.patch),
+    prerelease: match.groups.prerelease ? match.groups.prerelease.split(".") : [],
+  };
+}
+
+function comparePrereleaseIdentifiers(left, right) {
+  const leftIsNumeric = /^[0-9]+$/.test(left);
+  const rightIsNumeric = /^[0-9]+$/.test(right);
+
+  if (leftIsNumeric && rightIsNumeric) {
+    return Number(left) === Number(right) ? 0 : Number(left) < Number(right) ? -1 : 1;
+  }
+
+  if (leftIsNumeric !== rightIsNumeric) {
+    return leftIsNumeric ? -1 : 1;
+  }
+
+  if (left === right) {
+    return 0;
+  }
+
+  return left < right ? -1 : 1;
+}
+
+export function compareReleaseVersions(leftVersion, rightVersion) {
+  const left = parseReleaseVersion(leftVersion);
+  const right = parseReleaseVersion(rightVersion);
+
+  for (const key of ["major", "minor", "patch"]) {
+    if (left[key] !== right[key]) {
+      return left[key] < right[key] ? -1 : 1;
+    }
+  }
+
+  if (left.prerelease.length === 0 && right.prerelease.length === 0) {
+    return 0;
+  }
+
+  if (left.prerelease.length === 0) {
+    return 1;
+  }
+
+  if (right.prerelease.length === 0) {
+    return -1;
+  }
+
+  const length = Math.max(left.prerelease.length, right.prerelease.length);
+
+  for (let index = 0; index < length; index += 1) {
+    const leftIdentifier = left.prerelease[index];
+    const rightIdentifier = right.prerelease[index];
+
+    if (leftIdentifier === undefined) {
+      return -1;
+    }
+
+    if (rightIdentifier === undefined) {
+      return 1;
+    }
+
+    const comparison = comparePrereleaseIdentifiers(leftIdentifier, rightIdentifier);
+
+    if (comparison !== 0) {
+      return comparison;
+    }
+  }
+
+  return 0;
+}
+
+export function assertReleaseUpgrade(currentVersion, nextVersion) {
+  if (compareReleaseVersions(currentVersion, nextVersion) >= 0) {
+    throw new Error(
+      `Target version ${nextVersion} must be greater than current version ${currentVersion}`,
+    );
+  }
 }
 
 export function classifyNpmLookupError(stderr) {

--- a/test/bump-release-version.test.js
+++ b/test/bump-release-version.test.js
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  bumpPackageVersion,
+  normalizeReleaseTag,
+  updatePackageManifest,
+} from "../scripts/bump-release-version.mjs";
+
+test("normalizeReleaseTag accepts bare versions", () => {
+  assert.equal(normalizeReleaseTag("1.2.3"), "v1.2.3");
+  assert.equal(normalizeReleaseTag("v1.2.3-beta.1"), "v1.2.3-beta.1");
+});
+
+test("updatePackageManifest syncs root and optional dependency versions", () => {
+  const pkg = {
+    name: "kratos",
+    version: "0.2.0-alpha.1",
+    optionalDependencies: {
+      "@kratos/darwin-arm64": "0.2.0-alpha.1",
+      "@kratos/linux-x64-gnu": "0.2.0-alpha.1",
+    },
+  };
+
+  const updated = updatePackageManifest(pkg, "0.2.0");
+
+  assert.equal(updated.version, "0.2.0");
+  assert.deepEqual(updated.optionalDependencies, {
+    "@kratos/darwin-arm64": "0.2.0",
+    "@kratos/linux-x64-gnu": "0.2.0",
+  });
+});
+
+test("bumpPackageVersion rewrites package.json from tag input", async () => {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "kratos-bump-version-"));
+  const manifestPath = path.join(tempRoot, "package.json");
+
+  await fs.writeFile(
+    manifestPath,
+    `${JSON.stringify(
+      {
+        name: "kratos",
+        version: "0.2.0-alpha.1",
+        optionalDependencies: {
+          "@kratos/darwin-arm64": "0.2.0-alpha.1",
+          "@kratos/win32-x64-msvc": "0.2.0-alpha.1",
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  const result = await bumpPackageVersion("v0.2.0", manifestPath);
+  const updated = JSON.parse(await fs.readFile(manifestPath, "utf8"));
+
+  assert.equal(result.version, "0.2.0");
+  assert.equal(result.tag, "v0.2.0");
+  assert.equal(updated.version, "0.2.0");
+  assert.deepEqual(updated.optionalDependencies, {
+    "@kratos/darwin-arm64": "0.2.0",
+    "@kratos/win32-x64-msvc": "0.2.0",
+  });
+});

--- a/test/bump-release-version.test.js
+++ b/test/bump-release-version.test.js
@@ -6,6 +6,7 @@ import path from "node:path";
 
 import {
   bumpPackageVersion,
+  createManualBumpBranchName,
   normalizeReleaseTag,
   updatePackageManifest,
 } from "../scripts/bump-release-version.mjs";
@@ -32,6 +33,24 @@ test("updatePackageManifest syncs root and optional dependency versions", () => 
     "@kratos/darwin-arm64": "0.2.0",
     "@kratos/linux-x64-gnu": "0.2.0",
   });
+});
+
+test("createManualBumpBranchName avoids collisions for distinct valid prerelease tags", () => {
+  const dotted = createManualBumpBranchName("v1.2.3-alpha.1");
+  const hyphenated = createManualBumpBranchName("v1.2.3-alpha-1");
+
+  assert.notEqual(dotted, hyphenated);
+  assert.match(dotted, /^codex\/manual-bump-master-v1-2-3-alpha-1-[0-9a-f]{8}$/);
+  assert.match(hyphenated, /^codex\/manual-bump-master-v1-2-3-alpha-1-[0-9a-f]{8}$/);
+});
+
+test("createManualBumpBranchName distinguishes base refs for the same tag", () => {
+  const master = createManualBumpBranchName("v1.2.3", "master");
+  const release = createManualBumpBranchName("v1.2.3", "release/1.x");
+
+  assert.notEqual(master, release);
+  assert.match(master, /^codex\/manual-bump-master-v1-2-3-[0-9a-f]{8}$/);
+  assert.match(release, /^codex\/manual-bump-release-1-x-v1-2-3-[0-9a-f]{8}$/);
 });
 
 test("bumpPackageVersion rewrites package.json from tag input", async () => {
@@ -64,4 +83,34 @@ test("bumpPackageVersion rewrites package.json from tag input", async () => {
     "@kratos/darwin-arm64": "0.2.0",
     "@kratos/win32-x64-msvc": "0.2.0",
   });
+});
+
+test("bumpPackageVersion rejects downgrades and same-version rewrites", async () => {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "kratos-bump-version-"));
+  const manifestPath = path.join(tempRoot, "package.json");
+
+  await fs.writeFile(
+    manifestPath,
+    `${JSON.stringify(
+      {
+        name: "kratos",
+        version: "0.2.0-alpha.1",
+        optionalDependencies: {
+          "@kratos/darwin-arm64": "0.2.0-alpha.1",
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  await assert.rejects(
+    bumpPackageVersion("v0.1.0", manifestPath),
+    /Target version 0\.1\.0 must be greater than current version 0\.2\.0-alpha\.1/,
+  );
+
+  await assert.rejects(
+    bumpPackageVersion("v0.2.0-alpha.1", manifestPath),
+    /Target version 0\.2\.0-alpha\.1 must be greater than current version 0\.2\.0-alpha\.1/,
+  );
 });


### PR DESCRIPTION
## 배경

- `codingbuddy`에서 참고한 release drafter 패턴을 `kratos` 현재 release flow에 맞게 옮겼습니다.
- 실제 tag/publish는 계속 기존 release workflow와 `scripts/release-plan.mjs`를 기준으로 분리하고, 이번 PR은 draft 생성과 수동 bump 준비 자동화까지만 다룹니다.

## 변경 사항

- `.github/release-drafter.yml`과 `.github/workflows/release-drafter.yml`을 추가해 `master` 기준 draft release를 자동 갱신하도록 구성했습니다.
- manual dispatch 시 `target_ref`와 `dry_run`을 받아 비-`master` live draft update를 막는 guardrail을 넣었습니다.
- `.github/workflows/manual-release-bump.yml`을 추가해 수동 버전 bump를 branch/PR 단위로 준비할 수 있게 했습니다.
- `scripts/bump-release-version.mjs`를 추가해 root `package.json` version과 root `optionalDependencies`를 함께 갱신하도록 했습니다.
- `test/bump-release-version.test.js`를 추가해 tag normalize, dependency sync, branch name collision 방지를 실제 실행 테스트로 검증했습니다.

## 검증

- `node --test test/bump-release-version.test.js`
- `actionlint .github/workflows/manual-release-bump.yml .github/workflows/release-drafter.yml .github/workflows/release.yml .github/workflows/ci.yml`
- `git diff --check master..HEAD`

추가로 구현 중에 아래도 직접 실행했습니다.

- `node ./scripts/bump-release-version.mjs v0.2.0-alpha.2 <temp package.json>`
- branch name helper collision repro (`v1.2.3-alpha.1`, `v1.2.3-alpha-1`)
- workflow YAML parse 확인

## 브랜치 / 워크트리

- base: `master`
- head: `codex/release-drafter`
- current worktree: `/tmp/kratos-release-drafter`

## 리스크 또는 확인 포인트

- GitHub `workflow_dispatch` 경로와 draft release 업데이트 자체는 로컬에서 live 실행하지 않았습니다.
- release tag 생성, publish, stable promotion 실행은 이번 PR 범위에 포함하지 않았습니다.