### PR TITLE
test: WOW-1B CLI 테스트 support 추출

### DIFF
--- a/crates/kratos-cli/tests/cli_smoke.rs
+++ b/crates/kratos-cli/tests/cli_smoke.rs
@@ -1,6 +1,7 @@
-use std::path::{Path, PathBuf};
-use std::process::Command;
-use std::time::{SystemTime, UNIX_EPOCH};
+mod support;
+
+use support::cli::{run_cli, run_cli_in_dir};
+use support::fs::{copy_demo_app, repo_root};
 
 #[test]
 fn root_help_matches_expected_shape() {
@@ -92,10 +93,6 @@ fn clean_accepts_legacy_v1_reports_through_cli() {
     assert!(String::from_utf8_lossy(&apply.stdout).contains("Kratos clean deleted 2 file(s)."));
     assert!(!project_root.join("src/components/DeadWidget.tsx").exists());
     assert!(!project_root.join("src/lib/broken.ts").exists());
-}
-
-fn run_cli(args: &[&str]) -> std::process::Output {
-    run_cli_in_dir(&repo_root(), args)
 }
 
 #[test]
@@ -354,57 +351,4 @@ fn empty_inline_boolean_flags_stay_falsey_like_js() {
     assert!(clean_stdout.contains("Kratos clean dry run."));
     assert!(project_root.join("src/components/DeadWidget.tsx").exists());
     assert!(project_root.join("src/lib/broken.ts").exists());
-}
-
-fn run_cli_in_dir(cwd: &Path, args: &[&str]) -> std::process::Output {
-    Command::new(cli_binary())
-        .args(args)
-        .current_dir(cwd)
-        .output()
-        .expect("cli command should run")
-}
-
-fn cli_binary() -> PathBuf {
-    PathBuf::from(env!("CARGO_BIN_EXE_kratos-cli"))
-}
-
-fn repo_root() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .ancestors()
-        .nth(2)
-        .expect("workspace root should exist")
-        .to_path_buf()
-}
-
-fn copy_demo_app(label: &str) -> PathBuf {
-    let destination = temp_dir(label).join("demo-app");
-    copy_directory(&repo_root().join("fixtures/demo-app"), &destination);
-    destination
-}
-
-fn copy_directory(source: &Path, destination: &Path) {
-    std::fs::create_dir_all(destination).expect("destination directory should exist");
-
-    for entry in std::fs::read_dir(source).expect("source directory should be readable") {
-        let entry = entry.expect("directory entry should load");
-        let source_path = entry.path();
-        let destination_path = destination.join(entry.file_name());
-        let file_type = entry.file_type().expect("file type should load");
-
-        if file_type.is_dir() {
-            copy_directory(&source_path, &destination_path);
-        } else if file_type.is_file() {
-            std::fs::copy(&source_path, &destination_path).expect("file should copy");
-        }
-    }
-}
-
-fn temp_dir(label: &str) -> PathBuf {
-    let unique = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("system time should be valid")
-        .as_nanos();
-    let path = std::env::temp_dir().join(format!("kratos-cli-{label}-{unique}"));
-    std::fs::create_dir_all(&path).expect("temp dir should be created");
-    path
 }

--- a/crates/kratos-cli/tests/support/cli.rs
+++ b/crates/kratos-cli/tests/support/cli.rs
@@ -1,0 +1,20 @@
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use super::fs::repo_root;
+
+pub fn run_cli(args: &[&str]) -> Output {
+    run_cli_in_dir(&repo_root(), args)
+}
+
+pub fn run_cli_in_dir(cwd: &Path, args: &[&str]) -> Output {
+    Command::new(cli_binary())
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .expect("cli command should run")
+}
+
+pub fn cli_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_kratos-cli"))
+}

--- a/crates/kratos-cli/tests/support/fs.rs
+++ b/crates/kratos-cli/tests/support/fs.rs
@@ -1,0 +1,43 @@
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("workspace root should exist")
+        .to_path_buf()
+}
+
+pub fn copy_demo_app(label: &str) -> PathBuf {
+    let destination = temp_dir(label).join("demo-app");
+    copy_directory(&repo_root().join("fixtures/demo-app"), &destination);
+    destination
+}
+
+pub fn copy_directory(source: &Path, destination: &Path) {
+    std::fs::create_dir_all(destination).expect("destination directory should exist");
+
+    for entry in std::fs::read_dir(source).expect("source directory should be readable") {
+        let entry = entry.expect("directory entry should load");
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        let file_type = entry.file_type().expect("file type should load");
+
+        if file_type.is_dir() {
+            copy_directory(&source_path, &destination_path);
+        } else if file_type.is_file() {
+            std::fs::copy(&source_path, &destination_path).expect("file should copy");
+        }
+    }
+}
+
+pub fn temp_dir(label: &str) -> PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be valid")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!("kratos-cli-{label}-{unique}"));
+    std::fs::create_dir_all(&path).expect("temp dir should be created");
+    path
+}

--- a/crates/kratos-cli/tests/support/mod.rs
+++ b/crates/kratos-cli/tests/support/mod.rs
@@ -1,0 +1,2 @@
+pub mod cli;
+pub mod fs;


### PR DESCRIPTION
## 배경
- WOW-1B의 목표는 CLI 통합 테스트 helper를 tests/support 경계로 추출해 이후 diff/sweep/watch/report-html 계열 테스트가 공용 support를 재사용할 수 있게 만드는 것입니다.
- 이번 변경은 런타임 코드를 건드리지 않고 테스트 지원 코드만 정리합니다.

## 변경 사항
- crates/kratos-cli/tests/support/mod.rs를 추가해 support 모듈 진입점을 만들었습니다.
- crates/kratos-cli/tests/support/cli.rs에 run_cli, run_cli_in_dir, cli_binary를 모아 CLI 실행 helper를 공용화했습니다.
- crates/kratos-cli/tests/support/fs.rs에 repo_root, copy_demo_app, copy_directory, temp_dir를 모아 fixture/tempdir helper를 공용화했습니다.
- crates/kratos-cli/tests/cli_smoke.rs는 기존 assertion 본문을 유지한 채 새 support helper를 사용하도록 바꿨습니다.

## 검증
- cargo test -p kratos-cli --test cli_smoke
- cargo test --workspace
- npm test

## 브랜치 / 워크트리
- target branch: codex/wow-1b-cli-test-support-extraction
- worktree: /Users/pjw/workspace/kratos

## 이슈 연결
- 별도 이슈 연결 없음