### PR TITLE
ci: 수동 bump PR 생성 권한 fallback 추가

### DIFF
--- a/.github/workflows/manual-release-bump.yml
+++ b/.github/workflows/manual-release-bump.yml
@@ -142,9 +142,12 @@ jobs:
             --color "6E7781" \
             --description "Exclude automated release prep PRs from release notes."
 
-      - name: Create draft PR
+      - name: Create draft PR or print manual link
         if: ${{ !inputs.dry_run }}
         shell: bash
+        env:
+          DEFAULT_GH_TOKEN: ${{ github.token }}
+          PR_CREATE_TOKEN: ${{ secrets.KRATOS_RELEASE_BOT_TOKEN }}
         run: |
           cat > pr-body.md <<EOF
           ## 배경 / Background
@@ -174,10 +177,43 @@ jobs:
           - release 실행 전 최종 확인이 필요합니다.
           EOF
 
-          gh pr create \
+          if [ -n "$PR_CREATE_TOKEN" ]; then
+            export GH_TOKEN="$PR_CREATE_TOKEN"
+          else
+            export GH_TOKEN="$DEFAULT_GH_TOKEN"
+          fi
+
+          if pr_url=$(gh pr create \
             --draft \
             --base "${{ inputs.base_ref }}" \
             --head "${{ steps.meta.outputs.branch }}" \
             --title "${{ steps.meta.outputs.title }}" \
             --body-file pr-body.md \
-            --label skip-changelog
+            --label skip-changelog 2>/tmp/gh-pr-create-error.txt); then
+            echo "Created draft PR: $pr_url"
+            exit 0
+          fi
+
+          if grep -qiE "not permitted to create or approve pull requests|Resource not accessible by integration|createPullRequest" /tmp/gh-pr-create-error.txt; then
+            compare_url="https://github.com/${GITHUB_REPOSITORY}/compare/${{ inputs.base_ref }}...${{ steps.meta.outputs.branch }}?expand=1"
+
+            {
+              echo "### Manual release bump branch is ready"
+              echo
+              echo "GitHub Actions could not create a pull request with the available token."
+              echo
+              echo "- base: \`${{ inputs.base_ref }}\`"
+              echo "- branch: \`${{ steps.meta.outputs.branch }}\`"
+              echo "- title: \`${{ steps.meta.outputs.title }}\`"
+              echo "- PR URL: $compare_url"
+              echo
+              echo "Configure \`KRATOS_RELEASE_BOT_TOKEN\` with pull request creation permission to let this workflow create the draft PR automatically."
+            } >> "$GITHUB_STEP_SUMMARY"
+
+            cat /tmp/gh-pr-create-error.txt
+            echo "::warning::GitHub Actions is not permitted to create pull requests; branch was pushed and CI was dispatched. Open the PR manually: $compare_url"
+            exit 0
+          fi
+
+          cat /tmp/gh-pr-create-error.txt
+          exit 1


### PR DESCRIPTION
## 배경

- Manual Release Bump workflow에서 기본 `GITHUB_TOKEN`으로 `gh pr create`를 실행하면 repository 설정에 따라 `GitHub Actions is not permitted to create or approve pull requests` 오류로 실패합니다.
- 실제 bump branch push와 CI dispatch가 끝났더라도 마지막 PR 생성 단계 때문에 workflow 전체가 실패하는 문제가 있었습니다.

## 변경 사항

- `Create draft PR` 단계를 `Create draft PR or print manual link`로 바꿨습니다.
- `KRATOS_RELEASE_BOT_TOKEN` secret이 있으면 해당 token으로 PR 생성을 시도합니다.
- bot token이 없거나 기본 token이 PR 생성 권한에 막히면 workflow를 실패시키지 않고 `$GITHUB_STEP_SUMMARY`와 warning에 수동 PR 생성 URL을 남깁니다.
- 그 외 알 수 없는 `gh pr create` 실패는 기존처럼 실패로 처리합니다.

## 검증

- `actionlint .github/workflows/manual-release-bump.yml .github/workflows/release.yml .github/workflows/ci.yml .github/workflows/release-drafter.yml`
- 권한 에러 패턴 매칭 확인
- PR 생성 step 구조 확인
- GitHub expression을 더미로 치환한 PR 생성 step `bash -n`
- `npm run verify`
- `cargo test --workspace`
- `git diff --check`

## 참고

- release/tag/publish는 실행하지 않았습니다.
- 실제 GitHub Actions workflow_dispatch 재실행은 이 PR merge 후 확인해야 합니다.
- `KRATOS_PACKAGE_SMOKE_NATIVE_LIB`가 없어 로컬 native smoke 1건은 기존처럼 skip됐습니다.