### PR TITLE
feat: WOW-2B Suppression Schema And Finding Filter

### DIFF
--- a/crates/kratos-core/src/analyze.rs
+++ b/crates/kratos-core/src/analyze.rs
@@ -9,11 +9,13 @@ use crate::entrypoints::detect_entrypoint_kind;
 use crate::error::KratosResult;
 use crate::model::{
     BrokenImportFinding, DeadExportFinding, DeletionCandidateFinding, EntrypointKind, ExportRecord,
-    ImportSpecifierKind, ImportUsageRecord, ModuleRecord, OrphanFileFinding, OrphanKind,
-    ProjectConfig, ReportV2, ResolvedImportRecord, RouteEntrypointFinding, UnusedImportFinding,
+    FindingSet, ImportSpecifierKind, ImportUsageRecord, ModuleRecord, OrphanFileFinding,
+    OrphanKind, ProjectConfig, ReportV2, ResolvedImportRecord, RouteEntrypointFinding,
+    SummaryCounts, UnusedImportFinding,
 };
 use crate::parser::parse_module_source;
 use crate::resolve::{resolve_import_target, unresolved_import};
+use crate::suppressions::{apply_suppressions, load_project_suppressions};
 
 const DEFAULT_CONFIG_FILENAME: &str = "kratos.config.json";
 
@@ -189,29 +191,38 @@ pub fn analyze_with_config(config: &ProjectConfig) -> KratosResult<ReportV2> {
         }
     }
 
+    let mut findings = FindingSet {
+        broken_imports: broken_imports,
+        orphan_files,
+        dead_exports,
+        unused_imports,
+        route_entrypoints,
+        deletion_candidates,
+    };
+    let suppressions = load_project_suppressions(config);
+    let suppressed_findings = apply_suppressions(&mut findings, &suppressions);
+
     let mut report = ReportV2::new(config.root.clone());
     report.generated_at = Some(current_timestamp());
     report.config_path = config.config_path.clone().or_else(|| {
         let candidate = config.root.join(DEFAULT_CONFIG_FILENAME);
         candidate.exists().then_some(candidate)
     });
-    report.summary.files_scanned = modules.len();
-    report.summary.entrypoints = modules
-        .values()
-        .filter(|module| module.entrypoint_kind.is_some())
-        .count();
-    report.summary.broken_imports = broken_imports.len();
-    report.summary.orphan_files = orphan_files.len();
-    report.summary.dead_exports = dead_exports.len();
-    report.summary.unused_imports = unused_imports.len();
-    report.summary.route_entrypoints = route_entrypoints.len();
-    report.summary.deletion_candidates = deletion_candidates.len();
-    report.findings.broken_imports = broken_imports;
-    report.findings.orphan_files = orphan_files;
-    report.findings.dead_exports = dead_exports;
-    report.findings.unused_imports = unused_imports;
-    report.findings.route_entrypoints = route_entrypoints;
-    report.findings.deletion_candidates = deletion_candidates;
+    report.summary = SummaryCounts {
+        files_scanned: modules.len(),
+        entrypoints: modules
+            .values()
+            .filter(|module| module.entrypoint_kind.is_some())
+            .count(),
+        broken_imports: findings.broken_imports.len(),
+        orphan_files: findings.orphan_files.len(),
+        dead_exports: findings.dead_exports.len(),
+        unused_imports: findings.unused_imports.len(),
+        route_entrypoints: findings.route_entrypoints.len(),
+        deletion_candidates: findings.deletion_candidates.len(),
+        suppressed_findings,
+    };
+    report.findings = findings;
     report.modules = modules
         .into_values()
         .map(|mut module| {

--- a/crates/kratos-core/src/config.rs
+++ b/crates/kratos-core/src/config.rs
@@ -5,6 +5,7 @@ use std::path::{Component, Path, PathBuf};
 use crate::error::KratosResult;
 use crate::jsonc::{parse_loose_json, JsonValue};
 use crate::model::{PathAlias, ProjectConfig};
+use crate::suppressions::{parse_suppression_rules, SuppressionSource};
 
 const DEFAULT_CONFIG_FILENAME: &str = "kratos.config.json";
 const PACKAGE_ENTRY_EXTENSIONS: &[&str] = &[
@@ -76,6 +77,11 @@ pub fn load_project_config(root: impl Into<PathBuf>) -> KratosResult<ProjectConf
             base_url.as_deref(),
         )?,
         external_packages: collect_external_packages(&package_json),
+        suppressions: parse_suppression_rules(
+            &root,
+            user_config.get("suppressions"),
+            SuppressionSource::Config,
+        ),
     })
 }
 
@@ -374,7 +380,7 @@ fn normalize_project_root(root: PathBuf) -> PathBuf {
     normalize_path(absolute)
 }
 
-fn resolve_path(root: &Path, value: &str) -> PathBuf {
+pub(crate) fn resolve_path(root: &Path, value: &str) -> PathBuf {
     let path = Path::new(value);
 
     if path.is_absolute() {

--- a/crates/kratos-core/src/lib.rs
+++ b/crates/kratos-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod parser;
 pub mod report;
 pub mod report_format;
 pub mod resolve;
+pub mod suppressions;
 
 pub use error::{KratosError, KratosResult};
 pub use model::*;

--- a/crates/kratos-core/src/model.rs
+++ b/crates/kratos-core/src/model.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeSet;
 use std::path::PathBuf;
 
+use crate::suppressions::SuppressionRule;
+
 pub const REPORT_V2: u32 = 2;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -14,6 +16,7 @@ pub struct ProjectConfig {
     pub package_entries: Vec<PathBuf>,
     pub path_aliases: Vec<PathAlias>,
     pub external_packages: BTreeSet<String>,
+    pub suppressions: Vec<SuppressionRule>,
 }
 
 impl ProjectConfig {
@@ -28,6 +31,7 @@ impl ProjectConfig {
             package_entries: Vec::new(),
             path_aliases: Vec::new(),
             external_packages: BTreeSet::new(),
+            suppressions: Vec::new(),
         }
     }
 }
@@ -182,6 +186,7 @@ pub struct SummaryCounts {
     pub unused_imports: usize,
     pub route_entrypoints: usize,
     pub deletion_candidates: usize,
+    pub suppressed_findings: usize,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/crates/kratos-core/src/report.rs
+++ b/crates/kratos-core/src/report.rs
@@ -167,16 +167,30 @@ pub fn format_markdown_report(report: &ReportV2, report_path: &Path) -> KratosRe
 }
 
 fn serialize_summary(summary: &SummaryCounts) -> Value {
-    json!({
-        "filesScanned": summary.files_scanned,
-        "entrypoints": summary.entrypoints,
-        "brokenImports": summary.broken_imports,
-        "orphanFiles": summary.orphan_files,
-        "deadExports": summary.dead_exports,
-        "unusedImports": summary.unused_imports,
-        "routeEntrypoints": summary.route_entrypoints,
-        "deletionCandidates": summary.deletion_candidates,
-    })
+    let mut summary_value = serde_json::Map::new();
+    summary_value.insert("filesScanned".to_string(), json!(summary.files_scanned));
+    summary_value.insert("entrypoints".to_string(), json!(summary.entrypoints));
+    summary_value.insert("brokenImports".to_string(), json!(summary.broken_imports));
+    summary_value.insert("orphanFiles".to_string(), json!(summary.orphan_files));
+    summary_value.insert("deadExports".to_string(), json!(summary.dead_exports));
+    summary_value.insert("unusedImports".to_string(), json!(summary.unused_imports));
+    summary_value.insert(
+        "routeEntrypoints".to_string(),
+        json!(summary.route_entrypoints),
+    );
+    summary_value.insert(
+        "deletionCandidates".to_string(),
+        json!(summary.deletion_candidates),
+    );
+
+    if summary.suppressed_findings > 0 {
+        summary_value.insert(
+            "suppressedFindings".to_string(),
+            json!(summary.suppressed_findings),
+        );
+    }
+
+    Value::Object(summary_value)
 }
 
 fn serialize_broken_import(item: &BrokenImportFinding) -> Value {
@@ -253,6 +267,7 @@ fn parse_summary(value: Option<&Value>) -> SummaryCounts {
         unused_imports: read_usize(value, "unusedImports"),
         route_entrypoints: read_usize(value, "routeEntrypoints"),
         deletion_candidates: read_usize(value, "deletionCandidates"),
+        suppressed_findings: read_usize(value, "suppressedFindings"),
     }
 }
 
@@ -273,6 +288,11 @@ fn parse_required_summary(value: &serde_json::Map<String, Value>) -> KratosResul
             value,
             "deletionCandidates",
             "summary.deletionCandidates",
+        )?,
+        suppressed_findings: read_optional_usize(
+            value,
+            "suppressedFindings",
+            "summary.suppressedFindings",
         )?,
     })
 }
@@ -812,6 +832,23 @@ fn read_required_usize(
         .and_then(Value::as_u64)
         .map(|number| number as usize)
         .ok_or_else(|| KratosError::Json(format!("Report is missing required number `{path}`")))
+}
+
+fn read_optional_usize(
+    value: &serde_json::Map<String, Value>,
+    key: &str,
+    path: &str,
+) -> KratosResult<usize> {
+    match value.get(key) {
+        None | Some(Value::Null) => Ok(0),
+        Some(Value::Number(number)) => number
+            .as_u64()
+            .map(|number| number as usize)
+            .ok_or_else(|| KratosError::Json(format!("Report has invalid number `{path}`"))),
+        Some(_) => Err(KratosError::Json(format!(
+            "Report has invalid number `{path}`"
+        ))),
+    }
 }
 
 fn read_required_f64(

--- a/crates/kratos-core/src/report_format.rs
+++ b/crates/kratos-core/src/report_format.rs
@@ -24,9 +24,15 @@ pub fn format_summary_report(
             "Deletion candidates: {}",
             report.summary.deletion_candidates
         ),
-        String::new(),
-        format!("Saved report: {}", path_to_string(report_path)),
     ];
+    if report.summary.suppressed_findings > 0 {
+        lines.push(format!(
+            "Suppressed findings: {}",
+            report.summary.suppressed_findings
+        ));
+    }
+    lines.push(String::new());
+    lines.push(format!("Saved report: {}", path_to_string(report_path)));
 
     append_preview(
         &mut lines,
@@ -86,8 +92,14 @@ pub fn format_markdown_report(report: &ReportV2, report_path: &Path) -> KratosRe
             "- Deletion candidates: {}",
             report.summary.deletion_candidates
         ),
-        String::new(),
     ];
+    if report.summary.suppressed_findings > 0 {
+        lines.push(format!(
+            "- Suppressed findings: {}",
+            report.summary.suppressed_findings
+        ));
+    }
+    lines.push(String::new());
 
     push_markdown_section(
         &mut lines,

--- a/crates/kratos-core/src/suppressions.rs
+++ b/crates/kratos-core/src/suppressions.rs
@@ -1,0 +1,267 @@
+use std::path::{Path, PathBuf};
+
+use crate::config::{resolve_config_path, resolve_path};
+use crate::jsonc::JsonValue;
+use crate::model::{
+    BrokenImportFinding, DeadExportFinding, DeletionCandidateFinding, FindingSet,
+    OrphanFileFinding, ProjectConfig, UnusedImportFinding,
+};
+
+const GENERATED_SUPPRESSIONS_PATH: &str = ".kratos/suppressions.json";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SuppressionSource {
+    Config,
+    Generated,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SuppressionKind {
+    BrokenImport,
+    OrphanFile,
+    DeadExport,
+    UnusedImport,
+    DeletionCandidate,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SuppressionRule {
+    pub kind: SuppressionKind,
+    pub file: PathBuf,
+    pub source: Option<String>,
+    pub local: Option<String>,
+    pub export: Option<String>,
+    pub reason: String,
+    pub origin: SuppressionSource,
+}
+
+pub fn parse_suppression_rules(
+    root: &Path,
+    value: Option<&JsonValue>,
+    origin: SuppressionSource,
+) -> Vec<SuppressionRule> {
+    let Some(entries) = value.and_then(JsonValue::as_array) else {
+        return Vec::new();
+    };
+
+    entries
+        .iter()
+        .filter_map(|entry| parse_suppression_rule(root, entry, origin))
+        .collect()
+}
+
+pub fn load_generated_suppressions(root: &Path) -> Vec<SuppressionRule> {
+    let path = resolve_config_path(root, GENERATED_SUPPRESSIONS_PATH);
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+
+    let Ok(value) = crate::jsonc::parse_loose_json(&content) else {
+        return Vec::new();
+    };
+
+    parse_suppression_rules(
+        root,
+        value.get("suppressions"),
+        SuppressionSource::Generated,
+    )
+}
+
+pub fn load_project_suppressions(config: &ProjectConfig) -> Vec<SuppressionRule> {
+    let mut suppressions = config.suppressions.clone();
+    suppressions.extend(load_generated_suppressions(&config.root));
+    suppressions
+}
+
+pub fn apply_suppressions(findings: &mut FindingSet, suppressions: &[SuppressionRule]) -> usize {
+    let mut suppressed = 0;
+
+    suppressed += filter_broken_imports(&mut findings.broken_imports, suppressions);
+    suppressed += filter_orphan_files(&mut findings.orphan_files, suppressions);
+    suppressed += filter_dead_exports(&mut findings.dead_exports, suppressions);
+    suppressed += filter_unused_imports(&mut findings.unused_imports, suppressions);
+    suppressed += filter_deletion_candidates(&mut findings.deletion_candidates, suppressions);
+
+    suppressed
+}
+
+fn parse_suppression_rule(
+    root: &Path,
+    value: &JsonValue,
+    origin: SuppressionSource,
+) -> Option<SuppressionRule> {
+    let object = value.as_object()?;
+
+    let kind = match object.get("kind").and_then(JsonValue::as_str) {
+        Some("brokenImport") => SuppressionKind::BrokenImport,
+        Some("orphanFile") => SuppressionKind::OrphanFile,
+        Some("deadExport") => SuppressionKind::DeadExport,
+        Some("unusedImport") => SuppressionKind::UnusedImport,
+        Some("deletionCandidate") => SuppressionKind::DeletionCandidate,
+        _ => return None,
+    };
+
+    let reason = read_required_non_empty_string(object.get("reason"))?;
+    let file = read_root_relative_path(root, object.get("file").and_then(JsonValue::as_str)?)?;
+    let source = read_optional_exact_string(object.get("source"))?;
+    let local = read_optional_exact_string(object.get("local"))?;
+    let export = read_optional_exact_string(object.get("export"))?;
+
+    Some(SuppressionRule {
+        kind,
+        file,
+        source,
+        local,
+        export,
+        reason,
+        origin,
+    })
+}
+
+fn read_root_relative_path(root: &Path, raw: &str) -> Option<PathBuf> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return None;
+    }
+
+    let raw_path = Path::new(raw);
+    if raw_path.is_absolute() {
+        return None;
+    }
+
+    let resolved = resolve_path(root, raw);
+    let Ok(relative) = resolved.strip_prefix(root) else {
+        return None;
+    };
+
+    if relative.as_os_str().is_empty() {
+        return None;
+    }
+
+    Some(resolved)
+}
+
+fn read_required_non_empty_string(value: Option<&JsonValue>) -> Option<String> {
+    let value = value?.as_str()?.trim().to_string();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value)
+    }
+}
+
+fn read_optional_exact_string(value: Option<&JsonValue>) -> Option<Option<String>> {
+    let Some(value) = value else {
+        return Some(None);
+    };
+
+    match value {
+        JsonValue::Null => Some(None),
+        JsonValue::String(value) => {
+            let value = value.trim().to_string();
+            if value.is_empty() {
+                None
+            } else {
+                Some(Some(value))
+            }
+        }
+        _ => None,
+    }
+}
+
+fn filter_broken_imports(
+    findings: &mut Vec<BrokenImportFinding>,
+    suppressions: &[SuppressionRule],
+) -> usize {
+    let before = findings.len();
+    findings.retain(|item| !matches_broken_import(item, suppressions));
+    before - findings.len()
+}
+
+fn filter_orphan_files(
+    findings: &mut Vec<OrphanFileFinding>,
+    suppressions: &[SuppressionRule],
+) -> usize {
+    let before = findings.len();
+    findings.retain(|item| !matches_orphan_file(item, suppressions));
+    before - findings.len()
+}
+
+fn filter_dead_exports(
+    findings: &mut Vec<DeadExportFinding>,
+    suppressions: &[SuppressionRule],
+) -> usize {
+    let before = findings.len();
+    findings.retain(|item| !matches_dead_export(item, suppressions));
+    before - findings.len()
+}
+
+fn filter_unused_imports(
+    findings: &mut Vec<UnusedImportFinding>,
+    suppressions: &[SuppressionRule],
+) -> usize {
+    let before = findings.len();
+    findings.retain(|item| !matches_unused_import(item, suppressions));
+    before - findings.len()
+}
+
+fn filter_deletion_candidates(
+    findings: &mut Vec<DeletionCandidateFinding>,
+    suppressions: &[SuppressionRule],
+) -> usize {
+    let before = findings.len();
+    findings.retain(|item| !matches_deletion_candidate(item, suppressions));
+    before - findings.len()
+}
+
+fn matches_broken_import(item: &BrokenImportFinding, suppressions: &[SuppressionRule]) -> bool {
+    suppressions.iter().any(|suppression| {
+        suppression.kind == SuppressionKind::BrokenImport
+            && suppression.file == item.file
+            && suppression
+                .source
+                .as_ref()
+                .map_or(true, |source| source == &item.source)
+    })
+}
+
+fn matches_orphan_file(item: &OrphanFileFinding, suppressions: &[SuppressionRule]) -> bool {
+    suppressions.iter().any(|suppression| {
+        suppression.kind == SuppressionKind::OrphanFile && suppression.file == item.file
+    })
+}
+
+fn matches_dead_export(item: &DeadExportFinding, suppressions: &[SuppressionRule]) -> bool {
+    suppressions.iter().any(|suppression| {
+        suppression.kind == SuppressionKind::DeadExport
+            && suppression.file == item.file
+            && suppression
+                .export
+                .as_ref()
+                .map_or(true, |export| export == &item.export_name)
+    })
+}
+
+fn matches_unused_import(item: &UnusedImportFinding, suppressions: &[SuppressionRule]) -> bool {
+    suppressions.iter().any(|suppression| {
+        suppression.kind == SuppressionKind::UnusedImport
+            && suppression.file == item.file
+            && suppression
+                .source
+                .as_ref()
+                .map_or(true, |source| source == &item.source)
+            && suppression
+                .local
+                .as_ref()
+                .map_or(true, |local| local == &item.local)
+    })
+}
+
+fn matches_deletion_candidate(
+    item: &DeletionCandidateFinding,
+    suppressions: &[SuppressionRule],
+) -> bool {
+    suppressions.iter().any(|suppression| {
+        suppression.kind == SuppressionKind::DeletionCandidate && suppression.file == item.file
+    })
+}

--- a/crates/kratos-core/tests/config_and_discovery.rs
+++ b/crates/kratos-core/tests/config_and_discovery.rs
@@ -6,6 +6,7 @@ use kratos_core::jsonc::parse_loose_json;
 use kratos_core::jsonc::JsonValue;
 use kratos_core::model::ImportResolutionKind;
 use kratos_core::resolve::resolve_import_target;
+use kratos_core::suppressions::SuppressionKind;
 
 #[test]
 fn load_project_config_parses_comments_and_collects_entries() {
@@ -96,6 +97,73 @@ fn load_project_config_parses_comments_and_collects_entries() {
             .contains(&project.root().to_path_buf()),
         "empty export targets should be ignored"
     );
+}
+
+#[test]
+fn load_project_config_parses_suppressions_and_ignores_invalid_rules() {
+    let project = TestProject::new("suppression-config");
+    project.write(
+        "kratos.config.json",
+        r#"{
+  "suppressions": [
+    {
+      "kind": "brokenImport",
+      "file": "src/app/main.ts",
+      "source": "./missing",
+      "reason": "known missing shim"
+    },
+    {
+      "kind": "deadExport",
+      "file": "src/components/LazyCard.tsx",
+      "export": "default",
+      "reason": "loaded dynamically"
+    },
+    {
+      "kind": "deadExport",
+      "file": "../escape.ts",
+      "reason": "should be ignored"
+    },
+    {
+      "kind": "unusedImport",
+      "file": "/tmp/abs.ts",
+      "source": "./abs",
+      "local": "abs",
+      "reason": "should be ignored"
+    },
+    {
+      "kind": "unusedImport",
+      "file": "src/app/main.ts",
+      "source": 123,
+      "local": "main",
+      "reason": "should be ignored"
+    },
+    {
+      "kind": "deadExport",
+      "file": "src/app/main.ts",
+      "reason": ""
+    }
+  ]
+}
+"#,
+    );
+
+    let config = load_project_config(project.root()).expect("config should load");
+
+    assert_eq!(config.suppressions.len(), 2);
+    assert_eq!(config.suppressions[0].kind, SuppressionKind::BrokenImport);
+    assert_eq!(
+        config.suppressions[0].file,
+        project.root().join("src/app/main.ts")
+    );
+    assert_eq!(config.suppressions[0].source.as_deref(), Some("./missing"));
+    assert_eq!(config.suppressions[0].reason, "known missing shim");
+    assert_eq!(config.suppressions[1].kind, SuppressionKind::DeadExport);
+    assert_eq!(
+        config.suppressions[1].file,
+        project.root().join("src/components/LazyCard.tsx")
+    );
+    assert_eq!(config.suppressions[1].export.as_deref(), Some("default"));
+    assert_eq!(config.suppressions[1].reason, "loaded dynamically");
 }
 
 #[test]

--- a/crates/kratos-core/tests/suppressions.rs
+++ b/crates/kratos-core/tests/suppressions.rs
@@ -1,0 +1,295 @@
+use std::path::{Path, PathBuf};
+
+use kratos_core::analyze::analyze_project;
+use kratos_core::model::{
+    BrokenImportFinding, DeadExportFinding, DeletionCandidateFinding, EntrypointKind, FindingSet,
+    ImportKind, OrphanFileFinding, OrphanKind, RouteEntrypointFinding, UnusedImportFinding,
+};
+use kratos_core::report::{parse_report_json, serialize_report_pretty};
+use kratos_core::report_format::{format_markdown_report, format_summary_report};
+use kratos_core::suppressions::{
+    apply_suppressions, load_project_suppressions, SuppressionKind, SuppressionRule,
+    SuppressionSource,
+};
+
+#[test]
+fn load_project_suppressions_merges_config_and_generated_rules() {
+    let project = TestProject::new("suppression-loading");
+    project.write(
+        "kratos.config.json",
+        r#"{
+  "suppressions": [
+    {
+      "kind": "brokenImport",
+      "file": "src/index.ts",
+      "source": "./missing",
+      "reason": "config rule"
+    }
+  ]
+}
+"#,
+    );
+    project.write(
+        ".kratos/suppressions.json",
+        r#"{
+  "suppressions": [
+    {
+      "kind": "deadExport",
+      "file": "src/feature.ts",
+      "export": "helper",
+      "reason": "generated rule"
+    },
+    {
+      "kind": "deadExport",
+      "file": "../escape.ts",
+      "reason": "ignored"
+    }
+  ]
+}
+"#,
+    );
+
+    let config = kratos_core::config::load_project_config(project.root()).expect("config loads");
+    let suppressions = load_project_suppressions(&config);
+
+    assert_eq!(suppressions.len(), 2);
+    assert_eq!(suppressions[0].origin, SuppressionSource::Config);
+    assert_eq!(suppressions[1].origin, SuppressionSource::Generated);
+    assert_eq!(suppressions[0].file, project.root().join("src/index.ts"));
+    assert_eq!(suppressions[1].file, project.root().join("src/feature.ts"));
+}
+
+#[test]
+fn apply_suppressions_matches_exact_fields_and_counts_each_finding_once() {
+    let root = project_root("suppression-match");
+    let mut findings = FindingSet {
+        broken_imports: vec![
+            BrokenImportFinding {
+                file: root.join("src/index.ts"),
+                source: "./missing-a".to_string(),
+                kind: ImportKind::Static,
+            },
+            BrokenImportFinding {
+                file: root.join("src/index.ts"),
+                source: "./missing-b".to_string(),
+                kind: ImportKind::Static,
+            },
+        ],
+        orphan_files: vec![OrphanFileFinding {
+            file: root.join("src/orphan.ts"),
+            kind: OrphanKind::Module,
+            reason: "orphan".to_string(),
+            confidence: 0.9,
+        }],
+        dead_exports: vec![
+            DeadExportFinding {
+                file: root.join("src/dead.ts"),
+                export_name: "default".to_string(),
+            },
+            DeadExportFinding {
+                file: root.join("src/dead.ts"),
+                export_name: "helper".to_string(),
+            },
+        ],
+        unused_imports: vec![
+            UnusedImportFinding {
+                file: root.join("src/unused.ts"),
+                source: "./lib".to_string(),
+                local: "lib".to_string(),
+                imported: "lib".to_string(),
+            },
+            UnusedImportFinding {
+                file: root.join("src/unused.ts"),
+                source: "./lib".to_string(),
+                local: "other".to_string(),
+                imported: "other".to_string(),
+            },
+        ],
+        route_entrypoints: vec![RouteEntrypointFinding {
+            file: root.join("src/route.ts"),
+            kind: EntrypointKind::NextAppRoute,
+        }],
+        deletion_candidates: vec![DeletionCandidateFinding {
+            file: root.join("src/delete.ts"),
+            reason: "delete".to_string(),
+            confidence: 0.8,
+            safe: true,
+        }],
+    };
+
+    let suppressions = vec![
+        SuppressionRule {
+            kind: SuppressionKind::BrokenImport,
+            file: root.join("src/index.ts"),
+            source: Some("./missing-a".to_string()),
+            local: None,
+            export: None,
+            reason: "config".to_string(),
+            origin: SuppressionSource::Config,
+        },
+        SuppressionRule {
+            kind: SuppressionKind::BrokenImport,
+            file: root.join("src/index.ts"),
+            source: Some("./missing-a".to_string()),
+            local: None,
+            export: None,
+            reason: "generated".to_string(),
+            origin: SuppressionSource::Generated,
+        },
+        SuppressionRule {
+            kind: SuppressionKind::OrphanFile,
+            file: root.join("src/orphan.ts"),
+            source: None,
+            local: None,
+            export: None,
+            reason: "config".to_string(),
+            origin: SuppressionSource::Config,
+        },
+        SuppressionRule {
+            kind: SuppressionKind::DeadExport,
+            file: root.join("src/dead.ts"),
+            source: None,
+            local: None,
+            export: Some("default".to_string()),
+            reason: "config".to_string(),
+            origin: SuppressionSource::Config,
+        },
+        SuppressionRule {
+            kind: SuppressionKind::UnusedImport,
+            file: root.join("src/unused.ts"),
+            source: Some("./lib".to_string()),
+            local: Some("lib".to_string()),
+            export: None,
+            reason: "config".to_string(),
+            origin: SuppressionSource::Config,
+        },
+        SuppressionRule {
+            kind: SuppressionKind::DeletionCandidate,
+            file: root.join("src/delete.ts"),
+            source: None,
+            local: None,
+            export: None,
+            reason: "config".to_string(),
+            origin: SuppressionSource::Config,
+        },
+    ];
+
+    let suppressed = apply_suppressions(&mut findings, &suppressions);
+
+    assert_eq!(suppressed, 5);
+    assert_eq!(findings.broken_imports.len(), 1);
+    assert_eq!(findings.broken_imports[0].source, "./missing-b");
+    assert!(findings.orphan_files.is_empty());
+    assert_eq!(findings.dead_exports.len(), 1);
+    assert_eq!(findings.dead_exports[0].export_name, "helper");
+    assert_eq!(findings.unused_imports.len(), 1);
+    assert_eq!(findings.unused_imports[0].local, "other");
+    assert_eq!(findings.route_entrypoints.len(), 1);
+    assert!(findings.deletion_candidates.is_empty());
+}
+
+#[test]
+fn analyze_project_surfaces_suppressed_findings_in_summary_and_formatters() {
+    let project = TestProject::new("suppression-analysis");
+    project.write(
+        "kratos.config.json",
+        r#"{
+  "suppressions": [
+    {
+      "kind": "brokenImport",
+      "file": "src/index.ts",
+      "source": "./missing",
+      "reason": "config rule"
+    }
+  ]
+}
+"#,
+    );
+    project.write(
+        ".kratos/suppressions.json",
+        r#"{
+  "suppressions": [
+    {
+      "kind": "deadExport",
+      "file": "src/feature.ts",
+      "export": "helper",
+      "reason": "generated rule"
+    },
+    {
+      "kind": "deletionCandidate",
+      "file": "src/feature.ts",
+      "reason": "generated rule"
+    }
+  ]
+}
+"#,
+    );
+    project.write(
+        "src/index.ts",
+        "import './missing';\nexport const main = true;\n",
+    );
+    project.write("src/feature.ts", "export const helper = true;\n");
+
+    let report = analyze_project(project.root()).expect("analysis should succeed");
+    let report_path = project.root().join(".kratos/latest-report.json");
+    let summary = format_summary_report(&report, &report_path, "Kratos scan complete.")
+        .expect("summary should format");
+    let markdown = format_markdown_report(&report, &report_path).expect("markdown should format");
+    let serialized = serialize_report_pretty(&report).expect("report should serialize");
+    let parsed = parse_report_json(&serialized).expect("serialized report should parse");
+
+    assert_eq!(report.findings.broken_imports.len(), 0);
+    assert_eq!(report.findings.dead_exports.len(), 0);
+    assert_eq!(report.findings.deletion_candidates.len(), 0);
+    assert_eq!(report.summary.suppressed_findings, 3);
+    assert_eq!(parsed.summary.suppressed_findings, 3);
+    assert!(summary.contains("Suppressed findings: 3"));
+    assert!(markdown.contains("- Suppressed findings: 3"));
+    assert!(
+        serialized.contains("\"suppressedFindings\": 3"),
+        "expected optional suppressed findings field in serialized report"
+    );
+}
+
+fn project_root(label: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "kratos-{label}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("time should move forward")
+            .as_nanos()
+    ))
+}
+
+struct TestProject {
+    root: PathBuf,
+}
+
+impl TestProject {
+    fn new(label: &str) -> Self {
+        let root = project_root(label);
+        std::fs::create_dir_all(&root).expect("temp project should be created");
+        Self { root }
+    }
+
+    fn root(&self) -> &Path {
+        &self.root
+    }
+
+    fn write(&self, relative: &str, contents: &str) {
+        let path = self.root.join(relative);
+
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("parent directories should exist");
+        }
+
+        std::fs::write(path, contents).expect("file should be written");
+    }
+}
+
+impl Drop for TestProject {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}


### PR DESCRIPTION
배경
- exact suppression이 없어 결과 신뢰도를 사람이 수동으로만 보정해야 했고, report summary에도 suppression 적용 사실이 드러나지 않았습니다.
- WOW roadmap의 Analysis Trust 단계에서 config/generated suppression을 함께 읽고 finding filter에 반영합니다.

변경 사항
- kratos.config.json의 suppressions와 .kratos/suppressions.json을 exact-match 규칙으로 읽도록 추가했습니다.
- 잘못된 suppression rule은 전체 scan을 실패시키지 않고 rule 단위로 무시합니다.
- raw finding 계산 뒤 suppression filter를 적용하고 suppressed findings 수를 summary에 반영합니다.
- report JSON에는 schemaVersion 2를 유지한 채 summary.suppressedFindings를 optional field로 직렬화합니다.
- human summary / markdown formatter에 suppressed findings를 노출하고 회귀 테스트를 추가했습니다.

검증
- cargo test --workspace
- npm run verify

브랜치 / 워크트리
- target branch: codex/wow-2b-suppression-schema-filter
- worktree: /Users/pjw/workspace/kratos

이슈 연결
- 없음