### PR TITLE
feat: WOW-3B report diff 엔진과 diff 명령 추가

### DIFF
--- a/crates/kratos-cli/src/commands/diff.rs
+++ b/crates/kratos-cli/src/commands/diff.rs
@@ -1,0 +1,68 @@
+use std::fs;
+use std::io::Write;
+
+use clap::Parser;
+use kratos_core::report::parse_report_json;
+use kratos_core::report_diff::{
+    diff_reports, format_diff_json, format_diff_markdown, format_diff_summary,
+};
+use kratos_core::{KratosError, KratosResult};
+
+use super::{canonicalize_diff_args, resolve_report_input, write_output, CommandSpec};
+
+pub const NAME: &str = "diff";
+pub const SPEC: CommandSpec = CommandSpec {
+    name: NAME,
+    summary: "Compare two saved reports.",
+    usage: &[
+        "kratos diff [before-report-path-or-root] [after-report-path-or-root] [--format summary|json|md]",
+    ],
+};
+
+#[derive(Debug, Parser)]
+#[command(disable_help_flag = true, disable_version_flag = true)]
+struct DiffArgs {
+    #[arg(allow_hyphen_values = true)]
+    before: Option<String>,
+    #[arg(allow_hyphen_values = true)]
+    after: Option<String>,
+    #[arg(long, allow_hyphen_values = true)]
+    format: Option<String>,
+}
+
+pub fn run(args: &[String], stdout: &mut dyn Write) -> KratosResult<i32> {
+    let args = parse_args(args)?;
+    let cwd = std::env::current_dir()?;
+    let before_report_path = resolve_report_input(args.before.as_deref(), &cwd);
+    let after_report_path = resolve_report_input(args.after.as_deref(), &cwd);
+    let before_raw = fs::read_to_string(&before_report_path)?;
+    let after_raw = fs::read_to_string(&after_report_path)?;
+    let before = parse_report_json(&before_raw)?;
+    let after = parse_report_json(&after_raw)?;
+    let diff = diff_reports(&before, &after);
+    let format = args.format.as_deref().unwrap_or("summary");
+
+    match format {
+        "summary" => write_output(
+            stdout,
+            &format_diff_summary(&diff, &before_report_path, &after_report_path)?,
+        )?,
+        "json" => write_output(
+            stdout,
+            &format_diff_json(&diff, &before_report_path, &after_report_path)?,
+        )?,
+        "md" => write_output(
+            stdout,
+            &format_diff_markdown(&diff, &before_report_path, &after_report_path)?,
+        )?,
+        other => return Err(KratosError::Config(format!("Invalid diff format: {other}"))),
+    }
+
+    Ok(0)
+}
+
+fn parse_args(args: &[String]) -> KratosResult<DiffArgs> {
+    let canonical = canonicalize_diff_args(args);
+    DiffArgs::try_parse_from(std::iter::once(NAME).chain(canonical.iter().map(String::as_str)))
+        .map_err(|error| KratosError::Config(error.to_string().trim().to_string()))
+}

--- a/crates/kratos-cli/src/commands/mod.rs
+++ b/crates/kratos-cli/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod clean;
+pub mod diff;
 pub mod report;
 pub mod scan;
 
@@ -15,13 +16,14 @@ pub struct CommandSpec {
     pub usage: &'static [&'static str],
 }
 
-pub const COMMANDS: &[CommandSpec] = &[scan::SPEC, report::SPEC, clean::SPEC];
+pub const COMMANDS: &[CommandSpec] = &[scan::SPEC, report::SPEC, diff::SPEC, clean::SPEC];
 pub const DEFAULT_REPORT_RELATIVE_PATH: &str = ".kratos/latest-report.json";
 
 pub fn dispatch(command: &str, args: &[String], stdout: &mut dyn Write) -> KratosResult<i32> {
     match command {
         scan::NAME => dispatch_command(scan::SPEC, scan::run, args, stdout),
         report::NAME => dispatch_command(report::SPEC, report::run, args, stdout),
+        diff::NAME => dispatch_command(diff::SPEC, diff::run, args, stdout),
         clean::NAME => dispatch_command(clean::SPEC, clean::run, args, stdout),
         _ => Err(KratosError::Config(format!("Unknown command: {command}"))),
     }
@@ -229,6 +231,28 @@ pub fn canonicalize_report_args(raw_args: &[String]) -> Vec<String> {
 
     if let Some(input) = parsed.positionals.first() {
         args.push(input.clone());
+    }
+
+    if let Some(value) = parsed.flags.get("format").and_then(flag_value_as_string) {
+        if !value.is_empty() {
+            args.push("--format".to_string());
+            args.push(value.to_string());
+        }
+    }
+
+    args
+}
+
+pub fn canonicalize_diff_args(raw_args: &[String]) -> Vec<String> {
+    let parsed = parse_cli_options(raw_args, &["format"], &[]);
+    let mut args = Vec::new();
+
+    if let Some(before) = parsed.positionals.first() {
+        args.push(before.clone());
+    }
+
+    if let Some(after) = parsed.positionals.get(1) {
+        args.push(after.clone());
     }
 
     if let Some(value) = parsed.flags.get("format").and_then(flag_value_as_string) {

--- a/crates/kratos-cli/tests/cli_smoke.rs
+++ b/crates/kratos-cli/tests/cli_smoke.rs
@@ -10,7 +10,7 @@ fn root_help_matches_expected_shape() {
     assert!(output.status.success());
     assert_eq!(
         String::from_utf8_lossy(&output.stdout),
-        "Kratos\nDestroy dead code ruthlessly.\n\nUsage:\n  kratos scan [root] [--output path] [--json]\n  kratos report [report-path-or-root] [--format summary|json|md]\n  kratos clean [report-path-or-root] [--apply] [--min-confidence value]\n\nCommands:\n  scan    Analyze a codebase and save the latest report.\n  report  Print a saved report in summary, json, or markdown form.\n  clean   Show deletion candidates or delete them with --apply.\n"
+        "Kratos\nDestroy dead code ruthlessly.\n\nUsage:\n  kratos scan [root] [--output path] [--json]\n  kratos report [report-path-or-root] [--format summary|json|md]\n  kratos diff [before-report-path-or-root] [after-report-path-or-root] [--format summary|json|md]\n  kratos clean [report-path-or-root] [--apply] [--min-confidence value]\n\nCommands:\n  scan    Analyze a codebase and save the latest report.\n  report  Print a saved report in summary, json, or markdown form.\n  diff    Compare two saved reports.\n  clean   Show deletion candidates or delete them with --apply.\n"
     );
 }
 
@@ -21,7 +21,7 @@ fn unknown_command_returns_help_and_exit_code_one() {
     assert_eq!(output.status.code(), Some(1));
     assert_eq!(
         String::from_utf8_lossy(&output.stderr),
-        "Unknown command: nope\n\nKratos\nDestroy dead code ruthlessly.\n\nUsage:\n  kratos scan [root] [--output path] [--json]\n  kratos report [report-path-or-root] [--format summary|json|md]\n  kratos clean [report-path-or-root] [--apply] [--min-confidence value]\n\nCommands:\n  scan    Analyze a codebase and save the latest report.\n  report  Print a saved report in summary, json, or markdown form.\n  clean   Show deletion candidates or delete them with --apply.\n"
+        "Unknown command: nope\n\nKratos\nDestroy dead code ruthlessly.\n\nUsage:\n  kratos scan [root] [--output path] [--json]\n  kratos report [report-path-or-root] [--format summary|json|md]\n  kratos diff [before-report-path-or-root] [after-report-path-or-root] [--format summary|json|md]\n  kratos clean [report-path-or-root] [--apply] [--min-confidence value]\n\nCommands:\n  scan    Analyze a codebase and save the latest report.\n  report  Print a saved report in summary, json, or markdown form.\n  diff    Compare two saved reports.\n  clean   Show deletion candidates or delete them with --apply.\n"
     );
 }
 

--- a/crates/kratos-cli/tests/diff_cli.rs
+++ b/crates/kratos-cli/tests/diff_cli.rs
@@ -1,0 +1,186 @@
+mod support;
+
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+use support::cli::run_cli_in_dir;
+
+#[test]
+fn diff_accepts_project_roots_and_report_paths() {
+    let before_root = temp_dir("diff-before-root");
+    let after_root = temp_dir("diff-after-root");
+    let before_report_path = before_root.join(".kratos/latest-report.json");
+    let after_report_path = after_root.join("custom-report.json");
+
+    write_report(&before_report_path, &before_root, "./missing-a");
+    write_report(&after_report_path, &after_root, "./missing-b");
+
+    let output = run_cli_in_dir(
+        &before_root,
+        &[
+            "diff",
+            before_root.to_str().expect("before root should be utf8"),
+            after_report_path
+                .to_str()
+                .expect("after report should be utf8"),
+            "--format",
+            "md",
+        ],
+    );
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("# Kratos Diff"));
+    assert!(stdout.contains(&format!("Before: {}", before_report_path.display())));
+    assert!(stdout.contains(&format!("After: {}", after_report_path.display())));
+    assert!(stdout.contains("## Broken imports"));
+    assert!(stdout.contains("### Introduced (1)"));
+    assert!(stdout.contains("### Resolved (1)"));
+    assert!(stdout.contains("./missing-b"));
+}
+
+#[test]
+fn diff_defaults_to_summary_and_rejects_invalid_format() {
+    let before_root = temp_dir("diff-default-before");
+    let after_root = temp_dir("diff-default-after");
+    let before_report_path = before_root.join(".kratos/latest-report.json");
+    let after_report_path = after_root.join(".kratos/latest-report.json");
+
+    write_report(&before_report_path, &before_root, "./missing-a");
+    write_report(&after_report_path, &after_root, "./missing-b");
+
+    let summary_output = run_cli_in_dir(
+        &before_root,
+        &[
+            "diff",
+            before_root.to_str().expect("before root should be utf8"),
+            after_root.to_str().expect("after root should be utf8"),
+            "--format",
+        ],
+    );
+    assert!(summary_output.status.success());
+    let stdout = String::from_utf8_lossy(&summary_output.stdout);
+    assert!(stdout.contains("Kratos diff complete."));
+    assert!(stdout.contains("Broken imports: introduced 1, resolved 1, persisted 1"));
+    assert!(stdout.contains("Totals: introduced 1, resolved 1, persisted 1"));
+
+    let invalid_output = run_cli_in_dir(
+        &before_root,
+        &[
+            "diff",
+            before_root.to_str().expect("before root should be utf8"),
+            after_report_path
+                .to_str()
+                .expect("after report should be utf8"),
+            "--format",
+            "bogus",
+        ],
+    );
+    assert_eq!(invalid_output.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&invalid_output.stderr)
+        .contains("Kratos failed: Config error: Invalid diff format: bogus"));
+}
+
+#[test]
+fn diff_json_reports_full_shape() {
+    let before_root = temp_dir("diff-json-before");
+    let after_root = temp_dir("diff-json-after");
+    let before_report_path = before_root.join(".kratos/latest-report.json");
+    let after_report_path = after_root.join(".kratos/latest-report.json");
+
+    write_report(&before_report_path, &before_root, "./missing-a");
+    write_report(&after_report_path, &after_root, "./missing-b");
+
+    let output = run_cli_in_dir(
+        &before_root,
+        &[
+            "diff",
+            before_root.to_str().expect("before root should be utf8"),
+            after_root.to_str().expect("after root should be utf8"),
+            "--format",
+            "json",
+        ],
+    );
+
+    assert!(output.status.success());
+    let value: Value =
+        serde_json::from_slice(&output.stdout).expect("diff output should parse as json");
+    assert_eq!(
+        value["before"]["path"],
+        Value::from(before_report_path.to_string_lossy().to_string())
+    );
+    assert_eq!(
+        value["after"]["path"],
+        Value::from(after_report_path.to_string_lossy().to_string())
+    );
+    assert_eq!(
+        value["summary"]["brokenImports"]["introduced"],
+        Value::from(1)
+    );
+    assert_eq!(
+        value["findings"]["brokenImports"]["introduced"][0]["source"],
+        Value::from("./missing-b")
+    );
+}
+
+fn write_report(path: &Path, root: &Path, broken_source: &str) {
+    let report = serde_json::json!({
+        "schemaVersion": 2,
+        "generatedAt": "2026-04-22T00:00:00Z",
+        "project": {
+            "root": root.to_string_lossy(),
+            "configPath": null,
+        },
+        "summary": {
+            "filesScanned": 1,
+            "entrypoints": 0,
+            "brokenImports": 1,
+            "orphanFiles": 0,
+            "deadExports": 0,
+            "unusedImports": 0,
+            "routeEntrypoints": 0,
+            "deletionCandidates": 0,
+        },
+        "findings": {
+            "brokenImports": [{
+                "file": root.join("src/shared.ts").to_string_lossy(),
+                "source": "./shared",
+                "kind": "static",
+            }, {
+                "file": root.join("src/index.ts").to_string_lossy(),
+                "source": broken_source,
+                "kind": "static",
+            }],
+            "orphanFiles": [],
+            "deadExports": [],
+            "unusedImports": [],
+            "routeEntrypoints": [],
+            "deletionCandidates": [],
+        },
+        "graph": {
+            "modules": [{
+                "file": root.join("src/index.ts").to_string_lossy(),
+                "relativePath": "src/index.ts",
+                "entrypointKind": null,
+                "importedByCount": 0,
+                "importCount": 0,
+                "exportCount": 0,
+            }],
+        },
+    });
+
+    let body = serde_json::to_string_pretty(&report).expect("report should serialize");
+    std::fs::create_dir_all(path.parent().expect("report should have a parent"))
+        .expect("report directory should create");
+    std::fs::write(path, format!("{body}\n")).expect("report should write");
+}
+
+fn temp_dir(label: &str) -> PathBuf {
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system time should be valid")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!("kratos-cli-{label}-{unique}"));
+    std::fs::create_dir_all(&path).expect("temp dir should be created");
+    path
+}

--- a/crates/kratos-core/src/lib.rs
+++ b/crates/kratos-core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod jsonc;
 pub mod model;
 pub mod parser;
 pub mod report;
+pub mod report_diff;
 pub mod report_format;
 pub mod resolve;
 pub mod suppressions;

--- a/crates/kratos-core/src/report_diff.rs
+++ b/crates/kratos-core/src/report_diff.rs
@@ -1,0 +1,573 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+use serde_json::{json, Value};
+
+use crate::model::{
+    BrokenImportFinding, DeadExportFinding, DeletionCandidateFinding, OrphanFileFinding,
+    OrphanKind, ReportV2, RouteEntrypointFinding, UnusedImportFinding,
+};
+use crate::report::{entrypoint_kind_to_string, path_to_string};
+use crate::{KratosError, KratosResult};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct FindingDiff<T> {
+    pub introduced: Vec<T>,
+    pub resolved: Vec<T>,
+    pub persisted: Vec<T>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct FindingDiffCounts {
+    pub introduced: usize,
+    pub resolved: usize,
+    pub persisted: usize,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ReportDiffSummary {
+    pub broken_imports: FindingDiffCounts,
+    pub orphan_files: FindingDiffCounts,
+    pub dead_exports: FindingDiffCounts,
+    pub unused_imports: FindingDiffCounts,
+    pub route_entrypoints: FindingDiffCounts,
+    pub deletion_candidates: FindingDiffCounts,
+    pub totals: FindingDiffCounts,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ReportFindingDiffs {
+    pub broken_imports: FindingDiff<BrokenImportFinding>,
+    pub orphan_files: FindingDiff<OrphanFileFinding>,
+    pub dead_exports: FindingDiff<DeadExportFinding>,
+    pub unused_imports: FindingDiff<UnusedImportFinding>,
+    pub route_entrypoints: FindingDiff<RouteEntrypointFinding>,
+    pub deletion_candidates: FindingDiff<DeletionCandidateFinding>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ReportDiff {
+    pub summary: ReportDiffSummary,
+    pub findings: ReportFindingDiffs,
+}
+
+pub fn diff_reports(before: &ReportV2, after: &ReportV2) -> ReportDiff {
+    let findings = ReportFindingDiffs {
+        broken_imports: diff_finding_lists(
+            &before.findings.broken_imports,
+            &after.findings.broken_imports,
+            |item| broken_import_key(item, &before.root),
+            |item| broken_import_key(item, &after.root),
+        ),
+        orphan_files: diff_finding_lists(
+            &before.findings.orphan_files,
+            &after.findings.orphan_files,
+            |item| orphan_file_key(item, &before.root),
+            |item| orphan_file_key(item, &after.root),
+        ),
+        dead_exports: diff_finding_lists(
+            &before.findings.dead_exports,
+            &after.findings.dead_exports,
+            |item| dead_export_key(item, &before.root),
+            |item| dead_export_key(item, &after.root),
+        ),
+        unused_imports: diff_finding_lists(
+            &before.findings.unused_imports,
+            &after.findings.unused_imports,
+            |item| unused_import_key(item, &before.root),
+            |item| unused_import_key(item, &after.root),
+        ),
+        route_entrypoints: diff_finding_lists(
+            &before.findings.route_entrypoints,
+            &after.findings.route_entrypoints,
+            |item| route_entrypoint_key(item, &before.root),
+            |item| route_entrypoint_key(item, &after.root),
+        ),
+        deletion_candidates: diff_finding_lists(
+            &before.findings.deletion_candidates,
+            &after.findings.deletion_candidates,
+            |item| deletion_candidate_key(item, &before.root),
+            |item| deletion_candidate_key(item, &after.root),
+        ),
+    };
+
+    let summary = ReportDiffSummary {
+        broken_imports: findings.broken_imports.counts(),
+        orphan_files: findings.orphan_files.counts(),
+        dead_exports: findings.dead_exports.counts(),
+        unused_imports: findings.unused_imports.counts(),
+        route_entrypoints: findings.route_entrypoints.counts(),
+        deletion_candidates: findings.deletion_candidates.counts(),
+        totals: FindingDiffCounts {
+            introduced: findings.broken_imports.introduced.len()
+                + findings.orphan_files.introduced.len()
+                + findings.dead_exports.introduced.len()
+                + findings.unused_imports.introduced.len()
+                + findings.route_entrypoints.introduced.len()
+                + findings.deletion_candidates.introduced.len(),
+            resolved: findings.broken_imports.resolved.len()
+                + findings.orphan_files.resolved.len()
+                + findings.dead_exports.resolved.len()
+                + findings.unused_imports.resolved.len()
+                + findings.route_entrypoints.resolved.len()
+                + findings.deletion_candidates.resolved.len(),
+            persisted: findings.broken_imports.persisted.len()
+                + findings.orphan_files.persisted.len()
+                + findings.dead_exports.persisted.len()
+                + findings.unused_imports.persisted.len()
+                + findings.route_entrypoints.persisted.len()
+                + findings.deletion_candidates.persisted.len(),
+        },
+    };
+
+    ReportDiff { summary, findings }
+}
+
+pub fn format_diff_summary(
+    diff: &ReportDiff,
+    before_report_path: &Path,
+    after_report_path: &Path,
+) -> KratosResult<String> {
+    let mut lines = vec![
+        "Kratos diff complete.".to_string(),
+        String::new(),
+        format!("Before: {}", path_to_string(before_report_path)),
+        format!("After: {}", path_to_string(after_report_path)),
+        String::new(),
+    ];
+
+    lines.extend(render_summary_line(
+        "Broken imports",
+        &diff.summary.broken_imports,
+    ));
+    lines.extend(render_summary_line(
+        "Orphan files",
+        &diff.summary.orphan_files,
+    ));
+    lines.extend(render_summary_line(
+        "Dead exports",
+        &diff.summary.dead_exports,
+    ));
+    lines.extend(render_summary_line(
+        "Unused imports",
+        &diff.summary.unused_imports,
+    ));
+    lines.extend(render_summary_line(
+        "Route entrypoints",
+        &diff.summary.route_entrypoints,
+    ));
+    lines.extend(render_summary_line(
+        "Deletion candidates",
+        &diff.summary.deletion_candidates,
+    ));
+
+    lines.push(String::new());
+    lines.push(format!(
+        "Totals: introduced {}, resolved {}, persisted {}",
+        diff.summary.totals.introduced, diff.summary.totals.resolved, diff.summary.totals.persisted
+    ));
+
+    if diff.summary.totals.introduced == 0
+        && diff.summary.totals.resolved == 0
+        && diff.summary.totals.persisted == 0
+    {
+        lines.push("No finding changes.".to_string());
+    }
+
+    Ok(lines.join("\n"))
+}
+
+pub fn format_diff_markdown(
+    diff: &ReportDiff,
+    before_report_path: &Path,
+    after_report_path: &Path,
+) -> KratosResult<String> {
+    let mut lines = vec![
+        "# Kratos Diff".to_string(),
+        String::new(),
+        format!("- Before: {}", path_to_string(before_report_path)),
+        format!("- After: {}", path_to_string(after_report_path)),
+        String::new(),
+    ];
+
+    push_markdown_finding_diff(
+        &mut lines,
+        "Broken imports",
+        &diff.findings.broken_imports,
+        |item| format!("{} -> `{}`", path_to_string(&item.file), item.source),
+    );
+    push_markdown_finding_diff(
+        &mut lines,
+        "Orphan files",
+        &diff.findings.orphan_files,
+        |item| {
+            format!(
+                "{} ({})",
+                path_to_string(&item.file),
+                orphan_kind_to_string(&item.kind)
+            )
+        },
+    );
+    push_markdown_finding_diff(
+        &mut lines,
+        "Dead exports",
+        &diff.findings.dead_exports,
+        |item| format!("{} -> `{}`", path_to_string(&item.file), item.export_name),
+    );
+    push_markdown_finding_diff(
+        &mut lines,
+        "Unused imports",
+        &diff.findings.unused_imports,
+        |item| {
+            format!(
+                "{} -> `{}` from `{}`",
+                path_to_string(&item.file),
+                item.local,
+                item.source
+            )
+        },
+    );
+    push_markdown_finding_diff(
+        &mut lines,
+        "Route entrypoints",
+        &diff.findings.route_entrypoints,
+        |item| {
+            format!(
+                "{} ({})",
+                path_to_string(&item.file),
+                entrypoint_kind_to_string(&item.kind)
+            )
+        },
+    );
+    push_markdown_finding_diff(
+        &mut lines,
+        "Deletion candidates",
+        &diff.findings.deletion_candidates,
+        |item| {
+            format!(
+                "{} ({}, confidence {})",
+                path_to_string(&item.file),
+                item.reason,
+                item.confidence
+            )
+        },
+    );
+
+    if lines.last().is_some_and(|line| !line.is_empty()) {
+        lines.push(String::new());
+    }
+
+    Ok(lines.join("\n"))
+}
+
+pub fn format_diff_json(
+    diff: &ReportDiff,
+    before_report_path: &Path,
+    after_report_path: &Path,
+) -> KratosResult<String> {
+    serde_json::to_string_pretty(&report_diff_json_value(
+        diff,
+        before_report_path,
+        after_report_path,
+    ))
+    .map_err(|error| KratosError::Json(error.to_string()))
+}
+
+fn report_diff_json_value(
+    diff: &ReportDiff,
+    before_report_path: &Path,
+    after_report_path: &Path,
+) -> Value {
+    json!({
+        "before": {
+            "path": path_to_string(before_report_path),
+        },
+        "after": {
+            "path": path_to_string(after_report_path),
+        },
+        "summary": {
+            "brokenImports": counts_to_json(&diff.summary.broken_imports),
+            "orphanFiles": counts_to_json(&diff.summary.orphan_files),
+            "deadExports": counts_to_json(&diff.summary.dead_exports),
+            "unusedImports": counts_to_json(&diff.summary.unused_imports),
+            "routeEntrypoints": counts_to_json(&diff.summary.route_entrypoints),
+            "deletionCandidates": counts_to_json(&diff.summary.deletion_candidates),
+            "totals": counts_to_json(&diff.summary.totals),
+        },
+        "findings": {
+            "brokenImports": finding_diff_to_json(&diff.findings.broken_imports, serialize_broken_import),
+            "orphanFiles": finding_diff_to_json(&diff.findings.orphan_files, serialize_orphan_file),
+            "deadExports": finding_diff_to_json(&diff.findings.dead_exports, serialize_dead_export),
+            "unusedImports": finding_diff_to_json(&diff.findings.unused_imports, serialize_unused_import),
+            "routeEntrypoints": finding_diff_to_json(&diff.findings.route_entrypoints, serialize_route_entrypoint),
+            "deletionCandidates": finding_diff_to_json(&diff.findings.deletion_candidates, serialize_deletion_candidate),
+        },
+    })
+}
+
+fn diff_finding_lists<T: Clone>(
+    before: &[T],
+    after: &[T],
+    before_key_for_item: impl Fn(&T) -> String,
+    after_key_for_item: impl Fn(&T) -> String,
+) -> FindingDiff<T> {
+    let before_groups = group_items_by_key(before, &before_key_for_item);
+    let after_groups = group_items_by_key(after, &after_key_for_item);
+    let all_keys = all_group_keys(&before_groups, &after_groups);
+    let mut introduced = Vec::new();
+    let mut resolved = Vec::new();
+    let mut persisted = Vec::new();
+
+    for key in all_keys {
+        let before_items = before_groups.get(&key).cloned().unwrap_or_default();
+        let after_items = after_groups.get(&key).cloned().unwrap_or_default();
+        let shared_count = before_items.len().min(after_items.len());
+
+        persisted.extend(after_items.iter().take(shared_count).cloned());
+        resolved.extend(before_items.iter().skip(shared_count).cloned());
+        introduced.extend(after_items.iter().skip(shared_count).cloned());
+    }
+
+    FindingDiff {
+        introduced,
+        resolved,
+        persisted,
+    }
+}
+
+fn group_items_by_key<T: Clone>(
+    items: &[T],
+    key_for_item: &impl Fn(&T) -> String,
+) -> BTreeMap<String, Vec<T>> {
+    let mut grouped = BTreeMap::new();
+    for item in items {
+        grouped
+            .entry(key_for_item(item))
+            .or_insert_with(Vec::new)
+            .push(item.clone());
+    }
+    grouped
+}
+
+fn all_group_keys<T>(
+    before_groups: &BTreeMap<String, Vec<T>>,
+    after_groups: &BTreeMap<String, Vec<T>>,
+) -> BTreeSet<String> {
+    before_groups
+        .keys()
+        .chain(after_groups.keys())
+        .cloned()
+        .collect()
+}
+
+fn render_summary_line(label: &str, counts: &FindingDiffCounts) -> Vec<String> {
+    vec![format!(
+        "{label}: introduced {}, resolved {}, persisted {}",
+        counts.introduced, counts.resolved, counts.persisted
+    )]
+}
+
+fn push_markdown_finding_diff<T>(
+    lines: &mut Vec<String>,
+    title: &str,
+    diff: &FindingDiff<T>,
+    render: impl Fn(&T) -> String,
+) {
+    if diff.introduced.is_empty() && diff.resolved.is_empty() && diff.persisted.is_empty() {
+        return;
+    }
+
+    lines.push(format!("## {title}"));
+    lines.push(String::new());
+
+    push_markdown_change_group(lines, "Introduced", &diff.introduced, &render);
+    push_markdown_change_group(lines, "Resolved", &diff.resolved, &render);
+    push_markdown_change_group(lines, "Persisted", &diff.persisted, &render);
+}
+
+fn push_markdown_change_group<T>(
+    lines: &mut Vec<String>,
+    label: &str,
+    items: &[T],
+    render: &impl Fn(&T) -> String,
+) {
+    lines.push(format!("### {label} ({})", items.len()));
+
+    if items.is_empty() {
+        lines.push("- None".to_string());
+        lines.push(String::new());
+        return;
+    }
+
+    for item in items {
+        lines.push(format!("- {}", render(item)));
+    }
+    lines.push(String::new());
+}
+
+impl<T> FindingDiff<T> {
+    pub fn counts(&self) -> FindingDiffCounts {
+        FindingDiffCounts {
+            introduced: self.introduced.len(),
+            resolved: self.resolved.len(),
+            persisted: self.persisted.len(),
+        }
+    }
+}
+
+impl<T> Default for FindingDiff<T> {
+    fn default() -> Self {
+        Self {
+            introduced: Vec::new(),
+            resolved: Vec::new(),
+            persisted: Vec::new(),
+        }
+    }
+}
+
+fn finding_diff_to_json<T>(diff: &FindingDiff<T>, serialize_item: fn(&T) -> Value) -> Value {
+    json!({
+        "introduced": diff.introduced.iter().map(serialize_item).collect::<Vec<_>>(),
+        "resolved": diff.resolved.iter().map(serialize_item).collect::<Vec<_>>(),
+        "persisted": diff.persisted.iter().map(serialize_item).collect::<Vec<_>>(),
+    })
+}
+
+fn counts_to_json(counts: &FindingDiffCounts) -> Value {
+    json!({
+        "introduced": counts.introduced,
+        "resolved": counts.resolved,
+        "persisted": counts.persisted,
+    })
+}
+
+fn serialize_broken_import(item: &BrokenImportFinding) -> Value {
+    json!({
+        "file": path_to_string(&item.file),
+        "source": item.source,
+        "kind": import_kind_to_string(&item.kind),
+    })
+}
+
+fn serialize_orphan_file(item: &OrphanFileFinding) -> Value {
+    json!({
+        "file": path_to_string(&item.file),
+        "kind": orphan_kind_to_string(&item.kind),
+        "reason": item.reason,
+        "confidence": round_confidence(item.confidence),
+    })
+}
+
+fn serialize_dead_export(item: &DeadExportFinding) -> Value {
+    json!({
+        "file": path_to_string(&item.file),
+        "exportName": item.export_name,
+    })
+}
+
+fn serialize_unused_import(item: &UnusedImportFinding) -> Value {
+    json!({
+        "file": path_to_string(&item.file),
+        "source": item.source,
+        "local": item.local,
+        "imported": item.imported,
+    })
+}
+
+fn serialize_route_entrypoint(item: &RouteEntrypointFinding) -> Value {
+    json!({
+        "file": path_to_string(&item.file),
+        "kind": entrypoint_kind_to_string(&item.kind),
+    })
+}
+
+fn serialize_deletion_candidate(item: &DeletionCandidateFinding) -> Value {
+    json!({
+        "file": path_to_string(&item.file),
+        "reason": item.reason,
+        "confidence": round_confidence(item.confidence),
+        "safe": item.safe,
+    })
+}
+
+fn broken_import_key(item: &BrokenImportFinding, report_root: &Path) -> String {
+    format!(
+        "{}|{}|{}",
+        finding_file_key(&item.file, report_root),
+        item.source,
+        import_kind_to_string(&item.kind)
+    )
+}
+
+fn orphan_file_key(item: &OrphanFileFinding, report_root: &Path) -> String {
+    format!(
+        "{}|{}|{}|{}",
+        finding_file_key(&item.file, report_root),
+        orphan_kind_to_string(&item.kind),
+        item.reason,
+        item.confidence.to_bits()
+    )
+}
+
+fn dead_export_key(item: &DeadExportFinding, report_root: &Path) -> String {
+    format!("{}|{}", finding_file_key(&item.file, report_root), item.export_name)
+}
+
+fn unused_import_key(item: &UnusedImportFinding, report_root: &Path) -> String {
+    format!(
+        "{}|{}|{}|{}",
+        finding_file_key(&item.file, report_root),
+        item.source,
+        item.local,
+        item.imported
+    )
+}
+
+fn route_entrypoint_key(item: &RouteEntrypointFinding, report_root: &Path) -> String {
+    format!(
+        "{}|{}",
+        finding_file_key(&item.file, report_root),
+        entrypoint_kind_to_string(&item.kind)
+    )
+}
+
+fn deletion_candidate_key(item: &DeletionCandidateFinding, report_root: &Path) -> String {
+    format!(
+        "{}|{}|{}|{}",
+        finding_file_key(&item.file, report_root),
+        item.reason,
+        item.confidence.to_bits(),
+        item.safe
+    )
+}
+
+fn finding_file_key(file: &Path, report_root: &Path) -> String {
+    file.strip_prefix(report_root)
+        .map(path_to_string)
+        .unwrap_or_else(|_| path_to_string(file))
+}
+
+fn import_kind_to_string(kind: &crate::model::ImportKind) -> &'static str {
+    match kind {
+        crate::model::ImportKind::Static => "static",
+        crate::model::ImportKind::SideEffect => "side-effect",
+        crate::model::ImportKind::Reexport => "reexport",
+        crate::model::ImportKind::ReexportAll => "reexport-all",
+        crate::model::ImportKind::ReexportNamespace => "reexport-namespace",
+        crate::model::ImportKind::Require => "require",
+        crate::model::ImportKind::Dynamic => "dynamic",
+        crate::model::ImportKind::Unknown => "unknown",
+    }
+}
+
+fn orphan_kind_to_string(kind: &OrphanKind) -> &'static str {
+    match kind {
+        OrphanKind::Module => "orphan-module",
+        OrphanKind::Component => "orphan-component",
+        OrphanKind::RouteModule => "orphan-route-module",
+    }
+}
+
+fn round_confidence(value: f32) -> f32 {
+    (value * 100.0).round() / 100.0
+}

--- a/crates/kratos-core/tests/report_diff.rs
+++ b/crates/kratos-core/tests/report_diff.rs
@@ -1,0 +1,491 @@
+use std::path::PathBuf;
+
+use kratos_core::model::{
+    BrokenImportFinding, DeadExportFinding, DeletionCandidateFinding, EntrypointKind, FindingSet,
+    ImportKind, ModuleRecord, OrphanFileFinding, OrphanKind, ReportV2, RouteEntrypointFinding,
+    SummaryCounts, UnusedImportFinding,
+};
+use kratos_core::report_diff::{
+    diff_reports, format_diff_json, format_diff_markdown, format_diff_summary,
+};
+use serde_json::Value;
+
+#[test]
+fn diff_reports_only_tracks_finding_changes_and_ignores_report_metadata() {
+    let before = report_v2(
+        "/repo/before",
+        Some("/repo/before/kratos.config.json"),
+        Some("2026-04-22T00:00:00Z"),
+        summary_counts(1, 2, 3, 4, 5, 6, 7, 8, 9),
+        finding_set(
+            vec![
+                broken_import("/repo/src/a.ts", "./missing"),
+                broken_import("/repo/src/shared.ts", "./shared"),
+            ],
+            vec![
+                orphan_file("/repo/src/orphan-a.ts", OrphanKind::Module, "A", 0.91),
+                orphan_file("/repo/src/orphan-b.ts", OrphanKind::Component, "B", 0.82),
+            ],
+            vec![
+                dead_export("/repo/src/dead-a.ts", "old"),
+                dead_export("/repo/src/dead-b.ts", "keep"),
+            ],
+            vec![
+                unused_import("/repo/src/use-a.ts", "./lib", "old", "Old"),
+                unused_import("/repo/src/use-a.ts", "./lib", "keep", "Keep"),
+            ],
+            vec![route_entrypoint(
+                "/repo/src/routes.ts",
+                EntrypointKind::NextAppRoute,
+            )],
+            vec![
+                deletion_candidate("/repo/src/delete-a.ts", "unused", 0.98, true),
+                deletion_candidate("/repo/src/delete-b.ts", "kept", 0.77, false),
+            ],
+        ),
+        vec![module("/repo/src/one.ts")],
+    );
+    let after = report_v2(
+        "/repo/after",
+        None,
+        Some("2026-04-22T01:00:00Z"),
+        summary_counts(10, 20, 30, 40, 50, 60, 70, 80, 90),
+        finding_set(
+            vec![
+                broken_import("/repo/src/shared.ts", "./shared"),
+                broken_import("/repo/src/b.ts", "./introduced"),
+            ],
+            vec![
+                orphan_file("/repo/src/orphan-b.ts", OrphanKind::Component, "B", 0.82),
+                orphan_file("/repo/src/orphan-c.ts", OrphanKind::RouteModule, "C", 0.73),
+            ],
+            vec![dead_export("/repo/src/dead-b.ts", "keep")],
+            vec![
+                unused_import("/repo/src/use-a.ts", "./lib", "keep", "Keep"),
+                unused_import("/repo/src/use-a.ts", "./lib", "new", "New"),
+            ],
+            vec![
+                route_entrypoint("/repo/src/routes.ts", EntrypointKind::NextAppRoute),
+                route_entrypoint("/repo/src/route-tool.ts", EntrypointKind::ToolingEntry),
+            ],
+            vec![
+                deletion_candidate("/repo/src/delete-b.ts", "kept", 0.77, false),
+                deletion_candidate("/repo/src/delete-c.ts", "new", 0.65, true),
+            ],
+        ),
+        vec![module("/repo/src/two.ts"), module("/repo/src/three.ts")],
+    );
+
+    let diff = diff_reports(&before, &after);
+
+    assert_eq!(diff.summary.broken_imports.introduced, 1);
+    assert_eq!(diff.summary.broken_imports.resolved, 1);
+    assert_eq!(diff.summary.broken_imports.persisted, 1);
+    assert_eq!(diff.summary.orphan_files.introduced, 1);
+    assert_eq!(diff.summary.orphan_files.resolved, 1);
+    assert_eq!(diff.summary.orphan_files.persisted, 1);
+    assert_eq!(diff.summary.dead_exports.introduced, 0);
+    assert_eq!(diff.summary.dead_exports.resolved, 1);
+    assert_eq!(diff.summary.dead_exports.persisted, 1);
+    assert_eq!(diff.summary.unused_imports.introduced, 1);
+    assert_eq!(diff.summary.unused_imports.resolved, 1);
+    assert_eq!(diff.summary.unused_imports.persisted, 1);
+    assert_eq!(diff.summary.route_entrypoints.introduced, 1);
+    assert_eq!(diff.summary.route_entrypoints.resolved, 0);
+    assert_eq!(diff.summary.route_entrypoints.persisted, 1);
+    assert_eq!(diff.summary.deletion_candidates.introduced, 1);
+    assert_eq!(diff.summary.deletion_candidates.resolved, 1);
+    assert_eq!(diff.summary.deletion_candidates.persisted, 1);
+    assert_eq!(diff.summary.totals.introduced, 5);
+    assert_eq!(diff.summary.totals.resolved, 5);
+    assert_eq!(diff.summary.totals.persisted, 6);
+
+    assert_eq!(
+        diff.findings.broken_imports.introduced,
+        vec![broken_import("/repo/src/b.ts", "./introduced")]
+    );
+    assert_eq!(
+        diff.findings.broken_imports.resolved,
+        vec![broken_import("/repo/src/a.ts", "./missing")]
+    );
+    assert_eq!(
+        diff.findings.broken_imports.persisted,
+        vec![broken_import("/repo/src/shared.ts", "./shared")]
+    );
+    assert_eq!(
+        diff.findings.route_entrypoints.introduced,
+        vec![route_entrypoint(
+            "/repo/src/route-tool.ts",
+            EntrypointKind::ToolingEntry,
+        )]
+    );
+    assert_eq!(
+        diff.findings.route_entrypoints.persisted,
+        vec![route_entrypoint(
+            "/repo/src/routes.ts",
+            EntrypointKind::NextAppRoute,
+        )]
+    );
+    assert_eq!(
+        diff.findings.deletion_candidates.resolved,
+        vec![deletion_candidate(
+            "/repo/src/delete-a.ts",
+            "unused",
+            0.98,
+            true
+        )]
+    );
+}
+
+#[test]
+fn diff_formatters_render_summary_markdown_and_json() {
+    let before = report_v2(
+        "/repo/before",
+        None,
+        None,
+        SummaryCounts::default(),
+        finding_set(
+            vec![broken_import("/repo/src/a.ts", "./missing")],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        ),
+        vec![],
+    );
+    let after = report_v2(
+        "/repo/after",
+        None,
+        None,
+        SummaryCounts::default(),
+        finding_set(
+            vec![broken_import("/repo/src/b.ts", "./introduced")],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        ),
+        vec![],
+    );
+    let diff = diff_reports(&before, &after);
+    let before_path = PathBuf::from("/tmp/before-report.json");
+    let after_path = PathBuf::from("/tmp/after-report.json");
+
+    let summary =
+        format_diff_summary(&diff, &before_path, &after_path).expect("summary should format");
+    assert!(summary.contains("Kratos diff complete."));
+    assert!(summary.contains("Before: /tmp/before-report.json"));
+    assert!(summary.contains("Broken imports: introduced 1, resolved 1, persisted 0"));
+    assert!(summary.contains("Totals: introduced 1, resolved 1, persisted 0"));
+
+    let markdown =
+        format_diff_markdown(&diff, &before_path, &after_path).expect("markdown should format");
+    assert!(markdown.contains("# Kratos Diff"));
+    assert!(markdown.contains("## Broken imports"));
+    assert!(markdown.contains("### Introduced (1)"));
+    assert!(markdown.contains("### Resolved (1)"));
+    assert!(markdown.contains("### Persisted (0)"));
+
+    let json = format_diff_json(&diff, &before_path, &after_path).expect("json should format");
+    let value: Value = serde_json::from_str(&json).expect("diff json should parse");
+    assert_eq!(
+        value["before"]["path"],
+        Value::from("/tmp/before-report.json")
+    );
+    assert_eq!(
+        value["after"]["path"],
+        Value::from("/tmp/after-report.json")
+    );
+    assert_eq!(
+        value["summary"]["brokenImports"]["introduced"],
+        Value::from(1)
+    );
+    assert_eq!(
+        value["findings"]["brokenImports"]["introduced"][0]["file"],
+        Value::from("/repo/src/b.ts")
+    );
+}
+
+#[test]
+fn diff_reports_treats_matching_relative_paths_as_persisted_across_root_changes() {
+    let before = report_v2(
+        "/repo/before",
+        None,
+        None,
+        SummaryCounts::default(),
+        finding_set(
+            vec![broken_import("/repo/before/src/index.ts", "./shared")],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        ),
+        vec![],
+    );
+    let after = report_v2(
+        "/repo/after",
+        None,
+        None,
+        SummaryCounts::default(),
+        finding_set(
+            vec![broken_import("/repo/after/src/index.ts", "./shared")],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        ),
+        vec![],
+    );
+
+    let diff = diff_reports(&before, &after);
+
+    assert_eq!(diff.summary.broken_imports.introduced, 0);
+    assert_eq!(diff.summary.broken_imports.resolved, 0);
+    assert_eq!(diff.summary.broken_imports.persisted, 1);
+}
+
+#[test]
+fn diff_reports_tracks_duplicate_finding_count_changes() {
+    let before = report_v2(
+        "/repo/before",
+        None,
+        None,
+        SummaryCounts::default(),
+        finding_set(
+            vec![
+                broken_import("/repo/before/src/index.ts", "./shared"),
+                broken_import("/repo/before/src/index.ts", "./shared"),
+            ],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        ),
+        vec![],
+    );
+    let after = report_v2(
+        "/repo/after",
+        None,
+        None,
+        SummaryCounts::default(),
+        finding_set(
+            vec![broken_import("/repo/after/src/index.ts", "./shared")],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        ),
+        vec![],
+    );
+
+    let diff = diff_reports(&before, &after);
+
+    assert_eq!(diff.summary.broken_imports.introduced, 0);
+    assert_eq!(diff.summary.broken_imports.resolved, 1);
+    assert_eq!(diff.summary.broken_imports.persisted, 1);
+    assert_eq!(
+        diff.findings.broken_imports.resolved,
+        vec![broken_import("/repo/before/src/index.ts", "./shared")]
+    );
+    assert_eq!(
+        diff.findings.broken_imports.persisted,
+        vec![broken_import("/repo/after/src/index.ts", "./shared")]
+    );
+}
+
+#[test]
+fn diff_reports_treat_deletion_candidate_metadata_changes_as_real_changes() {
+    let before = report_v2(
+        "/repo/before",
+        None,
+        None,
+        SummaryCounts::default(),
+        finding_set(
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![deletion_candidate(
+                "/repo/before/src/delete.ts",
+                "unused",
+                0.55,
+                false,
+            )],
+        ),
+        vec![],
+    );
+    let after = report_v2(
+        "/repo/after",
+        None,
+        None,
+        SummaryCounts::default(),
+        finding_set(
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![deletion_candidate(
+                "/repo/after/src/delete.ts",
+                "unused but safer now",
+                0.91,
+                true,
+            )],
+        ),
+        vec![],
+    );
+
+    let diff = diff_reports(&before, &after);
+
+    assert_eq!(diff.summary.deletion_candidates.introduced, 1);
+    assert_eq!(diff.summary.deletion_candidates.resolved, 1);
+    assert_eq!(diff.summary.deletion_candidates.persisted, 0);
+    assert_eq!(
+        diff.findings.deletion_candidates.resolved,
+        vec![deletion_candidate(
+            "/repo/before/src/delete.ts",
+            "unused",
+            0.55,
+            false,
+        )]
+    );
+    assert_eq!(
+        diff.findings.deletion_candidates.introduced,
+        vec![deletion_candidate(
+            "/repo/after/src/delete.ts",
+            "unused but safer now",
+            0.91,
+            true,
+        )]
+    );
+}
+
+fn report_v2(
+    root: &str,
+    config_path: Option<&str>,
+    generated_at: Option<&str>,
+    summary: SummaryCounts,
+    findings: FindingSet,
+    modules: Vec<ModuleRecord>,
+) -> ReportV2 {
+    ReportV2 {
+        version: 2,
+        generated_at: generated_at.map(str::to_string),
+        root: PathBuf::from(root),
+        config_path: config_path.map(PathBuf::from),
+        summary,
+        findings,
+        modules,
+    }
+}
+
+fn summary_counts(
+    files_scanned: usize,
+    entrypoints: usize,
+    broken_imports: usize,
+    orphan_files: usize,
+    dead_exports: usize,
+    unused_imports: usize,
+    route_entrypoints: usize,
+    deletion_candidates: usize,
+    suppressed_findings: usize,
+) -> SummaryCounts {
+    SummaryCounts {
+        files_scanned,
+        entrypoints,
+        broken_imports,
+        orphan_files,
+        dead_exports,
+        unused_imports,
+        route_entrypoints,
+        deletion_candidates,
+        suppressed_findings,
+    }
+}
+
+fn finding_set(
+    broken_imports: Vec<BrokenImportFinding>,
+    orphan_files: Vec<OrphanFileFinding>,
+    dead_exports: Vec<DeadExportFinding>,
+    unused_imports: Vec<UnusedImportFinding>,
+    route_entrypoints: Vec<RouteEntrypointFinding>,
+    deletion_candidates: Vec<DeletionCandidateFinding>,
+) -> FindingSet {
+    FindingSet {
+        broken_imports,
+        orphan_files,
+        dead_exports,
+        unused_imports,
+        route_entrypoints,
+        deletion_candidates,
+    }
+}
+
+fn module(file: &str) -> ModuleRecord {
+    ModuleRecord {
+        file_path: PathBuf::from(file),
+        relative_path: file.trim_start_matches('/').to_string(),
+        ..ModuleRecord::default()
+    }
+}
+
+fn broken_import(file: &str, source: &str) -> BrokenImportFinding {
+    BrokenImportFinding {
+        file: PathBuf::from(file),
+        source: source.to_string(),
+        kind: ImportKind::Static,
+    }
+}
+
+fn orphan_file(file: &str, kind: OrphanKind, reason: &str, confidence: f32) -> OrphanFileFinding {
+    OrphanFileFinding {
+        file: PathBuf::from(file),
+        kind,
+        reason: reason.to_string(),
+        confidence,
+    }
+}
+
+fn dead_export(file: &str, export_name: &str) -> DeadExportFinding {
+    DeadExportFinding {
+        file: PathBuf::from(file),
+        export_name: export_name.to_string(),
+    }
+}
+
+fn unused_import(file: &str, source: &str, local: &str, imported: &str) -> UnusedImportFinding {
+    UnusedImportFinding {
+        file: PathBuf::from(file),
+        source: source.to_string(),
+        local: local.to_string(),
+        imported: imported.to_string(),
+    }
+}
+
+fn route_entrypoint(file: &str, kind: EntrypointKind) -> RouteEntrypointFinding {
+    RouteEntrypointFinding {
+        file: PathBuf::from(file),
+        kind,
+    }
+}
+
+fn deletion_candidate(
+    file: &str,
+    reason: &str,
+    confidence: f32,
+    safe: bool,
+) -> DeletionCandidateFinding {
+    DeletionCandidateFinding {
+        file: PathBuf::from(file),
+        reason: reason.to_string(),
+        confidence,
+        safe,
+    }
+}


### PR DESCRIPTION
## 배경
- WOW roadmap의 Phase 3B로 저장된 report 사이의 finding 변화를 비교하는 `kratos diff`를 추가합니다.
- history/presentation 단계의 기반 기능으로 introduced, resolved, persisted finding 비교를 제공해야 합니다.

## 변경 사항
- core에 finding-level report diff engine과 summary/markdown/json formatter를 추가했습니다.
- CLI에 `kratos diff` 명령을 추가하고 project root 입력 시 `.kratos/latest-report.json`를 해석하도록 연결했습니다.
- before/after report root가 달라도 상대 경로 기준으로 persisted finding을 비교하도록 정규화했습니다.
- core/cli 회귀 테스트를 추가했습니다.

## 검증
- `cargo test -p kratos-core --test report_diff`
- `cargo test -p kratos-cli --test diff_cli --test cli_smoke`
- `cargo test --workspace`
- `npm run verify`
  - native addon smoke 1건은 `KRATOS_PACKAGE_SMOKE_NATIVE_LIB` 미설정으로 skip

## 브랜치 / 워크트리
- base: `master`
- head: `codex/wow-3b-report-diff-engine`
- worktree: `/Users/pjw/workspace/kratos`

## 이슈 연결
- 별도 이슈 연결 없음