### PR TITLE
feat: clean dry-run 플래그와 결과 요약 추가

### DIFF
--- a/crates/kratos-cli/src/commands/clean.rs
+++ b/crates/kratos-cli/src/commands/clean.rs
@@ -4,7 +4,7 @@ use std::io::Write;
 use clap::Parser;
 use kratos_core::clean::clean_from_report;
 use kratos_core::report::parse_report_json;
-use kratos_core::KratosResult;
+use kratos_core::{KratosError, KratosResult};
 
 use super::{canonicalize_clean_args, resolve_report_input, write_output, CommandSpec};
 
@@ -12,7 +12,7 @@ pub const NAME: &str = "clean";
 pub const SPEC: CommandSpec = CommandSpec {
     name: NAME,
     summary: "Show deletion candidates or delete them with --apply.",
-    usage: &["kratos clean [report-path-or-root] [--apply]"],
+    usage: &["kratos clean [report-path-or-root] [--dry-run|--apply]"],
 };
 
 #[derive(Debug, Parser)]
@@ -22,10 +22,18 @@ struct CleanArgs {
     input: Option<String>,
     #[arg(long)]
     apply: bool,
+    #[arg(long = "dry-run")]
+    dry_run: bool,
 }
 
 pub fn run(args: &[String], stdout: &mut dyn Write) -> KratosResult<i32> {
     let args = parse_args(args)?;
+    if args.apply && args.dry_run {
+        return Err(KratosError::Config(
+            "--apply and --dry-run cannot be used together".to_string(),
+        ));
+    }
+
     let cwd = std::env::current_dir()?;
     let report_path = resolve_report_input(args.input.as_deref(), &cwd);
     let raw = fs::read_to_string(&report_path)?;
@@ -38,30 +46,66 @@ pub fn run(args: &[String], stdout: &mut dyn Write) -> KratosResult<i32> {
     }
 
     if !args.apply {
-        let mut lines = vec!["Kratos clean dry run.".to_string(), String::new()];
+        let mut lines = vec![
+            "Kratos clean dry run.".to_string(),
+            String::new(),
+            format!("- Report: {}", report_path.display()),
+            format!("- Candidates: {}", candidates.len()),
+            String::new(),
+            "Would delete:".to_string(),
+        ];
         for candidate in candidates {
             lines.push(format!(
-                "- {} ({})",
-                candidate.file.display(),
-                candidate.reason
+                "- {} ({}, confidence {:.2})",
+                format_project_path(&report.root, &candidate.file),
+                candidate.reason,
+                candidate.confidence
             ));
         }
         lines.push(String::new());
         lines.push("Re-run with --apply to delete these files.".to_string());
+        lines.push(format!(
+            "Re-run with `kratos clean {} --apply` to delete these files.",
+            report_path.display()
+        ));
         write_output(stdout, &lines.join("\n"))?;
         return Ok(0);
     }
 
     let outcome = clean_from_report(&report, true)?;
-    write_output(
-        stdout,
-        &format!("Kratos clean deleted {} file(s).", outcome.deleted_files),
-    )?;
+    let mut lines = vec![
+        format!("Kratos clean deleted {} file(s).", outcome.deleted_files),
+        String::new(),
+        format!("- Deleted: {}", outcome.deleted_files),
+        format!("- Skipped: {}", outcome.skipped_files),
+    ];
+    if !outcome.deleted_paths.is_empty() {
+        lines.push(String::new());
+        lines.push("Deleted files:".to_string());
+        for path in &outcome.deleted_paths {
+            lines.push(format!("- {}", format_project_path(&report.root, path)));
+        }
+    }
+    if !outcome.skipped_paths.is_empty() {
+        lines.push(String::new());
+        lines.push("Skipped files:".to_string());
+        for path in &outcome.skipped_paths {
+            lines.push(format!("- {}", format_project_path(&report.root, path)));
+        }
+    }
+    write_output(stdout, &lines.join("\n"))?;
     Ok(0)
 }
 
 fn parse_args(args: &[String]) -> KratosResult<CleanArgs> {
-    let canonical = canonicalize_clean_args(args);
+    let canonical = canonicalize_clean_args(args)?;
     CleanArgs::try_parse_from(std::iter::once(NAME).chain(canonical.iter().map(String::as_str)))
         .map_err(|error| kratos_core::KratosError::Config(error.to_string().trim().to_string()))
+}
+
+fn format_project_path(root: &std::path::Path, path: &std::path::Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
 }

--- a/crates/kratos-cli/src/commands/mod.rs
+++ b/crates/kratos-cli/src/commands/mod.rs
@@ -241,8 +241,8 @@ pub fn canonicalize_report_args(raw_args: &[String]) -> Vec<String> {
     args
 }
 
-pub fn canonicalize_clean_args(raw_args: &[String]) -> Vec<String> {
-    let parsed = parse_cli_options(raw_args, &[], &["apply"]);
+pub fn canonicalize_clean_args(raw_args: &[String]) -> KratosResult<Vec<String>> {
+    let parsed = parse_cli_options(raw_args, &[], &["apply", "dry-run"]);
     let mut args = Vec::new();
 
     if let Some(input) = parsed.positionals.first() {
@@ -253,7 +253,11 @@ pub fn canonicalize_clean_args(raw_args: &[String]) -> Vec<String> {
         args.push("--apply".to_string());
     }
 
-    args
+    if is_enabled_boolean_flag(parsed.flags.get("dry-run")) {
+        args.push("--dry-run".to_string());
+    }
+
+    Ok(args)
 }
 
 pub fn resolve_report_input(input: Option<&str>, cwd: &Path) -> PathBuf {

--- a/crates/kratos-cli/tests/cli_smoke.rs
+++ b/crates/kratos-cli/tests/cli_smoke.rs
@@ -10,7 +10,7 @@ fn root_help_matches_expected_shape() {
     assert!(output.status.success());
     assert_eq!(
         String::from_utf8_lossy(&output.stdout),
-        "Kratos\nDestroy dead code ruthlessly.\n\nUsage:\n  kratos scan [root] [--output path] [--json]\n  kratos report [report-path-or-root] [--format summary|json|md]\n  kratos clean [report-path-or-root] [--apply]\n\nCommands:\n  scan    Analyze a codebase and save the latest report.\n  report  Print a saved report in summary, json, or markdown form.\n  clean   Show deletion candidates or delete them with --apply.\n"
+        "Kratos\nDestroy dead code ruthlessly.\n\nUsage:\n  kratos scan [root] [--output path] [--json]\n  kratos report [report-path-or-root] [--format summary|json|md]\n  kratos clean [report-path-or-root] [--dry-run|--apply]\n\nCommands:\n  scan    Analyze a codebase and save the latest report.\n  report  Print a saved report in summary, json, or markdown form.\n  clean   Show deletion candidates or delete them with --apply.\n"
     );
 }
 
@@ -21,7 +21,7 @@ fn unknown_command_returns_help_and_exit_code_one() {
     assert_eq!(output.status.code(), Some(1));
     assert_eq!(
         String::from_utf8_lossy(&output.stderr),
-        "Unknown command: nope\n\nKratos\nDestroy dead code ruthlessly.\n\nUsage:\n  kratos scan [root] [--output path] [--json]\n  kratos report [report-path-or-root] [--format summary|json|md]\n  kratos clean [report-path-or-root] [--apply]\n\nCommands:\n  scan    Analyze a codebase and save the latest report.\n  report  Print a saved report in summary, json, or markdown form.\n  clean   Show deletion candidates or delete them with --apply.\n"
+        "Unknown command: nope\n\nKratos\nDestroy dead code ruthlessly.\n\nUsage:\n  kratos scan [root] [--output path] [--json]\n  kratos report [report-path-or-root] [--format summary|json|md]\n  kratos clean [report-path-or-root] [--dry-run|--apply]\n\nCommands:\n  scan    Analyze a codebase and save the latest report.\n  report  Print a saved report in summary, json, or markdown form.\n  clean   Show deletion candidates or delete them with --apply.\n"
     );
 }
 
@@ -358,7 +358,7 @@ fn clean_accepts_future_schema_reports_when_the_shape_is_compatible() {
     assert!(dry_run.status.success());
     let dry_run_stdout = String::from_utf8_lossy(&dry_run.stdout);
     assert!(dry_run_stdout.contains("Kratos clean dry run."));
-    assert!(dry_run_stdout.contains(&dead_file.display().to_string()));
+    assert!(dry_run_stdout.contains("dead.txt"));
     assert!(dead_file.exists());
 
     let apply = run_cli_in_dir(
@@ -391,6 +391,40 @@ fn scan_output_empty_string_defaults_and_missing_value_errors() {
         !project_root.join("--json").exists(),
         "missing output value should not create a stray report file"
     );
+}
+
+#[test]
+fn clean_supports_explicit_dry_run_and_rejects_conflicting_flags() {
+    let project_root = copy_demo_app("cli-clean-flags");
+    let report_path = project_root.join(".kratos/latest-report.json");
+
+    let prepare_report = run_cli_in_dir(&project_root, &["scan"]);
+    assert!(prepare_report.status.success());
+    assert!(report_path.exists());
+
+    let dry_run = run_cli_in_dir(
+        &project_root,
+        &[
+            "clean",
+            "--dry-run",
+            report_path.to_str().expect("path should be utf8"),
+        ],
+    );
+    assert!(dry_run.status.success());
+    assert!(String::from_utf8_lossy(&dry_run.stdout).contains("Kratos clean dry run."));
+
+    let conflict = run_cli_in_dir(
+        &project_root,
+        &[
+            "clean",
+            "--dry-run",
+            "--apply",
+            report_path.to_str().expect("path should be utf8"),
+        ],
+    );
+    assert_eq!(conflict.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&conflict.stderr)
+        .contains("Kratos failed: Config error: --apply and --dry-run cannot be used together"));
 }
 
 #[test]

--- a/crates/kratos-core/src/clean.rs
+++ b/crates/kratos-core/src/clean.rs
@@ -11,6 +11,8 @@ use crate::report::parse_report_json;
 pub struct CleanOutcome {
     pub deleted_files: usize,
     pub skipped_files: usize,
+    pub deleted_paths: Vec<PathBuf>,
+    pub skipped_paths: Vec<PathBuf>,
 }
 
 pub fn clean_from_report_path(
@@ -54,6 +56,13 @@ pub fn clean_from_report(report: &ReportV2, apply: bool) -> KratosResult<CleanOu
         return Ok(CleanOutcome {
             deleted_files: 0,
             skipped_files: report.findings.deletion_candidates.len(),
+            deleted_paths: Vec::new(),
+            skipped_paths: report
+                .findings
+                .deletion_candidates
+                .iter()
+                .map(|candidate| candidate.file.clone())
+                .collect(),
         });
     }
 
@@ -66,11 +75,13 @@ pub fn clean_from_report(report: &ReportV2, apply: bool) -> KratosResult<CleanOu
 
         if !is_within_directory(&report_root_path, &candidate_path) {
             outcome.skipped_files += 1;
+            outcome.skipped_paths.push(candidate_path);
             continue;
         }
 
         if !file_exists(&candidate_path) {
             outcome.skipped_files += 1;
+            outcome.skipped_paths.push(candidate_path);
             continue;
         }
 
@@ -81,6 +92,7 @@ pub fn clean_from_report(report: &ReportV2, apply: bool) -> KratosResult<CleanOu
 
         if !is_within_directory(&deletion_root, &candidate_parent) {
             outcome.skipped_files += 1;
+            outcome.skipped_paths.push(candidate_path);
             continue;
         }
 
@@ -88,9 +100,11 @@ pub fn clean_from_report(report: &ReportV2, apply: bool) -> KratosResult<CleanOu
             Ok(()) => {
                 remove_empty_directories(candidate_parent_path, &report_root_path)?;
                 outcome.deleted_files += 1;
+                outcome.deleted_paths.push(candidate_path);
             }
             Err(error) if error.kind() == ErrorKind::NotFound => {
                 outcome.skipped_files += 1;
+                outcome.skipped_paths.push(candidate_path);
             }
             Err(error) => return Err(error.into()),
         }


### PR DESCRIPTION
## 배경

`clean`이 사실상 dry-run만 수행하면서도 플래그 계약이 명확하지 않았고, apply 결과도 사람이 읽기엔 정보가 부족했습니다.

## 변경 사항

- `kratos clean`에 명시적 `--dry-run` 플래그를 추가했습니다.
- `--apply`와 `--dry-run` 동시 사용 시 config error로 즉시 실패하도록 했습니다.
- dry-run/apply 모두 report 기준 경로와 삭제/skip 결과를 더 자세히 보여주도록 개선했습니다.
- clean outcome에 deleted/skipped path 집계를 추가하고 CLI smoke test를 보강했습니다.

## 검증

- `cargo test -p kratos-core --test clean_safety`
- `cargo test -p kratos-cli --test cli_smoke clean_supports_explicit_dry_run_and_rejects_conflicting_flags`

## 브랜치 / 워크트리

- 브랜치: `codex/clean-dry-run-contract`
- PR base: `codex/report-preview-format`
- 워크트리: `/Users/pjw/workspace/kratos`

## 리스크 또는 확인 포인트

- help output이 함께 바뀌므로 CLI 문서와 예시 명령이 있다면 추후 맞춰주는 것이 좋습니다.
