### PR TITLE
ci: 릴리즈 publish 경로와 artifact 런타임 수정

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -289,14 +289,14 @@ jobs:
         run: node --test test/package-smoke.test.js
 
       - name: Upload native addon artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: native-${{ matrix.target }}
           path: ${{ steps.addon.outputs.archive_name }}
           if-no-files-found: error
 
       - name: Upload addon npm package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: addon-npm-${{ matrix.target }}
           path: ${{ steps.addon_pack.outputs.tarball }}
@@ -327,7 +327,7 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Download addon npm tarballs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: addon-npm-*
           path: addon-packages
@@ -379,7 +379,7 @@ jobs:
               exit 1
             fi
 
-            if npm publish "$tarball" --access public --tag "$NPM_DIST_TAG" >/tmp/npm-publish.txt 2>/tmp/npm-publish-error.txt; then
+            if npm publish "./$tarball" --access public --tag "$NPM_DIST_TAG" >/tmp/npm-publish.txt 2>/tmp/npm-publish-error.txt; then
               echo "Published ${package_name}@${package_version}"
               continue
             fi
@@ -428,7 +428,7 @@ jobs:
               exit 1
             fi
 
-            if npm publish "$tarball" --access public --tag "$NPM_DIST_TAG" >/tmp/npm-publish.txt 2>/tmp/npm-publish-error.txt; then
+            if npm publish "./$tarball" --access public --tag "$NPM_DIST_TAG" >/tmp/npm-publish.txt 2>/tmp/npm-publish-error.txt; then
               echo "Published ${package_name}@${package_version}"
               continue
             fi
@@ -526,7 +526,7 @@ jobs:
           popd >/dev/null
 
       - name: Upload root npm tarball
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: root-npm-tarball
           path: ${{ steps.pack.outputs.tarball }}
@@ -548,7 +548,7 @@ jobs:
         if: ${{ steps.auth.outputs.mode == 'trusted' && steps.npm_state.outputs.already_published != 'true' }}
         shell: bash
         run: |
-          if npm publish "${{ steps.pack.outputs.tarball }}" --access public --tag "${{ needs.resolve.outputs.npmDistTag }}" >/tmp/npm-publish.txt 2>/tmp/npm-publish-error.txt; then
+          if npm publish "./${{ steps.pack.outputs.tarball }}" --access public --tag "${{ needs.resolve.outputs.npmDistTag }}" >/tmp/npm-publish.txt 2>/tmp/npm-publish-error.txt; then
             exit 0
           fi
 
@@ -567,7 +567,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         shell: bash
         run: |
-          if npm publish "${{ steps.pack.outputs.tarball }}" --access public --tag "${{ needs.resolve.outputs.npmDistTag }}" >/tmp/npm-publish.txt 2>/tmp/npm-publish-error.txt; then
+          if npm publish "./${{ steps.pack.outputs.tarball }}" --access public --tag "${{ needs.resolve.outputs.npmDistTag }}" >/tmp/npm-publish.txt 2>/tmp/npm-publish-error.txt; then
             exit 0
           fi
 
@@ -598,20 +598,20 @@ jobs:
 
     steps:
       - name: Download root npm tarball
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: root-npm-tarball
           path: release-assets
 
       - name: Download native addon artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: native-*
           path: release-assets
           merge-multiple: true
 
       - name: Download addon npm tarballs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: addon-npm-*
           path: release-assets


### PR DESCRIPTION
## 배경

- v0.2.0 release workflow에서 addon tarball publish가 `addon-packages/*.tgz`를 파일 경로가 아니라 GitHub shorthand처럼 해석해 실패했습니다.
- release job의 artifact upload/download 액션도 Node.js 20 deprecation warning을 내고 있어 Node.js 24 런타임 지원 버전으로 올립니다.

## 변경 사항

- addon/root npm publish 대상 tarball을 모두 `./...tgz` 형태의 명시적 파일 경로로 전달합니다.
- release workflow의 `actions/upload-artifact`와 `actions/download-artifact`를 `v7`로 올립니다.

## 검증

- `node -p "require('./package.json').version"` -> `0.2.0`
- `node ./scripts/release-plan.mjs v0.2.0`
- `actionlint .github/workflows/release.yml .github/workflows/ci.yml .github/workflows/manual-release-bump.yml .github/workflows/release-drafter.yml`
- `rg -n "actions/(upload|download)-artifact@v4|actions/(upload|download)-artifact@v7|npm publish" .github/workflows/release.yml`
- `npm run verify`
- `cargo test --workspace`
- `git diff --check`

## 참고

- release/tag/publish는 실행하지 않았습니다.
- `npm publish ./addon-packages/<tarball> --dry-run`은 npm이 tarball metadata를 읽는 단계까지 확인했지만, registry 대기 시간이 길어 중단했습니다.
- `KRATOS_PACKAGE_SMOKE_NATIVE_LIB`가 없어서 로컬 root package native smoke 1건은 기존처럼 skip됐습니다.