### PR TITLE
feat: scan report 출력 품질 개선

### DIFF
--- a/crates/kratos-core/src/report.rs
+++ b/crates/kratos-core/src/report.rs
@@ -709,7 +709,7 @@ pub(crate) fn entrypoint_kind_to_string(kind: &EntrypointKind) -> &'static str {
     }
 }
 
-fn import_kind_to_string(kind: &ImportKind) -> &'static str {
+pub(crate) fn import_kind_to_string(kind: &ImportKind) -> &'static str {
     match kind {
         ImportKind::Static => "static",
         ImportKind::SideEffect => "side-effect",

--- a/crates/kratos-core/src/report_format.rs
+++ b/crates/kratos-core/src/report_format.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use crate::model::ReportV2;
-use crate::report::{entrypoint_kind_to_string, path_to_string};
+use crate::report::{entrypoint_kind_to_string, import_kind_to_string, path_to_string};
 use crate::KratosResult;
 
 pub fn format_summary_report(
@@ -12,7 +12,20 @@ pub fn format_summary_report(
     let mut lines = vec![
         title.to_string(),
         String::new(),
-        format!("Root: {}", path_to_string(&report.root)),
+        "Project:".to_string(),
+        format!("- Root: {}", path_to_string(&report.root)),
+        format!(
+            "- Generated: {}",
+            report.generated_at.as_deref().unwrap_or("undefined")
+        ),
+        format!("- Saved report: {}", path_to_string(report_path)),
+    ];
+    if let Some(config_path) = &report.config_path {
+        lines.push(format!("- Config: {}", format_project_path(report, config_path)));
+    }
+    lines.extend([
+        String::new(),
+        "Finding counts:".to_string(),
         format!("Files scanned: {}", report.summary.files_scanned),
         format!("Entrypoints: {}", report.summary.entrypoints),
         format!("Broken imports: {}", report.summary.broken_imports),
@@ -24,7 +37,7 @@ pub fn format_summary_report(
             "Deletion candidates: {}",
             report.summary.deletion_candidates
         ),
-    ];
+    ]);
     if report.summary.suppressed_findings > 0 {
         lines.push(format!(
             "Suppressed findings: {}",
@@ -32,25 +45,52 @@ pub fn format_summary_report(
         ));
     }
     lines.push(String::new());
-    lines.push(format!("Saved report: {}", path_to_string(report_path)));
+    lines.push("Findings preview:".to_string());
 
     append_preview(
         &mut lines,
         "Broken imports",
         &report.findings.broken_imports,
-        |item| format!("{} -> {}", path_to_string(&item.file), item.source),
+        |item| {
+            format!(
+                "{} -> {} ({})",
+                format_project_path(report, &item.file),
+                item.source,
+                import_kind_to_string(&item.kind)
+            )
+        },
     );
     append_preview(
         &mut lines,
         "Orphan files",
         &report.findings.orphan_files,
-        |item| path_to_string(&item.file),
+        |item| {
+            format!(
+                "{} [{:.2}] {}",
+                format_project_path(report, &item.file),
+                item.confidence,
+                item.reason
+            )
+        },
     );
     append_preview(
         &mut lines,
         "Dead exports",
         &report.findings.dead_exports,
-        |item| format!("{}#{}", path_to_string(&item.file), item.export_name),
+        |item| format!("{}#{}", format_project_path(report, &item.file), item.export_name),
+    );
+    append_preview(
+        &mut lines,
+        "Unused imports",
+        &report.findings.unused_imports,
+        |item| {
+            format!(
+                "{} -> {} from {}",
+                format_project_path(report, &item.file),
+                item.local,
+                item.source
+            )
+        },
     );
     append_preview(
         &mut lines,
@@ -59,11 +99,34 @@ pub fn format_summary_report(
         |item| {
             format!(
                 "{} ({})",
-                path_to_string(&item.file),
+                format_project_path(report, &item.file),
                 entrypoint_kind_to_string(&item.kind)
             )
         },
     );
+    append_preview(
+        &mut lines,
+        "Deletion candidates",
+        &report.findings.deletion_candidates,
+        |item| {
+            format!(
+                "{} [{:.2}] {}",
+                format_project_path(report, &item.file),
+                item.confidence,
+                item.reason
+            )
+        },
+    );
+    lines.push(String::new());
+    lines.push("Next steps:".to_string());
+    lines.push(format!(
+        "- kratos report {} --format md",
+        format_shell_argument(&path_to_string(report_path))
+    ));
+    lines.push(format!(
+        "- kratos clean {}",
+        format_shell_argument(&path_to_string(report_path))
+    ));
 
     Ok(lines.join("\n"))
 }
@@ -78,6 +141,11 @@ pub fn format_markdown_report(report: &ReportV2, report_path: &Path) -> KratosRe
         ),
         format!("- Root: {}", path_to_string(&report.root)),
         format!("- Report: {}", path_to_string(report_path)),
+    ];
+    if let Some(config_path) = &report.config_path {
+        lines.push(format!("- Config: {}", format_project_path(report, config_path)));
+    }
+    lines.extend([
         String::new(),
         "## Summary".to_string(),
         String::new(),
@@ -92,7 +160,7 @@ pub fn format_markdown_report(report: &ReportV2, report_path: &Path) -> KratosRe
             "- Deletion candidates: {}",
             report.summary.deletion_candidates
         ),
-    ];
+    ]);
     if report.summary.suppressed_findings > 0 {
         lines.push(format!(
             "- Suppressed findings: {}",
@@ -100,33 +168,70 @@ pub fn format_markdown_report(report: &ReportV2, report_path: &Path) -> KratosRe
         ));
     }
     lines.push(String::new());
+    lines.push("## Next Steps".to_string());
+    lines.push(String::new());
+    lines.push(format!(
+        "- {}",
+        format_markdown_inline_code(&format!(
+            "kratos report {} --format md",
+            format_shell_argument(&path_to_string(report_path))
+        ))
+    ));
+    lines.push(format!(
+        "- {}",
+        format_markdown_inline_code(&format!(
+            "kratos clean {}",
+            format_shell_argument(&path_to_string(report_path))
+        ))
+    ));
+    lines.push(String::new());
 
     push_markdown_section(
         &mut lines,
-        "Broken imports",
+        &format!("Broken imports ({})", report.findings.broken_imports.len()),
         &report.findings.broken_imports,
-        |item| format!("{} -> `{}`", path_to_string(&item.file), item.source),
+        |item| {
+            format!(
+                "{} -> `{}` ({})",
+                format_project_path(report, &item.file),
+                item.source,
+                import_kind_to_string(&item.kind)
+            )
+        },
     );
     push_markdown_section(
         &mut lines,
-        "Orphan files",
+        &format!("Orphan files ({})", report.findings.orphan_files.len()),
         &report.findings.orphan_files,
-        |item| format!("{} ({})", path_to_string(&item.file), item.reason),
+        |item| {
+            format!(
+                "{} ({}, confidence {:.2})",
+                format_project_path(report, &item.file),
+                item.reason,
+                item.confidence
+            )
+        },
     );
     push_markdown_section(
         &mut lines,
-        "Dead exports",
+        &format!("Dead exports ({})", report.findings.dead_exports.len()),
         &report.findings.dead_exports,
-        |item| format!("{} -> `{}`", path_to_string(&item.file), item.export_name),
+        |item| {
+            format!(
+                "{} -> `{}`",
+                format_project_path(report, &item.file),
+                item.export_name
+            )
+        },
     );
     push_markdown_section(
         &mut lines,
-        "Unused imports",
+        &format!("Unused imports ({})", report.findings.unused_imports.len()),
         &report.findings.unused_imports,
         |item| {
             format!(
                 "{} -> `{}` from `{}`",
-                path_to_string(&item.file),
+                format_project_path(report, &item.file),
                 item.local,
                 item.source
             )
@@ -134,26 +239,30 @@ pub fn format_markdown_report(report: &ReportV2, report_path: &Path) -> KratosRe
     );
     push_markdown_section(
         &mut lines,
-        "Route entrypoints",
+        &format!("Route entrypoints ({})", report.findings.route_entrypoints.len()),
         &report.findings.route_entrypoints,
         |item| {
             format!(
                 "{} ({})",
-                path_to_string(&item.file),
+                format_project_path(report, &item.file),
                 entrypoint_kind_to_string(&item.kind)
             )
         },
     );
     push_markdown_section(
         &mut lines,
-        "Deletion candidates",
+        &format!(
+            "Deletion candidates ({})",
+            report.findings.deletion_candidates.len()
+        ),
         &report.findings.deletion_candidates,
         |item| {
             format!(
-                "{} ({}, confidence {})",
-                path_to_string(&item.file),
+                "{} ({}, confidence {:.2}, safe {})",
+                format_project_path(report, &item.file),
                 item.reason,
-                item.confidence
+                item.confidence,
+                item.safe
             )
         },
     );
@@ -180,6 +289,37 @@ fn append_preview<T>(
 
     if items.len() > 5 {
         lines.push(format!("- ...and {} more", items.len() - 5));
+    }
+}
+
+fn format_project_path(report: &ReportV2, path: &Path) -> String {
+    path.strip_prefix(&report.root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn format_shell_argument(value: &str) -> String {
+    if value.is_empty() {
+        "''".to_string()
+    } else {
+        format!("'{}'", value.replace('\'', "'\\''"))
+    }
+}
+
+fn format_markdown_inline_code(value: &str) -> String {
+    let delimiter_width = value
+        .split(|character| character != '`')
+        .map(str::len)
+        .max()
+        .unwrap_or(0)
+        + 1;
+    let delimiter = "`".repeat(delimiter_width);
+
+    if value.starts_with('`') || value.ends_with('`') {
+        format!("{delimiter} {value} {delimiter}")
+    } else {
+        format!("{delimiter}{value}{delimiter}")
     }
 }
 

--- a/crates/kratos-core/tests/report_format.rs
+++ b/crates/kratos-core/tests/report_format.rs
@@ -58,6 +58,50 @@ fn incomplete_future_schema_reports_fail_fast_instead_of_rendering_defaults() {
     assert!(error.to_string().contains("required object `summary`"));
 }
 
+#[test]
+fn next_steps_quote_report_paths_with_spaces() {
+    let report = parse_report_json(
+        "{\"schemaVersion\":2,\"project\":{\"root\":\"/tmp/demo root\",\"configPath\":null},\"summary\":{\"filesScanned\":0,\"entrypoints\":0,\"brokenImports\":0,\"orphanFiles\":0,\"deadExports\":0,\"unusedImports\":0,\"routeEntrypoints\":0,\"deletionCandidates\":0},\"findings\":{\"brokenImports\":[],\"orphanFiles\":[],\"deadExports\":[],\"unusedImports\":[],\"routeEntrypoints\":[],\"deletionCandidates\":[]},\"graph\":{\"modules\":[]}}",
+    )
+    .expect("report should parse");
+    let report_path = Path::new("/tmp/demo root/.kratos/latest report.json");
+
+    let summary = format_summary_report(&report, report_path, "Kratos report.")
+        .expect("summary should format");
+    let markdown = format_markdown_report(&report, report_path).expect("markdown should format");
+
+    assert!(summary.contains(
+        "kratos report '/tmp/demo root/.kratos/latest report.json' --format md"
+    ));
+    assert!(summary.contains(
+        "kratos clean '/tmp/demo root/.kratos/latest report.json'"
+    ));
+    assert!(markdown.contains(
+        "`kratos report '/tmp/demo root/.kratos/latest report.json' --format md`"
+    ));
+    assert!(markdown.contains(
+        "`kratos clean '/tmp/demo root/.kratos/latest report.json'`"
+    ));
+}
+
+#[test]
+fn next_steps_escape_report_paths_with_backticks_for_markdown() {
+    let report = parse_report_json(
+        "{\"schemaVersion\":2,\"project\":{\"root\":\"/tmp/demo\",\"configPath\":null},\"summary\":{\"filesScanned\":0,\"entrypoints\":0,\"brokenImports\":0,\"orphanFiles\":0,\"deadExports\":0,\"unusedImports\":0,\"routeEntrypoints\":0,\"deletionCandidates\":0},\"findings\":{\"brokenImports\":[],\"orphanFiles\":[],\"deadExports\":[],\"unusedImports\":[],\"routeEntrypoints\":[],\"deletionCandidates\":[]},\"graph\":{\"modules\":[]}}",
+    )
+    .expect("report should parse");
+    let report_path = Path::new("/tmp/demo/.kratos/latest`report`.json");
+
+    let markdown = format_markdown_report(&report, report_path).expect("markdown should format");
+
+    assert!(markdown.contains(
+        "``kratos report '/tmp/demo/.kratos/latest`report`.json' --format md``"
+    ));
+    assert!(markdown.contains(
+        "``kratos clean '/tmp/demo/.kratos/latest`report`.json'``"
+    ));
+}
+
 fn repo_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .ancestors()

--- a/fixtures/parity/demo-app/report-markdown.md
+++ b/fixtures/parity/demo-app/report-markdown.md
@@ -15,30 +15,35 @@
 - Route entrypoints: 1
 - Deletion candidates: 2
 
-## Broken imports
+## Next Steps
 
-- <ROOT>/src/lib/broken.ts -> `./missing-helper`
+- `kratos report '<REPORT>' --format md`
+- `kratos clean '<REPORT>'`
 
-## Orphan files
+## Broken imports (1)
 
-- <ROOT>/src/components/DeadWidget.tsx (Component-like module has no inbound references.)
-- <ROOT>/src/lib/broken.ts (Module has no inbound references and is not treated as an entrypoint.)
+- src/lib/broken.ts -> `./missing-helper` (static)
 
-## Dead exports
+## Orphan files (2)
 
-- <ROOT>/src/components/DeadWidget.tsx -> `DeadWidget`
-- <ROOT>/src/lib/broken.ts -> `brokenFeature`
-- <ROOT>/src/lib/math.ts -> `multiply`
+- src/components/DeadWidget.tsx (Component-like module has no inbound references., confidence 0.92)
+- src/lib/broken.ts (Module has no inbound references and is not treated as an entrypoint., confidence 0.88)
 
-## Unused imports
+## Dead exports (3)
+
+- src/components/DeadWidget.tsx -> `DeadWidget`
+- src/lib/broken.ts -> `brokenFeature`
+- src/lib/math.ts -> `multiply`
+
+## Unused imports (0)
 
 - None
 
-## Route entrypoints
+## Route entrypoints (1)
 
-- <ROOT>/pages/home.tsx (next-pages-route)
+- pages/home.tsx (next-pages-route)
 
-## Deletion candidates
+## Deletion candidates (2)
 
-- <ROOT>/src/components/DeadWidget.tsx (Component-like module has no inbound references., confidence 0.92)
-- <ROOT>/src/lib/broken.ts (Module has no inbound references and is not treated as an entrypoint., confidence 0.88)
+- src/components/DeadWidget.tsx (Component-like module has no inbound references., confidence 0.92, safe true)
+- src/lib/broken.ts (Module has no inbound references and is not treated as an entrypoint., confidence 0.88, safe true)

--- a/fixtures/parity/demo-app/report-summary.txt
+++ b/fixtures/parity/demo-app/report-summary.txt
@@ -1,6 +1,11 @@
 Kratos report.
 
-Root: <ROOT>
+Project:
+- Root: <ROOT>
+- Generated: <GENERATED_AT>
+- Saved report: <REPORT>
+
+Finding counts:
 Files scanned: 5
 Entrypoints: 1
 Broken imports: 1
@@ -10,19 +15,27 @@ Unused imports: 0
 Route entrypoints: 1
 Deletion candidates: 2
 
-Saved report: <REPORT>
+Findings preview:
 
 Broken imports:
-- <ROOT>/src/lib/broken.ts -> ./missing-helper
+- src/lib/broken.ts -> ./missing-helper (static)
 
 Orphan files:
-- <ROOT>/src/components/DeadWidget.tsx
-- <ROOT>/src/lib/broken.ts
+- src/components/DeadWidget.tsx [0.92] Component-like module has no inbound references.
+- src/lib/broken.ts [0.88] Module has no inbound references and is not treated as an entrypoint.
 
 Dead exports:
-- <ROOT>/src/components/DeadWidget.tsx#DeadWidget
-- <ROOT>/src/lib/broken.ts#brokenFeature
-- <ROOT>/src/lib/math.ts#multiply
+- src/components/DeadWidget.tsx#DeadWidget
+- src/lib/broken.ts#brokenFeature
+- src/lib/math.ts#multiply
 
 Route entrypoints:
-- <ROOT>/pages/home.tsx (next-pages-route)
+- pages/home.tsx (next-pages-route)
+
+Deletion candidates:
+- src/components/DeadWidget.tsx [0.92] Component-like module has no inbound references.
+- src/lib/broken.ts [0.88] Module has no inbound references and is not treated as an entrypoint.
+
+Next steps:
+- kratos report '<REPORT>' --format md
+- kratos clean '<REPORT>'


### PR DESCRIPTION
## 배경

`scan`/`report` 출력이 실제 사용 기준으로 너무 얇아서, 저장된 report를 다시 열지 않아도 핵심 finding을 바로 파악할 수 있어야 했습니다.

## 변경 사항

- summary/markdown formatter에 프로젝트 메타데이터와 next step 힌트를 추가했습니다.
- broken import, orphan file, deletion candidate preview를 상대경로와 상세 reason 중심으로 강화했습니다.
- markdown section title에 count를 표시하고 deletion candidate에 safe/confidence 정보를 노출했습니다.
- parity fixture를 새 formatter 출력에 맞게 갱신했습니다.

## 검증

- `cargo test -p kratos-core --test report_format --test report_v2`

## 브랜치 / 워크트리

- 브랜치: `codex/report-preview-format`
- PR base: `codex/ignore-patterns`
- 워크트리: `/Users/pjw/workspace/kratos`

## 리스크 또는 확인 포인트

- 출력 형식이 바뀌었기 때문에 외부 문서나 스크린샷이 있다면 후속 동기화가 필요할 수 있습니다.
