### PR TITLE
feat: fail-on CI 게이트 추가

### DIFF
--- a/crates/kratos-cli/src/commands/mod.rs
+++ b/crates/kratos-cli/src/commands/mod.rs
@@ -2,11 +2,11 @@ pub mod clean;
 pub mod report;
 pub mod scan;
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-use kratos_core::{KratosError, KratosResult};
+use kratos_core::{KratosError, KratosResult, ReportV2};
 
 #[derive(Clone, Copy)]
 pub struct CommandSpec {
@@ -198,7 +198,7 @@ pub fn parse_cli_options(
 }
 
 pub fn canonicalize_scan_args(raw_args: &[String]) -> KratosResult<Vec<String>> {
-    let parsed = parse_cli_options(raw_args, &["output"], &["json"]);
+    let parsed = parse_cli_options(raw_args, &["output", "fail-on"], &["json"]);
     let mut args = Vec::new();
 
     if let Some(root) = parsed.positionals.first() {
@@ -220,11 +220,16 @@ pub fn canonicalize_scan_args(raw_args: &[String]) -> KratosResult<Vec<String>> 
         args.push("--json".to_string());
     }
 
+    if let Some(value) = required_value_flag(parsed.flags.get("fail-on"), "--fail-on")? {
+        args.push("--fail-on".to_string());
+        args.push(value.to_string());
+    }
+
     Ok(args)
 }
 
-pub fn canonicalize_report_args(raw_args: &[String]) -> Vec<String> {
-    let parsed = parse_cli_options(raw_args, &["format"], &[]);
+pub fn canonicalize_report_args(raw_args: &[String]) -> KratosResult<Vec<String>> {
+    let parsed = parse_cli_options(raw_args, &["format", "fail-on"], &[]);
     let mut args = Vec::new();
 
     if let Some(input) = parsed.positionals.first() {
@@ -238,7 +243,12 @@ pub fn canonicalize_report_args(raw_args: &[String]) -> Vec<String> {
         }
     }
 
-    args
+    if let Some(value) = required_value_flag(parsed.flags.get("fail-on"), "--fail-on")? {
+        args.push("--fail-on".to_string());
+        args.push(value.to_string());
+    }
+
+    Ok(args)
 }
 
 pub fn canonicalize_clean_args(raw_args: &[String]) -> KratosResult<Vec<String>> {
@@ -326,5 +336,143 @@ fn is_enabled_boolean_flag(value: Option<&ParsedFlagValue>) -> bool {
         Some(ParsedFlagValue::Present) => true,
         Some(ParsedFlagValue::Value(raw)) => !raw.is_empty(),
         None => false,
+    }
+}
+
+fn required_value_flag<'a>(
+    value: Option<&'a ParsedFlagValue>,
+    flag_name: &str,
+) -> KratosResult<Option<&'a str>> {
+    match value {
+        None => Ok(None),
+        Some(ParsedFlagValue::Present) => Err(KratosError::Config(format!(
+            "{flag_name} requires a value"
+        ))),
+        Some(ParsedFlagValue::Value(raw)) if raw.trim().is_empty() => Err(KratosError::Config(
+            format!("{flag_name} requires a non-empty value"),
+        )),
+        Some(ParsedFlagValue::Value(raw)) => Ok(Some(raw.as_str())),
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum FailOnKind {
+    BrokenImports,
+    OrphanFiles,
+    DeadExports,
+    UnusedImports,
+    DeletionCandidates,
+}
+
+pub fn parse_fail_on(raw: Option<&str>) -> KratosResult<Vec<FailOnKind>> {
+    let Some(raw) = raw else {
+        return Ok(Vec::new());
+    };
+
+    let normalized = raw.trim();
+    if normalized.is_empty() || normalized.eq_ignore_ascii_case("none") {
+        return Ok(Vec::new());
+    }
+
+    let mut kinds = BTreeSet::new();
+
+    for token in normalized.split(',').map(str::trim).filter(|token| !token.is_empty()) {
+        match token.to_ascii_lowercase().as_str() {
+            "any" | "all" | "findings" => {
+                kinds.extend([
+                    FailOnKind::BrokenImports,
+                    FailOnKind::OrphanFiles,
+                    FailOnKind::DeadExports,
+                    FailOnKind::UnusedImports,
+                    FailOnKind::DeletionCandidates,
+                ]);
+            }
+            "broken-import" | "broken-imports" | "broken_imports" => {
+                kinds.insert(FailOnKind::BrokenImports);
+            }
+            "orphan-file" | "orphan-files" | "orphan_files" => {
+                kinds.insert(FailOnKind::OrphanFiles);
+            }
+            "dead-export" | "dead-exports" | "dead_exports" => {
+                kinds.insert(FailOnKind::DeadExports);
+            }
+            "unused-import" | "unused-imports" | "unused_imports" => {
+                kinds.insert(FailOnKind::UnusedImports);
+            }
+            "deletion-candidate" | "deletion-candidates" | "deletion_candidates" => {
+                kinds.insert(FailOnKind::DeletionCandidates);
+            }
+            other => {
+                return Err(KratosError::Config(format!(
+                    "Invalid --fail-on value: {other}"
+                )))
+            }
+        }
+    }
+
+    Ok(kinds.into_iter().collect())
+}
+
+pub fn fail_on_exit_code(report: &ReportV2, fail_on: &[FailOnKind]) -> i32 {
+    if gated_findings(report, fail_on).is_empty() {
+        0
+    } else {
+        2
+    }
+}
+
+pub fn render_fail_on_message(
+    report: &ReportV2,
+    fail_on: &[FailOnKind],
+    markdown: bool,
+) -> Option<String> {
+    let failures = gated_findings(report, fail_on);
+    if failures.is_empty() {
+        return None;
+    }
+
+    let matched = failures
+        .iter()
+        .map(|(kind, count)| format!("{}: {}", fail_on_label(*kind), count))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    if markdown {
+        Some(format!(
+            "## Gate Status\n\n- Result: failed\n- Matched findings: {matched}\n"
+        ))
+    } else {
+        Some(format!("Gate status: failed\nMatched findings: {matched}"))
+    }
+}
+
+fn gated_findings(report: &ReportV2, fail_on: &[FailOnKind]) -> Vec<(FailOnKind, usize)> {
+    fail_on
+        .iter()
+        .copied()
+        .filter_map(|kind| {
+            let count = fail_on_count(report, kind);
+            (count > 0).then_some((kind, count))
+        })
+        .collect()
+}
+
+fn fail_on_count(report: &ReportV2, kind: FailOnKind) -> usize {
+    match kind {
+        FailOnKind::BrokenImports => report.findings.broken_imports.len(),
+        FailOnKind::OrphanFiles => report.findings.orphan_files.len(),
+        FailOnKind::DeadExports => report.findings.dead_exports.len(),
+        FailOnKind::UnusedImports => report.findings.unused_imports.len(),
+        FailOnKind::DeletionCandidates => report.findings.deletion_candidates.len(),
+    }
+}
+
+fn fail_on_label(kind: FailOnKind) -> &'static str {
+    match kind {
+        FailOnKind::BrokenImports => "broken imports",
+        FailOnKind::OrphanFiles => "orphan files",
+        FailOnKind::DeadExports => "dead exports",
+        FailOnKind::UnusedImports => "unused imports",
+        FailOnKind::DeletionCandidates => "deletion candidates",
     }
 }

--- a/crates/kratos-cli/src/commands/report.rs
+++ b/crates/kratos-cli/src/commands/report.rs
@@ -7,13 +7,16 @@ use kratos_core::report_format::{format_markdown_report, format_summary_report};
 use kratos_core::{KratosError, KratosResult};
 use serde_json::Value;
 
-use super::{canonicalize_report_args, resolve_report_input, write_output, CommandSpec};
+use super::{
+    canonicalize_report_args, fail_on_exit_code, parse_fail_on, render_fail_on_message,
+    resolve_report_input, write_output, CommandSpec,
+};
 
 pub const NAME: &str = "report";
 pub const SPEC: CommandSpec = CommandSpec {
     name: NAME,
     summary: "Print a saved report in summary, json, or markdown form.",
-    usage: &["kratos report [report-path-or-root] [--format summary|json|md]"],
+    usage: &["kratos report [report-path-or-root] [--format summary|json|md] [--fail-on kinds]"],
 };
 
 #[derive(Debug, Parser)]
@@ -23,6 +26,8 @@ struct ReportArgs {
     input: Option<String>,
     #[arg(long, allow_hyphen_values = true)]
     format: Option<String>,
+    #[arg(long = "fail-on", allow_hyphen_values = true)]
+    fail_on: Option<String>,
 }
 
 pub fn run(args: &[String], stdout: &mut dyn Write) -> KratosResult<i32> {
@@ -33,6 +38,8 @@ pub fn run(args: &[String], stdout: &mut dyn Write) -> KratosResult<i32> {
     let raw_json: Value =
         serde_json::from_str(&raw).map_err(|error| KratosError::Json(error.to_string()))?;
     let format = args.format.as_deref().unwrap_or("summary");
+    let fail_on = parse_fail_on(args.fail_on.as_deref())?;
+    let mut exit_code = 0;
 
     match format {
         "summary" => {
@@ -40,7 +47,11 @@ pub fn run(args: &[String], stdout: &mut dyn Write) -> KratosResult<i32> {
             write_output(
                 stdout,
                 &format_summary_report(&report, &report_path, "Kratos report.")?,
-            )?
+            )?;
+            if let Some(message) = render_fail_on_message(&report, &fail_on, false) {
+                write_output(stdout, &message)?;
+            }
+            exit_code = fail_on_exit_code(&report, &fail_on);
         }
         "json" => write_output(
             stdout,
@@ -49,7 +60,11 @@ pub fn run(args: &[String], stdout: &mut dyn Write) -> KratosResult<i32> {
         )?,
         "md" => {
             let report = parse_report_json(&raw)?;
-            write_output(stdout, &format_markdown_report(&report, &report_path)?)?
+            write_output(stdout, &format_markdown_report(&report, &report_path)?)?;
+            if let Some(message) = render_fail_on_message(&report, &fail_on, true) {
+                write_output(stdout, &message)?;
+            }
+            exit_code = fail_on_exit_code(&report, &fail_on);
         }
         other => {
             return Err(KratosError::Config(format!(
@@ -58,11 +73,16 @@ pub fn run(args: &[String], stdout: &mut dyn Write) -> KratosResult<i32> {
         }
     }
 
-    Ok(0)
+    if format == "json" && !fail_on.is_empty() {
+        let report = parse_report_json(&raw)?;
+        exit_code = fail_on_exit_code(&report, &fail_on);
+    }
+
+    Ok(exit_code)
 }
 
 fn parse_args(args: &[String]) -> KratosResult<ReportArgs> {
-    let canonical = canonicalize_report_args(args);
+    let canonical = canonicalize_report_args(args)?;
     ReportArgs::try_parse_from(std::iter::once(NAME).chain(canonical.iter().map(String::as_str)))
         .map_err(|error| KratosError::Config(error.to_string().trim().to_string()))
 }

--- a/crates/kratos-cli/src/commands/scan.rs
+++ b/crates/kratos-cli/src/commands/scan.rs
@@ -9,7 +9,8 @@ use kratos_core::report_format::format_summary_report;
 use kratos_core::{KratosError, KratosResult};
 
 use super::{
-    canonicalize_scan_args, resolve_input_path, write_output, CommandSpec,
+    canonicalize_scan_args, fail_on_exit_code, parse_fail_on, render_fail_on_message,
+    resolve_input_path, write_output, CommandSpec,
     DEFAULT_REPORT_RELATIVE_PATH,
 };
 
@@ -17,7 +18,7 @@ pub const NAME: &str = "scan";
 pub const SPEC: CommandSpec = CommandSpec {
     name: NAME,
     summary: "Analyze a codebase and save the latest report.",
-    usage: &["kratos scan [root] [--output path] [--json]"],
+    usage: &["kratos scan [root] [--output path] [--json] [--fail-on kinds]"],
 };
 
 #[derive(Debug, Parser)]
@@ -29,6 +30,8 @@ struct ScanArgs {
     output: Option<String>,
     #[arg(long)]
     json: bool,
+    #[arg(long = "fail-on", allow_hyphen_values = true)]
+    fail_on: Option<String>,
 }
 
 pub fn run(args: &[String], stdout: &mut dyn Write) -> KratosResult<i32> {
@@ -41,6 +44,7 @@ pub fn run(args: &[String], stdout: &mut dyn Write) -> KratosResult<i32> {
     let output_path = resolve_output_path(&root, args.output.as_deref());
     let report = analyze_project(&root)?;
     let serialized = serialize_report_pretty(&report)?;
+    let fail_on = parse_fail_on(args.fail_on.as_deref())?;
 
     if let Some(parent) = output_path.parent() {
         fs::create_dir_all(parent)?;
@@ -49,14 +53,19 @@ pub fn run(args: &[String], stdout: &mut dyn Write) -> KratosResult<i32> {
 
     if args.json {
         write_output(stdout, &serialized)?;
-        return Ok(0);
+        return Ok(fail_on_exit_code(&report, &fail_on));
     }
 
     write_output(
         stdout,
         &format_summary_report(&report, &output_path, "Kratos scan complete.")?,
     )?;
-    Ok(0)
+
+    if let Some(message) = render_fail_on_message(&report, &fail_on, false) {
+        write_output(stdout, &message)?;
+    }
+
+    Ok(fail_on_exit_code(&report, &fail_on))
 }
 
 fn parse_args(args: &[String]) -> KratosResult<ScanArgs> {

--- a/crates/kratos-cli/tests/cli_smoke.rs
+++ b/crates/kratos-cli/tests/cli_smoke.rs
@@ -10,7 +10,7 @@ fn root_help_matches_expected_shape() {
     assert!(output.status.success());
     assert_eq!(
         String::from_utf8_lossy(&output.stdout),
-        "Kratos\nDestroy dead code ruthlessly.\n\nUsage:\n  kratos scan [root] [--output path] [--json]\n  kratos report [report-path-or-root] [--format summary|json|md]\n  kratos clean [report-path-or-root] [--dry-run|--apply]\n\nCommands:\n  scan    Analyze a codebase and save the latest report.\n  report  Print a saved report in summary, json, or markdown form.\n  clean   Show deletion candidates or delete them with --apply.\n"
+        "Kratos\nDestroy dead code ruthlessly.\n\nUsage:\n  kratos scan [root] [--output path] [--json] [--fail-on kinds]\n  kratos report [report-path-or-root] [--format summary|json|md] [--fail-on kinds]\n  kratos clean [report-path-or-root] [--dry-run|--apply]\n\nCommands:\n  scan    Analyze a codebase and save the latest report.\n  report  Print a saved report in summary, json, or markdown form.\n  clean   Show deletion candidates or delete them with --apply.\n"
     );
 }
 
@@ -21,7 +21,7 @@ fn unknown_command_returns_help_and_exit_code_one() {
     assert_eq!(output.status.code(), Some(1));
     assert_eq!(
         String::from_utf8_lossy(&output.stderr),
-        "Unknown command: nope\n\nKratos\nDestroy dead code ruthlessly.\n\nUsage:\n  kratos scan [root] [--output path] [--json]\n  kratos report [report-path-or-root] [--format summary|json|md]\n  kratos clean [report-path-or-root] [--dry-run|--apply]\n\nCommands:\n  scan    Analyze a codebase and save the latest report.\n  report  Print a saved report in summary, json, or markdown form.\n  clean   Show deletion candidates or delete them with --apply.\n"
+        "Unknown command: nope\n\nKratos\nDestroy dead code ruthlessly.\n\nUsage:\n  kratos scan [root] [--output path] [--json] [--fail-on kinds]\n  kratos report [report-path-or-root] [--format summary|json|md] [--fail-on kinds]\n  kratos clean [report-path-or-root] [--dry-run|--apply]\n\nCommands:\n  scan    Analyze a codebase and save the latest report.\n  report  Print a saved report in summary, json, or markdown form.\n  clean   Show deletion candidates or delete them with --apply.\n"
     );
 }
 
@@ -391,6 +391,40 @@ fn scan_output_empty_string_defaults_and_missing_value_errors() {
         !project_root.join("--json").exists(),
         "missing output value should not create a stray report file"
     );
+}
+
+#[test]
+fn scan_and_report_support_fail_on_ci_gate() {
+    let project_root = copy_demo_app("cli-fail-on");
+    let report_path = project_root.join(".kratos/latest-report.json");
+
+    let scan = run_cli_in_dir(
+        &project_root,
+        &["scan", "--fail-on", "broken-imports,deletion-candidates"],
+    );
+    assert_eq!(scan.status.code(), Some(2));
+    let scan_stdout = String::from_utf8_lossy(&scan.stdout);
+    assert!(scan_stdout.contains("Kratos scan complete."));
+    assert!(scan_stdout.contains("Gate status: failed"));
+    assert!(scan_stdout.contains("broken imports: 1"));
+    assert!(scan_stdout.contains("deletion candidates: 2"));
+    assert!(report_path.exists());
+
+    let report = run_cli_in_dir(
+        &project_root,
+        &[
+            "report",
+            report_path.to_str().expect("path should be utf8"),
+            "--format",
+            "md",
+            "--fail-on",
+            "any",
+        ],
+    );
+    assert_eq!(report.status.code(), Some(2));
+    let report_stdout = String::from_utf8_lossy(&report.stdout);
+    assert!(report_stdout.contains("## Gate Status"));
+    assert!(report_stdout.contains("- Result: failed"));
 }
 
 #[test]

--- a/test/package-smoke.test.js
+++ b/test/package-smoke.test.js
@@ -126,6 +126,37 @@ test("packed root package boots the actual native addon for the current platform
   assert.equal(path.resolve(report.project.root), demoAppPath);
 });
 
+test("packed root package can fail CI gates on findings", async (t) => {
+  const nativeLibraryPath = process.env.KRATOS_PACKAGE_SMOKE_NATIVE_LIB;
+
+  if (!nativeLibraryPath) {
+    t.skip("KRATOS_PACKAGE_SMOKE_NATIVE_LIB is not set");
+    return;
+  }
+
+  const resolvedNativeLibraryPath = path.resolve(repoRoot, nativeLibraryPath);
+  const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "kratos-package-gate-smoke-"));
+  const rootPackage = await packRootTarball(tempRoot);
+  const addonTarballs = await packAddonTarballs(tempRoot, {
+    nativeLibraryPath: resolvedNativeLibraryPath,
+  });
+  const installRoot = await installPackedRootPackage(tempRoot, rootPackage, addonTarballs);
+  const demoAppPath = path.join(repoRoot, "fixtures", "demo-app");
+
+  const runResult = runInstalledKratos(
+    installRoot,
+    ["scan", demoAppPath, "--fail-on", "broken-imports,deletion-candidates"],
+    {
+      cwd: installRoot,
+    },
+  );
+
+  assert.equal(runResult.status, 2, runResult.stderr || runResult.stdout);
+  assert.match(runResult.stdout, /Kratos scan complete\./);
+  assert.match(runResult.stdout, /Gate status: failed/);
+  assert.match(runResult.stdout, /broken imports: 1/);
+});
+
 async function assertWindowsCmdShimTargetsInstalledLauncher(installRoot) {
   const launcherPath = path.join(
     installRoot,


### PR DESCRIPTION
## 배경

이 라이브러리를 GitHub Actions 같은 CI에서 gate로 쓰려면 finding이 있을 때 명확한 종료 코드와 사람이 읽을 수 있는 실패 요약이 필요했습니다.

## 변경 사항

- `scan`과 `report`에 `--fail-on`을 추가해 선택한 finding 종류가 있으면 exit code `2`를 반환하도록 했습니다.
- summary/markdown 출력에 gate failure 메시지를 붙이고, json 출력은 exit code만 바꾸도록 유지했습니다.
- CLI smoke test에 `--fail-on` 시나리오를 추가했습니다.
- 설치 패키지 기준 smoke test에 CI gate 시나리오를 추가했습니다.

## 검증

- `cargo test -p kratos-cli --test cli_smoke scan_and_report_support_fail_on_ci_gate`
- `cargo run -p kratos-cli -- scan ./fixtures/demo-app --fail-on broken-imports,deletion-candidates`
- `npm test`

## 브랜치 / 워크트리

- 브랜치: `codex/ci-fail-on-gate`
- PR base: `codex/clean-dry-run-contract`
- 워크트리: `/Users/pjw/workspace/kratos`

## 리스크 또는 확인 포인트

- `KRATOS_PACKAGE_SMOKE_NATIVE_LIB`가 없는 환경에서는 native boot smoke와 package gate smoke가 skip됩니다.
