### PR TITLE
chore: 0.2.1 수동 bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kratos",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Destroy dead code ruthlessly.",
   "author": "JeremyDev87",
   "type": "module",
@@ -47,11 +47,11 @@
     "analysis"
   ],
   "optionalDependencies": {
-    "@kratos/darwin-arm64": "0.2.0",
-    "@kratos/darwin-x64": "0.2.0",
-    "@kratos/linux-x64-gnu": "0.2.0",
-    "@kratos/linux-arm64-gnu": "0.2.0",
-    "@kratos/win32-x64-msvc": "0.2.0"
+    "@kratos/darwin-arm64": "0.2.1",
+    "@kratos/darwin-x64": "0.2.1",
+    "@kratos/linux-x64-gnu": "0.2.1",
+    "@kratos/linux-arm64-gnu": "0.2.1",
+    "@kratos/win32-x64-msvc": "0.2.1"
   },
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
## 배경 / Background

- manual release bump workflow로 release 준비 버전을 `0.2.1`로 승격합니다.
- 실제 tag / publish는 이 PR merge 이후 별도 release workflow에서 진행합니다.

## 변경 사항 / Changes

- root package version을 `0.2.1`로 올립니다.
- root `optionalDependencies`의 native addon 버전도 `0.2.1`로 맞춥니다.

## 검증 / Verification

- manual release bump workflow에서 bump branch push 및 CI dispatch까지 완료되었습니다.
- PR 생성은 GitHub Actions token 권한 제한으로 자동 생성되지 않아 수동으로 열었습니다.

## 브랜치 / 워크트리 / Branches and worktrees

- base: `master`
- branch: `codex/manual-bump-master-v0-2-1-9b2fe475`

## 리스크 또는 확인 포인트 / Risks or follow-ups

- stable tag / publish는 아직 실행하지 않았습니다.
- release 실행 전 최종 확인이 필요합니다.