### PR TITLE
ci: release gh repo 컨텍스트 추가

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -595,6 +595,7 @@ jobs:
       - publish-root-package
     env:
       GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
 
     steps:
       - name: Download root npm tarball


### PR DESCRIPTION
## 요약
- GitHub release job에 `GH_REPO`를 추가해 checkout 없는 환경에서도 `gh release`가 대상 repo를 정확히 찾도록 했습니다
- artifact download만 수행하는 release 마감 job이 `.git` 없는 작업 디렉터리에서 실패하던 문제를 막습니다

## 원인
- `Create or update GitHub release` job은 checkout 없이 `gh release view/edit/upload/create`를 호출했습니다
- 이 상태에서 `gh`가 로컬 git repository를 찾으려다 `fatal: not a git repository`로 종료했습니다

## 검증
- `actionlint .github/workflows/release.yml`
- `git diff --check`
- `/tmp`에서 `GH_REPO=JeremyDev87/kratos gh release view v0.2.1 --json tagName,url`
- 참고: 같은 `/tmp`에서 repo 지정 없이 `gh release view v0.2.1`은 `not a git repository`로 실패하는 것도 재현했습니다

## 메모
- release/tag/publish는 실행하지 않았습니다
- 이번 수정은 이미 npm publish가 끝난 뒤 마지막 GitHub release step에서만 터지던 blocker를 겨냥합니다