### PR TITLE
feat: WOW-3A clean threshold 정책 추가

### DIFF
--- a/crates/kratos-cli/src/commands/clean.rs
+++ b/crates/kratos-cli/src/commands/clean.rs
@@ -1,27 +1,25 @@
 use std::fs;
 use std::io::Write;
 
-use clap::Parser;
-use kratos_core::clean::clean_from_report;
+use kratos_core::clean::{clean_from_report_with_min_confidence, plan_clean_candidates};
+use kratos_core::config::load_clean_min_confidence;
 use kratos_core::report::parse_report_json;
 use kratos_core::KratosResult;
 
-use super::{canonicalize_clean_args, resolve_report_input, write_output, CommandSpec};
+use super::{parse_cli_options, resolve_report_input, write_output, CommandSpec, ParsedFlagValue};
 
 pub const NAME: &str = "clean";
 pub const SPEC: CommandSpec = CommandSpec {
     name: NAME,
     summary: "Show deletion candidates or delete them with --apply.",
-    usage: &["kratos clean [report-path-or-root] [--apply]"],
+    usage: &["kratos clean [report-path-or-root] [--apply] [--min-confidence value]"],
 };
 
-#[derive(Debug, Parser)]
-#[command(disable_help_flag = true, disable_version_flag = true)]
+#[derive(Debug, Default)]
 struct CleanArgs {
-    #[arg(allow_hyphen_values = true)]
     input: Option<String>,
-    #[arg(long)]
     apply: bool,
+    min_confidence: Option<f32>,
 }
 
 pub fn run(args: &[String], stdout: &mut dyn Write) -> KratosResult<i32> {
@@ -30,38 +28,137 @@ pub fn run(args: &[String], stdout: &mut dyn Write) -> KratosResult<i32> {
     let report_path = resolve_report_input(args.input.as_deref(), &cwd);
     let raw = fs::read_to_string(&report_path)?;
     let report = parse_report_json(&raw)?;
-    let candidates = &report.findings.deletion_candidates;
 
-    if candidates.is_empty() {
+    if report.findings.deletion_candidates.is_empty() {
         write_output(stdout, "Kratos clean found no deletion candidates.")?;
         return Ok(0);
     }
 
+    let min_confidence = match args.min_confidence {
+        Some(value) => value,
+        None => load_clean_min_confidence(&report.root)?,
+    };
+
     if !args.apply {
-        let mut lines = vec!["Kratos clean dry run.".to_string(), String::new()];
-        for candidate in candidates {
-            lines.push(format!(
-                "- {} ({})",
-                candidate.file.display(),
-                candidate.reason
-            ));
-        }
-        lines.push(String::new());
-        lines.push("Re-run with --apply to delete these files.".to_string());
-        write_output(stdout, &lines.join("\n"))?;
+        let plan = plan_clean_candidates(&report, min_confidence)?;
+        write_output(stdout, &format_clean_plan(&plan))?;
         return Ok(0);
     }
 
-    let outcome = clean_from_report(&report, true)?;
+    let outcome = clean_from_report_with_min_confidence(&report, min_confidence)?;
     write_output(
         stdout,
-        &format!("Kratos clean deleted {} file(s).", outcome.deleted_files),
+        &format!(
+            "Kratos clean deleted {} file(s).\nskipped_files: {}",
+            outcome.deleted_files, outcome.skipped_files
+        ),
     )?;
     Ok(0)
 }
 
 fn parse_args(args: &[String]) -> KratosResult<CleanArgs> {
-    let canonical = canonicalize_clean_args(args);
-    CleanArgs::try_parse_from(std::iter::once(NAME).chain(canonical.iter().map(String::as_str)))
-        .map_err(|error| kratos_core::KratosError::Config(error.to_string().trim().to_string()))
+    let parsed = parse_cli_options(args, &["min-confidence"], &["apply"]);
+    if parsed.positionals.len() > 1 {
+        return Err(kratos_core::KratosError::Config(
+            "clean accepts at most one report-path-or-root argument".to_string(),
+        ));
+    }
+
+    let mut cleaned = CleanArgs {
+        input: parsed.positionals.first().cloned(),
+        apply: parse_apply_flag(parsed.flags.get("apply"))?,
+        min_confidence: None,
+    };
+
+    if let Some(value) = parsed.flags.get("min-confidence") {
+        cleaned.min_confidence = Some(parse_min_confidence(value)?);
+    }
+
+    Ok(cleaned)
+}
+
+fn parse_apply_flag(value: Option<&ParsedFlagValue>) -> KratosResult<bool> {
+    match value {
+        Some(ParsedFlagValue::Present) => Ok(true),
+        Some(ParsedFlagValue::Value(raw)) => parse_explicit_boolean(raw),
+        None => Ok(false),
+    }
+}
+
+fn parse_explicit_boolean(raw: &str) -> KratosResult<bool> {
+    let normalized = raw.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        "" => Ok(false),
+        "true" | "1" | "yes" | "on" => Ok(true),
+        "false" | "0" | "no" | "off" => Ok(false),
+        _ => Err(kratos_core::KratosError::Config(
+            "--apply must be a boolean flag or an explicit boolean value".to_string(),
+        )),
+    }
+}
+
+fn parse_min_confidence(value: &ParsedFlagValue) -> KratosResult<f32> {
+    let raw = match value {
+        ParsedFlagValue::Present => {
+            return Err(kratos_core::KratosError::Config(
+                "--min-confidence requires a value".to_string(),
+            ))
+        }
+        ParsedFlagValue::Value(raw) => raw.trim(),
+    };
+
+    if raw.is_empty() {
+        return Err(kratos_core::KratosError::Config(
+            "--min-confidence requires a value".to_string(),
+        ));
+    }
+
+    let parsed = raw.parse::<f32>().map_err(|_| {
+        kratos_core::KratosError::Config("--min-confidence must be between 0.0 and 1.0".to_string())
+    })?;
+
+    if !parsed.is_finite() || !(0.0..=1.0).contains(&parsed) {
+        return Err(kratos_core::KratosError::Config(
+            "--min-confidence must be between 0.0 and 1.0".to_string(),
+        ));
+    }
+
+    Ok(parsed)
+}
+
+fn format_clean_plan(plan: &kratos_core::clean::CleanThresholdPlan) -> String {
+    let mut lines = vec![
+        "Kratos clean dry run.".to_string(),
+        String::new(),
+        format!("Deletion targets: {}", plan.deletion_targets.len()),
+    ];
+
+    for candidate in &plan.deletion_targets {
+        lines.push(format_candidate_line(candidate));
+    }
+
+    if !plan.threshold_skipped_targets.is_empty() {
+        lines.push(String::new());
+        lines.push(format!(
+            "Threshold-skipped targets: {}",
+            plan.threshold_skipped_targets.len()
+        ));
+
+        for candidate in &plan.threshold_skipped_targets {
+            lines.push(format_candidate_line(candidate));
+        }
+    }
+
+    lines.push(String::new());
+    lines.push("Re-run with --apply to delete these files.".to_string());
+    lines.join("\n")
+}
+
+fn format_candidate_line(candidate: &kratos_core::model::DeletionCandidateFinding) -> String {
+    format!(
+        "- {} (confidence {:.2}, {})",
+        candidate.file.display(),
+        candidate.confidence,
+        candidate.reason
+    )
 }

--- a/crates/kratos-cli/tests/clean_threshold_cli.rs
+++ b/crates/kratos-cli/tests/clean_threshold_cli.rs
@@ -1,0 +1,259 @@
+mod support;
+
+use serde_json::json;
+
+use support::cli::run_cli_in_dir;
+use support::fs::temp_dir;
+
+#[test]
+fn clean_uses_config_threshold_and_flag_override() {
+    let project_root = temp_dir("clean-threshold-cli");
+    write_clean_threshold_fixture(&project_root, 0.98, 0.96, 0.75);
+
+    let dry_run = run_cli_in_dir(&project_root, &["clean"]);
+    assert!(dry_run.status.success());
+    let dry_run_stdout = String::from_utf8_lossy(&dry_run.stdout);
+    assert!(dry_run_stdout.contains("Kratos clean dry run."));
+    assert!(dry_run_stdout.contains("Deletion targets: 0"));
+    assert!(dry_run_stdout.contains("Threshold-skipped targets: 2"));
+    assert!(dry_run_stdout.contains("high-confidence.ts"));
+    assert!(dry_run_stdout.contains("mid-confidence.ts"));
+
+    let overridden = run_cli_in_dir(&project_root, &["clean", "--min-confidence", "0.9"]);
+    assert!(overridden.status.success());
+    let overridden_stdout = String::from_utf8_lossy(&overridden.stdout);
+    assert!(overridden_stdout.contains("Deletion targets: 1"));
+    assert!(overridden_stdout.contains("Threshold-skipped targets: 1"));
+    assert!(overridden_stdout.contains("high-confidence.ts"));
+    assert!(overridden_stdout.contains("mid-confidence.ts"));
+
+    let apply = run_cli_in_dir(
+        &project_root,
+        &["clean", "--apply", "--min-confidence", "0.9"],
+    );
+    assert!(apply.status.success());
+    let apply_stdout = String::from_utf8_lossy(&apply.stdout);
+    assert!(apply_stdout.contains("Kratos clean deleted 1 file(s)."));
+    assert!(apply_stdout.contains("skipped_files: 1"));
+    assert!(!project_root.join("high-confidence.ts").exists());
+    assert!(project_root.join("mid-confidence.ts").exists());
+}
+
+#[test]
+fn clean_rejects_out_of_range_min_confidence_values() {
+    let project_root = temp_dir("clean-threshold-cli-invalid");
+    write_clean_threshold_fixture(&project_root, 0.50, 0.40, 0.20);
+
+    let output = run_cli_in_dir(&project_root, &["clean", "--min-confidence", "1.5"]);
+    assert_eq!(output.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&output.stderr)
+        .contains("--min-confidence must be between 0.0 and 1.0"));
+}
+
+#[test]
+fn clean_rejects_invalid_thresholds_config_shape() {
+    let project_root = temp_dir("clean-threshold-cli-invalid-config-shape");
+    write_clean_threshold_fixture(&project_root, 0.50, 0.40, 0.20);
+    std::fs::write(
+        project_root.join("kratos.config.json"),
+        "{\n  \"thresholds\": []\n}\n",
+    )
+    .expect("config should write");
+
+    let output = run_cli_in_dir(&project_root, &["clean"]);
+    assert_eq!(output.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&output.stderr).contains(
+        "thresholds must be an object when specifying thresholds.cleanMinConfidence"
+    ));
+}
+
+#[test]
+fn clean_noop_ignores_invalid_thresholds_config_shape() {
+    let project_root = temp_dir("clean-threshold-cli-noop-invalid-config-shape");
+    write_clean_threshold_fixture(&project_root, 0.50, 0.40, 0.20);
+    std::fs::write(
+        project_root.join("kratos.config.json"),
+        "{\n  \"thresholds\": []\n}\n",
+    )
+    .expect("config should write");
+
+    let report_path = project_root.join(".kratos/latest-report.json");
+    let mut report: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(&report_path).expect("report should read"),
+    )
+    .expect("report should parse");
+    report["summary"]["deletionCandidates"] = json!(0);
+    report["findings"]["deletionCandidates"] = json!([]);
+    std::fs::write(
+        &report_path,
+        serde_json::to_string_pretty(&report).expect("report should serialize"),
+    )
+    .expect("report should write");
+
+    let output = run_cli_in_dir(&project_root, &["clean"]);
+    assert!(output.status.success());
+    assert!(String::from_utf8_lossy(&output.stdout).contains("Kratos clean found no deletion candidates."));
+}
+
+#[test]
+fn clean_apply_false_stays_dry_run() {
+    let project_root = temp_dir("clean-threshold-cli-apply-false");
+    write_clean_threshold_fixture(&project_root, 0.50, 0.40, 0.20);
+
+    let output = run_cli_in_dir(
+        &project_root,
+        &["clean", "--apply=false", "--min-confidence", "0.3"],
+    );
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Kratos clean dry run."));
+    assert!(project_root.join("high-confidence.ts").exists());
+    assert!(project_root.join("mid-confidence.ts").exists());
+}
+
+#[test]
+fn clean_apply_empty_string_stays_dry_run() {
+    let project_root = temp_dir("clean-threshold-cli-apply-empty");
+    write_clean_threshold_fixture(&project_root, 0.50, 0.40, 0.20);
+
+    let output = run_cli_in_dir(
+        &project_root,
+        &["clean", "--apply=", "--min-confidence", "0.3"],
+    );
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Kratos clean dry run."));
+    assert!(project_root.join("high-confidence.ts").exists());
+    assert!(project_root.join("mid-confidence.ts").exists());
+}
+
+#[test]
+fn clean_rejects_invalid_apply_value() {
+    let project_root = temp_dir("clean-threshold-cli-apply-invalid");
+    write_clean_threshold_fixture(&project_root, 0.50, 0.40, 0.20);
+
+    let output = run_cli_in_dir(
+        &project_root,
+        &["clean", "--apply=maybe", "--min-confidence", "0.3"],
+    );
+    assert_eq!(output.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&output.stderr)
+        .contains("--apply must be a boolean flag or an explicit boolean value"));
+    assert!(project_root.join("high-confidence.ts").exists());
+    assert!(project_root.join("mid-confidence.ts").exists());
+}
+
+#[test]
+fn clean_rejects_surplus_positionals() {
+    let project_root = temp_dir("clean-threshold-cli-surplus-positionals");
+    write_clean_threshold_fixture(&project_root, 0.50, 0.40, 0.20);
+
+    let report_path = project_root.join(".kratos/latest-report.json");
+    let output = run_cli_in_dir(
+        &project_root,
+        &[
+            "clean",
+            report_path.to_str().expect("path should be utf8"),
+            "extra",
+        ],
+    );
+    assert_eq!(output.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&output.stderr)
+        .contains("clean accepts at most one report-path-or-root argument"));
+}
+
+#[test]
+fn clean_rejects_missing_threshold_key_when_thresholds_is_present() {
+    let project_root = temp_dir("clean-threshold-cli-missing-threshold-key");
+    write_clean_threshold_fixture(&project_root, 0.50, 0.40, 0.20);
+    std::fs::write(
+        project_root.join("kratos.config.json"),
+        "{\n  \"thresholds\": {}\n}\n",
+    )
+    .expect("config should write");
+
+    let output = run_cli_in_dir(&project_root, &["clean"]);
+    assert_eq!(output.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&output.stderr)
+        .contains("thresholds.cleanMinConfidence is required when thresholds is present"));
+}
+
+fn write_clean_threshold_fixture(
+    project_root: &std::path::Path,
+    config_threshold: f32,
+    high_confidence: f32,
+    mid_confidence: f32,
+) {
+    std::fs::create_dir_all(project_root.join(".kratos")).expect("report dir should exist");
+    std::fs::create_dir_all(project_root.join("src")).expect("source dir should exist");
+    std::fs::write(
+        project_root.join("kratos.config.json"),
+        serde_json::to_string_pretty(&json!({
+            "thresholds": {
+                "cleanMinConfidence": config_threshold,
+            }
+        }))
+        .expect("config should serialize"),
+    )
+    .expect("config should write");
+
+    std::fs::write(
+        project_root.join("high-confidence.ts"),
+        "export const high = true;\n",
+    )
+    .expect("high file should write");
+    std::fs::write(
+        project_root.join("mid-confidence.ts"),
+        "export const mid = true;\n",
+    )
+    .expect("mid file should write");
+
+    let report = json!({
+        "schemaVersion": 2,
+        "generatedAt": "2026-04-21T00:00:00Z",
+        "project": {
+            "root": project_root,
+            "configPath": project_root.join("kratos.config.json"),
+        },
+        "summary": {
+            "filesScanned": 2,
+            "entrypoints": 0,
+            "brokenImports": 0,
+            "orphanFiles": 0,
+            "deadExports": 0,
+            "unusedImports": 0,
+            "routeEntrypoints": 0,
+            "deletionCandidates": 2,
+        },
+        "findings": {
+            "brokenImports": [],
+            "orphanFiles": [],
+            "deadExports": [],
+            "unusedImports": [],
+            "routeEntrypoints": [],
+            "deletionCandidates": [
+                {
+                    "file": project_root.join("high-confidence.ts"),
+                    "reason": "high confidence candidate",
+                    "confidence": high_confidence,
+                    "safe": true,
+                },
+                {
+                    "file": project_root.join("mid-confidence.ts"),
+                    "reason": "mid confidence candidate",
+                    "confidence": mid_confidence,
+                    "safe": true,
+                }
+            ],
+        },
+        "graph": {
+            "modules": [],
+        },
+    });
+
+    std::fs::write(
+        project_root.join(".kratos/latest-report.json"),
+        serde_json::to_string_pretty(&report).expect("report should serialize"),
+    )
+    .expect("report should write");
+}

--- a/crates/kratos-cli/tests/cli_smoke.rs
+++ b/crates/kratos-cli/tests/cli_smoke.rs
@@ -10,7 +10,7 @@ fn root_help_matches_expected_shape() {
     assert!(output.status.success());
     assert_eq!(
         String::from_utf8_lossy(&output.stdout),
-        "Kratos\nDestroy dead code ruthlessly.\n\nUsage:\n  kratos scan [root] [--output path] [--json]\n  kratos report [report-path-or-root] [--format summary|json|md]\n  kratos clean [report-path-or-root] [--apply]\n\nCommands:\n  scan    Analyze a codebase and save the latest report.\n  report  Print a saved report in summary, json, or markdown form.\n  clean   Show deletion candidates or delete them with --apply.\n"
+        "Kratos\nDestroy dead code ruthlessly.\n\nUsage:\n  kratos scan [root] [--output path] [--json]\n  kratos report [report-path-or-root] [--format summary|json|md]\n  kratos clean [report-path-or-root] [--apply] [--min-confidence value]\n\nCommands:\n  scan    Analyze a codebase and save the latest report.\n  report  Print a saved report in summary, json, or markdown form.\n  clean   Show deletion candidates or delete them with --apply.\n"
     );
 }
 
@@ -21,7 +21,7 @@ fn unknown_command_returns_help_and_exit_code_one() {
     assert_eq!(output.status.code(), Some(1));
     assert_eq!(
         String::from_utf8_lossy(&output.stderr),
-        "Unknown command: nope\n\nKratos\nDestroy dead code ruthlessly.\n\nUsage:\n  kratos scan [root] [--output path] [--json]\n  kratos report [report-path-or-root] [--format summary|json|md]\n  kratos clean [report-path-or-root] [--apply]\n\nCommands:\n  scan    Analyze a codebase and save the latest report.\n  report  Print a saved report in summary, json, or markdown form.\n  clean   Show deletion candidates or delete them with --apply.\n"
+        "Unknown command: nope\n\nKratos\nDestroy dead code ruthlessly.\n\nUsage:\n  kratos scan [root] [--output path] [--json]\n  kratos report [report-path-or-root] [--format summary|json|md]\n  kratos clean [report-path-or-root] [--apply] [--min-confidence value]\n\nCommands:\n  scan    Analyze a codebase and save the latest report.\n  report  Print a saved report in summary, json, or markdown form.\n  clean   Show deletion candidates or delete them with --apply.\n"
     );
 }
 

--- a/crates/kratos-core/src/clean.rs
+++ b/crates/kratos-core/src/clean.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use serde_json::Value;
 
 use crate::error::{KratosError, KratosResult};
-use crate::model::{ReportV2, REPORT_V2};
+use crate::model::{DeletionCandidateFinding, ReportV2, REPORT_V2};
 use crate::report::parse_report_json;
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -13,12 +13,26 @@ pub struct CleanOutcome {
     pub skipped_files: usize,
 }
 
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct CleanThresholdPlan {
+    pub deletion_targets: Vec<DeletionCandidateFinding>,
+    pub threshold_skipped_targets: Vec<DeletionCandidateFinding>,
+}
+
 pub fn clean_from_report_path(
     report_path: impl AsRef<Path>,
     apply: bool,
 ) -> KratosResult<CleanOutcome> {
     let report = load_clean_report(report_path)?;
     clean_from_report(&report, apply)
+}
+
+pub fn clean_from_report_path_with_min_confidence(
+    report_path: impl AsRef<Path>,
+    min_confidence: f32,
+) -> KratosResult<CleanOutcome> {
+    let report = load_clean_report(report_path)?;
+    clean_from_report_with_min_confidence(&report, min_confidence)
 }
 
 pub fn load_clean_report(report_path: impl AsRef<Path>) -> KratosResult<ReportV2> {
@@ -42,6 +56,33 @@ pub fn load_clean_report(report_path: impl AsRef<Path>) -> KratosResult<ReportV2
     parse_report_json(&raw)
 }
 
+pub fn plan_clean_candidates(
+    report: &ReportV2,
+    min_confidence: f32,
+) -> KratosResult<CleanThresholdPlan> {
+    validate_clean_threshold_inputs(report, min_confidence)?;
+
+    let mut plan = CleanThresholdPlan::default();
+
+    for candidate in &report.findings.deletion_candidates {
+        if candidate.confidence >= min_confidence {
+            plan.deletion_targets.push(candidate.clone());
+        } else {
+            plan.threshold_skipped_targets.push(candidate.clone());
+        }
+    }
+
+    Ok(plan)
+}
+
+pub fn clean_from_report_with_min_confidence(
+    report: &ReportV2,
+    min_confidence: f32,
+) -> KratosResult<CleanOutcome> {
+    let plan = plan_clean_candidates(report, min_confidence)?;
+    apply_clean_plan(report, &plan)
+}
+
 pub fn clean_from_report(report: &ReportV2, apply: bool) -> KratosResult<CleanOutcome> {
     if report.version < REPORT_V2 {
         return Err(KratosError::InvalidReportVersion {
@@ -57,11 +98,35 @@ pub fn clean_from_report(report: &ReportV2, apply: bool) -> KratosResult<CleanOu
         });
     }
 
+    clean_from_report_with_min_confidence(report, 0.0)
+}
+
+fn validate_clean_threshold_inputs(report: &ReportV2, min_confidence: f32) -> KratosResult<()> {
+    if report.version < REPORT_V2 {
+        return Err(KratosError::InvalidReportVersion {
+            expected: REPORT_V2,
+            found: report.version,
+        });
+    }
+
+    if !min_confidence.is_finite() || !(0.0..=1.0).contains(&min_confidence) {
+        return Err(KratosError::Config(
+            "--min-confidence must be between 0.0 and 1.0".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+fn apply_clean_plan(report: &ReportV2, plan: &CleanThresholdPlan) -> KratosResult<CleanOutcome> {
     let report_root_path = resolve_path(&report.root);
     let deletion_root = realpath_or_fallback(&report.root);
-    let mut outcome = CleanOutcome::default();
+    let mut outcome = CleanOutcome {
+        deleted_files: 0,
+        skipped_files: plan.threshold_skipped_targets.len(),
+    };
 
-    for candidate in &report.findings.deletion_candidates {
+    for candidate in &plan.deletion_targets {
         let candidate_path = resolve_path(&candidate.file);
 
         if !is_within_directory(&report_root_path, &candidate_path) {

--- a/crates/kratos-core/src/config.rs
+++ b/crates/kratos-core/src/config.rs
@@ -85,6 +85,14 @@ pub fn load_project_config(root: impl Into<PathBuf>) -> KratosResult<ProjectConf
     })
 }
 
+pub fn load_clean_min_confidence(root: impl Into<PathBuf>) -> KratosResult<f32> {
+    let root = normalize_project_root(root.into());
+    let user_config = read_loose_json_file(&resolve_config_path(&root, DEFAULT_CONFIG_FILENAME))?
+        .unwrap_or_else(empty_object);
+
+    read_clean_min_confidence(&user_config)
+}
+
 pub fn resolve_config_path(root: &Path, file_name: &str) -> PathBuf {
     root.join(file_name)
 }
@@ -106,6 +114,34 @@ fn read_loose_json_file(file_path: &Path) -> KratosResult<Option<JsonValue>> {
 
     let content = std::fs::read_to_string(file_path)?;
     Ok(Some(parse_loose_json(&content)?))
+}
+
+fn read_clean_min_confidence(user_config: &JsonValue) -> KratosResult<f32> {
+    let Some(thresholds) = user_config.get("thresholds") else {
+        return Ok(0.0);
+    };
+    let Some(thresholds) = thresholds.as_object() else {
+        return Err(config_error(
+            "thresholds must be an object when specifying thresholds.cleanMinConfidence",
+        ));
+    };
+
+    let Some(value) = thresholds.get("cleanMinConfidence") else {
+        return Err(config_error(
+            "thresholds.cleanMinConfidence is required when thresholds is present",
+        ));
+    };
+
+    let Some(value) = (match value {
+        JsonValue::Number(raw) => raw.parse::<f64>().ok(),
+        _ => None,
+    }) else {
+        return Err(config_error(
+            "thresholds.cleanMinConfidence must be a number between 0.0 and 1.0",
+        ));
+    };
+
+    validate_clean_min_confidence(value, "thresholds.cleanMinConfidence")
 }
 
 fn normalize_roots(root: &Path, roots: Option<&JsonValue>) -> KratosResult<Vec<PathBuf>> {
@@ -412,6 +448,16 @@ fn resolve_alias_target_pattern(root: &Path, value: &str) -> String {
 
 fn config_error(message: &str) -> crate::error::KratosError {
     crate::error::KratosError::Config(message.to_string())
+}
+
+fn validate_clean_min_confidence(value: f64, field_name: &str) -> KratosResult<f32> {
+    if !value.is_finite() || !(0.0..=1.0).contains(&value) {
+        return Err(config_error(&format!(
+            "{field_name} must be between 0.0 and 1.0"
+        )));
+    }
+
+    Ok(value as f32)
 }
 
 fn normalize_path(path: PathBuf) -> PathBuf {

--- a/crates/kratos-core/tests/clean_thresholds.rs
+++ b/crates/kratos-core/tests/clean_thresholds.rs
@@ -1,0 +1,96 @@
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use kratos_core::clean::{clean_from_report_with_min_confidence, plan_clean_candidates};
+use kratos_core::model::{DeletionCandidateFinding, ReportV2};
+
+#[test]
+fn plan_clean_candidates_splits_deletion_targets_and_threshold_skips() {
+    let temp_root = temp_dir("clean-threshold-plan");
+    let report = report_with_candidates(
+        &temp_root,
+        &[
+            ("src/high.ts", 0.95),
+            ("src/medium.ts", 0.80),
+            ("src/low.ts", 0.25),
+        ],
+    );
+
+    let plan = plan_clean_candidates(&report, 0.8).expect("plan should build");
+
+    assert_eq!(plan.deletion_targets.len(), 2);
+    assert_eq!(plan.threshold_skipped_targets.len(), 1);
+    assert_eq!(plan.deletion_targets[0].file, temp_root.join("src/high.ts"));
+    assert_eq!(
+        plan.deletion_targets[1].file,
+        temp_root.join("src/medium.ts")
+    );
+    assert_eq!(
+        plan.threshold_skipped_targets[0].file,
+        temp_root.join("src/low.ts")
+    );
+}
+
+#[test]
+fn clean_from_report_with_min_confidence_skips_low_confidence_targets() {
+    let temp_root = temp_dir("clean-threshold-apply");
+    let report = report_with_candidates(&temp_root, &[("src/high.ts", 0.96), ("src/low.ts", 0.40)]);
+
+    let outcome =
+        clean_from_report_with_min_confidence(&report, 0.9).expect("clean should succeed");
+
+    assert_eq!(outcome.deleted_files, 1);
+    assert_eq!(outcome.skipped_files, 1);
+    assert!(!temp_root.join("src/high.ts").exists());
+    assert!(temp_root.join("src/low.ts").exists());
+}
+
+#[test]
+fn clean_from_report_with_min_confidence_rejects_invalid_thresholds() {
+    let temp_root = temp_dir("clean-threshold-invalid");
+    let report = report_with_candidates(&temp_root, &[("src/high.ts", 0.96)]);
+
+    let error = clean_from_report_with_min_confidence(&report, 1.1)
+        .expect_err("threshold should be rejected");
+    assert!(
+        error
+            .to_string()
+            .contains("--min-confidence must be between 0.0 and 1.0"),
+        "unexpected error: {error}"
+    );
+}
+
+fn report_with_candidates(root: &Path, candidates: &[(&str, f32)]) -> ReportV2 {
+    let mut report = ReportV2::new(root.to_path_buf());
+    std::fs::create_dir_all(root).expect("report root should exist");
+
+    for (relative, _) in candidates {
+        let path = root.join(relative);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("candidate parent should exist");
+        }
+        std::fs::write(&path, "export const dead = true;\n").expect("candidate file should write");
+    }
+
+    report.findings.deletion_candidates = candidates
+        .iter()
+        .map(|(relative, confidence)| DeletionCandidateFinding {
+            file: root.join(relative),
+            reason: format!("{} candidate", relative),
+            confidence: *confidence,
+            safe: true,
+        })
+        .collect();
+
+    report
+}
+
+fn temp_dir(label: &str) -> PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be valid")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!("kratos-core-{label}-{unique}"));
+    std::fs::create_dir_all(&path).expect("temp dir should be created");
+    path
+}

--- a/crates/kratos-core/tests/config_and_discovery.rs
+++ b/crates/kratos-core/tests/config_and_discovery.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 
+use kratos_core::config::load_clean_min_confidence;
 use kratos_core::config::load_project_config;
 use kratos_core::discover::collect_source_files;
 use kratos_core::jsonc::parse_loose_json;
@@ -96,6 +97,93 @@ fn load_project_config_parses_comments_and_collects_entries() {
             .package_entries
             .contains(&project.root().to_path_buf()),
         "empty export targets should be ignored"
+    );
+}
+
+#[test]
+fn load_clean_min_confidence_defaults_to_zero_and_reads_thresholds() {
+    let project = TestProject::new("clean-confidence-defaults");
+
+    assert_eq!(
+        load_clean_min_confidence(project.root()).expect("default threshold should load"),
+        0.0
+    );
+
+    project.write(
+        "kratos.config.json",
+        r#"{
+  "thresholds": {
+    "cleanMinConfidence": 0.85
+  }
+}
+"#,
+    );
+
+    assert_eq!(
+        load_clean_min_confidence(project.root()).expect("threshold should load"),
+        0.85
+    );
+}
+
+#[test]
+fn load_clean_min_confidence_rejects_out_of_range_values() {
+    let project = TestProject::new("clean-confidence-invalid");
+    project.write(
+        "kratos.config.json",
+        r#"{
+  "thresholds": {
+    "cleanMinConfidence": 1.2
+  }
+}
+"#,
+    );
+
+    let error = load_clean_min_confidence(project.root()).expect_err("threshold should fail");
+    assert!(
+        error
+            .to_string()
+            .contains("thresholds.cleanMinConfidence must be between 0.0 and 1.0"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn load_clean_min_confidence_rejects_non_object_thresholds() {
+    let project = TestProject::new("clean-confidence-invalid-thresholds-shape");
+    project.write(
+        "kratos.config.json",
+        r#"{
+  "thresholds": []
+}
+"#,
+    );
+
+    let error = load_clean_min_confidence(project.root()).expect_err("thresholds shape should fail");
+    assert!(
+        error
+            .to_string()
+            .contains("thresholds must be an object when specifying thresholds.cleanMinConfidence"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn load_clean_min_confidence_rejects_missing_key_when_thresholds_is_present() {
+    let project = TestProject::new("clean-confidence-missing-threshold-key");
+    project.write(
+        "kratos.config.json",
+        r#"{
+  "thresholds": {}
+}
+"#,
+    );
+
+    let error = load_clean_min_confidence(project.root()).expect_err("missing threshold key should fail");
+    assert!(
+        error
+            .to_string()
+            .contains("thresholds.cleanMinConfidence is required when thresholds is present"),
+        "unexpected error: {error}"
     );
 }
 


### PR DESCRIPTION
## 배경
- WOW roadmap의 Phase 3A로 clean 실행에 confidence threshold 정책을 추가합니다.
- dry-run과 apply가 같은 정책을 따르도록 맞춰 cleanup 판단을 일관되게 유지합니다.

## 변경 사항
- `thresholds.cleanMinConfidence` config와 `kratos clean --min-confidence` override를 추가했습니다.
- core clean 경로에 threshold-aware planning helper를 도입해 dry-run/apply가 같은 기준을 쓰도록 정리했습니다.
- CLI dry-run 출력에 threshold로 skip된 항목을 분리해 보여주고, apply 결과에 `skipped_files`를 포함했습니다.
- config/core/cli 회귀 테스트를 추가했습니다.

## 검증
- `cargo test -p kratos-core --test config_and_discovery --test clean_thresholds --test clean_safety`
- `cargo test -p kratos-cli --test clean_threshold_cli --test cli_smoke`
- `cargo test --workspace`
- `npm run verify`
  - native addon smoke 1건은 `KRATOS_PACKAGE_SMOKE_NATIVE_LIB` 미설정으로 skip

## 브랜치 / 워크트리
- base: `master`
- head: `codex/wow-3a-clean-threshold-policy`
- worktree: `/Users/pjw/workspace/kratos`

## 이슈 연결
- 별도 이슈 연결 없음