### PR TITLE
feat(core): clean preview planner 추가

### DIFF
--- a/crates/kratos-core/src/clean.rs
+++ b/crates/kratos-core/src/clean.rs
@@ -101,6 +101,21 @@ pub fn clean_from_report(report: &ReportV2, apply: bool) -> KratosResult<CleanOu
     clean_from_report_with_min_confidence(report, 0.0)
 }
 
+pub(crate) fn is_safe_clean_candidate(report_root: &Path, candidate_path: &Path) -> bool {
+    let report_root_path = resolve_path(report_root);
+    let candidate_path = resolve_path(candidate_path);
+
+    if !is_within_directory(&report_root_path, &candidate_path) {
+        return false;
+    }
+
+    let deletion_root = realpath_or_fallback(report_root);
+    let candidate_parent_path = candidate_path.parent().unwrap_or(report_root_path.as_path());
+    let candidate_parent = realpath_or_fallback(candidate_parent_path);
+
+    is_within_directory(&deletion_root, &candidate_parent)
+}
+
 fn validate_clean_threshold_inputs(report: &ReportV2, min_confidence: f32) -> KratosResult<()> {
     if report.version < REPORT_V2 {
         return Err(KratosError::InvalidReportVersion {
@@ -120,7 +135,6 @@ fn validate_clean_threshold_inputs(report: &ReportV2, min_confidence: f32) -> Kr
 
 fn apply_clean_plan(report: &ReportV2, plan: &CleanThresholdPlan) -> KratosResult<CleanOutcome> {
     let report_root_path = resolve_path(&report.root);
-    let deletion_root = realpath_or_fallback(&report.root);
     let mut outcome = CleanOutcome {
         deleted_files: 0,
         skipped_files: plan.threshold_skipped_targets.len(),
@@ -129,25 +143,12 @@ fn apply_clean_plan(report: &ReportV2, plan: &CleanThresholdPlan) -> KratosResul
     for candidate in &plan.deletion_targets {
         let candidate_path = resolve_path(&candidate.file);
 
-        if !is_within_directory(&report_root_path, &candidate_path) {
+        if !is_safe_clean_candidate(&report.root, &candidate_path) || !file_exists(&candidate_path) {
             outcome.skipped_files += 1;
             continue;
         }
 
-        if !file_exists(&candidate_path) {
-            outcome.skipped_files += 1;
-            continue;
-        }
-
-        let candidate_parent_path = candidate_path
-            .parent()
-            .unwrap_or(report_root_path.as_path());
-        let candidate_parent = realpath_or_fallback(candidate_parent_path);
-
-        if !is_within_directory(&deletion_root, &candidate_parent) {
-            outcome.skipped_files += 1;
-            continue;
-        }
+        let candidate_parent_path = candidate_path.parent().unwrap_or(report_root_path.as_path());
 
         match std::fs::remove_file(&candidate_path) {
             Ok(()) => {
@@ -165,7 +166,11 @@ fn apply_clean_plan(report: &ReportV2, plan: &CleanThresholdPlan) -> KratosResul
 }
 
 fn file_exists(path: &Path) -> bool {
-    std::fs::metadata(path).is_ok()
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => true,
+        Ok(_) => std::fs::metadata(path).is_ok(),
+        Err(_) => false,
+    }
 }
 
 fn realpath_or_fallback(path: &Path) -> PathBuf {

--- a/crates/kratos-core/src/clean_preview.rs
+++ b/crates/kratos-core/src/clean_preview.rs
@@ -1,0 +1,176 @@
+use std::fs::File;
+use std::io::{BufRead, BufReader, ErrorKind};
+use std::path::{Path, PathBuf};
+
+use crate::clean::{is_safe_clean_candidate, plan_clean_candidates};
+use crate::model::{DeletionCandidateFinding, ReportV2};
+use crate::KratosResult;
+
+pub const BINARY_PREVIEW_MARKER: &str = "[binary file]";
+pub const MISSING_PREVIEW_MARKER: &str = "[missing file]";
+pub const UNREADABLE_PREVIEW_MARKER: &str = "[preview unavailable]";
+const MAX_PREVIEW_LINES: usize = 20;
+const MAX_PREVIEW_BYTES: usize = 16 * 1024;
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct CleanPreviewItem {
+    pub file: PathBuf,
+    pub relative_path: String,
+    pub reason: String,
+    pub confidence: f32,
+    pub exists: bool,
+    pub preview_excerpt: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct CleanPreviewPlan {
+    pub items: Vec<CleanPreviewItem>,
+    pub deletion_target_paths: Vec<PathBuf>,
+    pub threshold_skipped_targets: Vec<DeletionCandidateFinding>,
+    pub unavailable_targets: Vec<DeletionCandidateFinding>,
+}
+
+pub fn build_clean_preview(
+    report: &ReportV2,
+    min_confidence: f32,
+) -> KratosResult<CleanPreviewPlan> {
+    let threshold_plan = plan_clean_candidates(report, min_confidence)?;
+    let mut items = Vec::new();
+    let mut unavailable_targets = Vec::new();
+
+    for candidate in &threshold_plan.deletion_targets {
+        if !is_safe_clean_candidate(&report.root, &candidate.file) {
+            unavailable_targets.push(candidate.clone());
+            continue;
+        }
+
+        items.push(build_preview_item(candidate, &report.root));
+    }
+
+    items.sort_by(|left, right| {
+        right
+            .confidence
+            .total_cmp(&left.confidence)
+            .then_with(|| left.relative_path.cmp(&right.relative_path))
+    });
+
+    Ok(CleanPreviewPlan {
+        deletion_target_paths: items.iter().map(|item| item.file.clone()).collect(),
+        items,
+        threshold_skipped_targets: threshold_plan.threshold_skipped_targets,
+        unavailable_targets,
+    })
+}
+
+fn build_preview_item(
+    candidate: &DeletionCandidateFinding,
+    report_root: &Path,
+) -> CleanPreviewItem {
+    let (exists, preview_excerpt) = read_preview_excerpt(&candidate.file);
+
+    CleanPreviewItem {
+        file: candidate.file.clone(),
+        relative_path: to_project_relative_path(&candidate.file, report_root),
+        reason: candidate.reason.clone(),
+        confidence: candidate.confidence,
+        exists,
+        preview_excerpt,
+    }
+}
+
+fn read_preview_excerpt(path: &Path) -> (bool, String) {
+    if let Ok(metadata) = std::fs::symlink_metadata(path) {
+        if metadata.file_type().is_symlink() {
+            return read_symlink_preview_excerpt(path);
+        }
+    }
+
+    match File::open(path) {
+        Ok(file) => match preview_from_reader(BufReader::new(file)) {
+            Ok(preview_excerpt) => (true, preview_excerpt),
+            Err(_) => (
+                std::fs::symlink_metadata(path).is_ok(),
+                UNREADABLE_PREVIEW_MARKER.to_string(),
+            ),
+        },
+        Err(error) if error.kind() == ErrorKind::NotFound => {
+            (false, MISSING_PREVIEW_MARKER.to_string())
+        }
+        Err(_) => (
+            std::fs::symlink_metadata(path).is_ok(),
+            UNREADABLE_PREVIEW_MARKER.to_string(),
+        ),
+    }
+}
+
+fn read_symlink_preview_excerpt(path: &Path) -> (bool, String) {
+    if std::fs::symlink_metadata(path).is_ok() {
+        (true, UNREADABLE_PREVIEW_MARKER.to_string())
+    } else {
+        (false, MISSING_PREVIEW_MARKER.to_string())
+    }
+}
+
+fn preview_from_reader<R: BufRead>(mut reader: R) -> std::io::Result<String> {
+    let mut excerpt = Vec::new();
+    let mut lines = 0usize;
+
+    while lines < MAX_PREVIEW_LINES && excerpt.len() < MAX_PREVIEW_BYTES {
+        let buffer = reader.fill_buf()?;
+        if buffer.is_empty() {
+            break;
+        }
+
+        let remaining = MAX_PREVIEW_BYTES - excerpt.len();
+        let candidate = &buffer[..buffer.len().min(remaining)];
+
+        let consumed = match candidate.iter().position(|byte| *byte == b'\n') {
+            Some(index) => {
+                lines += 1;
+                index + 1
+            }
+            None => candidate.len(),
+        };
+
+        if candidate[..consumed].contains(&0) {
+            return Ok(BINARY_PREVIEW_MARKER.to_string());
+        }
+
+        excerpt.extend_from_slice(&candidate[..consumed]);
+        reader.consume(consumed);
+    }
+
+    match String::from_utf8(excerpt) {
+        Ok(text) => Ok(text
+            .lines()
+            .take(MAX_PREVIEW_LINES)
+            .collect::<Vec<_>>()
+            .join("\n")),
+        Err(error) => {
+            let utf8_error = error.utf8_error();
+
+            if utf8_error.error_len().is_none() {
+                let valid_prefix = error.into_bytes();
+                let text = std::str::from_utf8(&valid_prefix[..utf8_error.valid_up_to()])
+                    .expect("valid UTF-8 prefix should decode");
+                Ok(text
+                    .lines()
+                    .take(MAX_PREVIEW_LINES)
+                    .collect::<Vec<_>>()
+                    .join("\n"))
+            } else {
+                Ok(BINARY_PREVIEW_MARKER.to_string())
+            }
+        }
+    }
+}
+
+fn to_project_relative_path(file: &Path, report_root: &Path) -> String {
+    file.strip_prefix(report_root)
+        .map(path_to_forward_slashes)
+        .unwrap_or_else(|_| path_to_forward_slashes(file))
+}
+
+fn path_to_forward_slashes(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}

--- a/crates/kratos-core/src/lib.rs
+++ b/crates/kratos-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod analyze;
 pub mod clean;
+pub mod clean_preview;
 pub mod config;
 pub mod discover;
 pub mod entrypoints;

--- a/crates/kratos-core/tests/clean_preview.rs
+++ b/crates/kratos-core/tests/clean_preview.rs
@@ -1,0 +1,383 @@
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use kratos_core::clean_preview::{
+    build_clean_preview, BINARY_PREVIEW_MARKER, MISSING_PREVIEW_MARKER, UNREADABLE_PREVIEW_MARKER,
+};
+use kratos_core::model::{DeletionCandidateFinding, ReportV2};
+
+#[test]
+fn build_clean_preview_orders_items_by_confidence_then_relative_path() {
+    let temp_root = temp_dir("clean-preview-order");
+    let report = report_with_candidates(
+        &temp_root,
+        &[
+            (
+                "src/beta.ts",
+                0.80,
+                Some("export const beta = true;\n".as_bytes()),
+            ),
+            (
+                "src/alpha.ts",
+                0.80,
+                Some("export const alpha = true;\n".as_bytes()),
+            ),
+            (
+                "src/high.ts",
+                0.95,
+                Some("export const high = true;\n".as_bytes()),
+            ),
+        ],
+    );
+
+    let preview = build_clean_preview(&report, 0.5).expect("preview should build");
+
+    assert_eq!(
+        preview
+            .items
+            .iter()
+            .map(|item| item.relative_path.as_str())
+            .collect::<Vec<_>>(),
+        vec!["src/high.ts", "src/alpha.ts", "src/beta.ts"]
+    );
+    assert_eq!(
+        preview.deletion_target_paths,
+        vec![
+            temp_root.join("src/high.ts"),
+            temp_root.join("src/alpha.ts"),
+            temp_root.join("src/beta.ts"),
+        ]
+    );
+}
+
+#[test]
+fn build_clean_preview_excludes_below_threshold_targets_and_keeps_counts() {
+    let temp_root = temp_dir("clean-preview-threshold");
+    let report = report_with_candidates(
+        &temp_root,
+        &[
+            (
+                "src/keep.ts",
+                0.95,
+                Some("export const keep = true;\n".as_bytes()),
+            ),
+            (
+                "src/skip.ts",
+                0.20,
+                Some("export const skip = true;\n".as_bytes()),
+            ),
+        ],
+    );
+
+    let preview = build_clean_preview(&report, 0.9).expect("preview should build");
+
+    assert_eq!(preview.items.len(), 1);
+    assert_eq!(preview.items[0].relative_path, "src/keep.ts");
+    assert_eq!(preview.threshold_skipped_targets.len(), 1);
+    assert_eq!(
+        preview.threshold_skipped_targets[0].file,
+        temp_root.join("src/skip.ts")
+    );
+}
+
+#[test]
+fn build_clean_preview_limits_excerpt_and_marks_missing_files() {
+    let temp_root = temp_dir("clean-preview-excerpt");
+    let long_text = (1..=25)
+        .map(|index| format!("line {index}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let report = report_with_candidates(
+        &temp_root,
+        &[
+            ("src/long.ts", 0.90, Some(long_text.as_bytes())),
+            ("src/missing.ts", 0.85, None),
+        ],
+    );
+
+    let preview = build_clean_preview(&report, 0.8).expect("preview should build");
+    let long_item = preview
+        .items
+        .iter()
+        .find(|item| item.relative_path == "src/long.ts")
+        .expect("long item should exist");
+    let missing_item = preview
+        .items
+        .iter()
+        .find(|item| item.relative_path == "src/missing.ts")
+        .expect("missing item should exist");
+
+    assert!(long_item.exists);
+    assert!(long_item.preview_excerpt.contains("line 1"));
+    assert!(long_item.preview_excerpt.contains("line 20"));
+    assert!(!long_item.preview_excerpt.contains("line 21"));
+
+    assert!(!missing_item.exists);
+    assert_eq!(missing_item.preview_excerpt, MISSING_PREVIEW_MARKER);
+}
+
+#[test]
+fn build_clean_preview_ignores_binary_tail_after_excerpt_limit() {
+    let temp_root = temp_dir("clean-preview-tail-limit");
+    let mut bytes = (1..=20)
+        .map(|index| format!("line {index}\n"))
+        .collect::<String>()
+        .into_bytes();
+    bytes.extend_from_slice(&[0, 159, 146, 150]);
+
+    let report = report_with_candidates(&temp_root, &[("src/tail.ts", 0.9, Some(&bytes))]);
+
+    let preview = build_clean_preview(&report, 0.5).expect("preview should build");
+
+    assert!(preview.items[0].exists);
+    assert_eq!(
+        preview.items[0].preview_excerpt,
+        (1..=20)
+            .map(|index| format!("line {index}"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+}
+
+#[test]
+fn build_clean_preview_truncates_large_single_line_files() {
+    let temp_root = temp_dir("clean-preview-long-line");
+    let long_line = "a".repeat(64 * 1024);
+    let report = report_with_candidates(
+        &temp_root,
+        &[("src/long-line.ts", 0.9, Some(long_line.as_bytes()))],
+    );
+
+    let preview = build_clean_preview(&report, 0.5).expect("preview should build");
+
+    assert!(preview.items[0].exists);
+    assert!(preview.items[0].preview_excerpt.starts_with('a'));
+    assert!(preview.items[0].preview_excerpt.len() < long_line.len());
+    assert!(preview.items[0].preview_excerpt.len() <= 16 * 1024);
+}
+
+#[test]
+fn build_clean_preview_truncates_multibyte_text_without_marking_binary() {
+    let temp_root = temp_dir("clean-preview-multibyte-line");
+    let long_line = "가".repeat(6_000);
+    let report = report_with_candidates(
+        &temp_root,
+        &[("src/multibyte.txt", 0.9, Some(long_line.as_bytes()))],
+    );
+
+    let preview = build_clean_preview(&report, 0.5).expect("preview should build");
+
+    assert!(preview.items[0].exists);
+    assert_ne!(preview.items[0].preview_excerpt, BINARY_PREVIEW_MARKER);
+    assert!(preview.items[0].preview_excerpt.starts_with('가'));
+    assert!(preview.items[0].preview_excerpt.len() < long_line.len());
+    assert!(preview.items[0].preview_excerpt.chars().all(|ch| ch == '가'));
+}
+
+#[test]
+fn build_clean_preview_uses_binary_and_unreadable_markers() {
+    let temp_root = temp_dir("clean-preview-binary");
+    let report = report_with_candidates(
+        &temp_root,
+        &[("src/binary.bin", 0.9, Some(&[0, 159, 146, 150]))],
+    );
+
+    let preview = build_clean_preview(&report, 0.5).expect("preview should build");
+    assert_eq!(preview.items[0].preview_excerpt, BINARY_PREVIEW_MARKER);
+
+    #[cfg(unix)]
+    {
+        let unreadable_dir = temp_root.join("src/private");
+        let unreadable_path = unreadable_dir.join("blocked.ts");
+        std::fs::create_dir_all(&unreadable_dir).expect("private dir should exist");
+        std::fs::write(&unreadable_path, "export const blocked = true;\n")
+            .expect("unreadable file should write");
+        let permissions = std::os::unix::fs::PermissionsExt::from_mode(0o000);
+        std::fs::set_permissions(&unreadable_dir, permissions).expect("permissions should update");
+
+        let unreadable_report =
+            report_with_candidates(&temp_root, &[("src/private/blocked.ts", 0.91, None)]);
+        let unreadable_preview =
+            build_clean_preview(&unreadable_report, 0.5).expect("preview should build");
+
+        assert_eq!(
+            unreadable_preview.items[0].preview_excerpt,
+            UNREADABLE_PREVIEW_MARKER
+        );
+
+        let restore = std::os::unix::fs::PermissionsExt::from_mode(0o755);
+        std::fs::set_permissions(&unreadable_dir, restore).expect("permissions should restore");
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn build_clean_preview_keeps_unknown_existence_false_for_unreadable_paths() {
+    let temp_root = temp_dir("clean-preview-unreadable-missing");
+    let hidden_dir = temp_root.join("src/hidden");
+
+    std::fs::create_dir_all(&hidden_dir).expect("hidden dir should exist");
+    let permissions = std::os::unix::fs::PermissionsExt::from_mode(0o000);
+    std::fs::set_permissions(&hidden_dir, permissions).expect("permissions should update");
+
+    let report = report_with_candidates(&temp_root, &[("src/hidden/missing.ts", 0.91, None)]);
+    let preview = build_clean_preview(&report, 0.5).expect("preview should build");
+
+    assert_eq!(preview.items[0].preview_excerpt, UNREADABLE_PREVIEW_MARKER);
+    assert!(!preview.items[0].exists);
+
+    let restore = std::os::unix::fs::PermissionsExt::from_mode(0o755);
+    std::fs::set_permissions(&hidden_dir, restore).expect("permissions should restore");
+}
+
+#[test]
+fn build_clean_preview_skips_symlink_escaped_targets() {
+    let temp_root = temp_dir("clean-preview-symlink-escape");
+    let report_root = temp_root.join("app");
+    let outside_root = temp_root.join("outside");
+    let outside_file = outside_root.join("secret.ts");
+    let link_path = report_root.join("link");
+
+    std::fs::create_dir_all(&report_root).expect("report root should exist");
+    std::fs::create_dir_all(&outside_root).expect("outside root should exist");
+    std::fs::write(&outside_file, "export const secret = true;\n")
+        .expect("outside file should write");
+    symlink_dir(&outside_root, &link_path);
+
+    let mut report = ReportV2::new(report_root.clone());
+    report
+        .findings
+        .deletion_candidates
+        .push(DeletionCandidateFinding {
+            file: link_path.join("secret.ts"),
+            reason: "escaped candidate".to_string(),
+            confidence: 0.95,
+            safe: true,
+        });
+
+    let preview = build_clean_preview(&report, 0.5).expect("preview should build");
+
+    assert!(preview.items.is_empty());
+    assert!(preview.deletion_target_paths.is_empty());
+    assert_eq!(preview.unavailable_targets.len(), 1);
+    assert_eq!(preview.unavailable_targets[0].file, link_path.join("secret.ts"));
+}
+
+#[test]
+fn build_clean_preview_does_not_follow_live_symlink_targets() {
+    let temp_root = temp_dir("clean-preview-symlink-file");
+    let report_root = temp_root.join("app");
+    let outside_root = temp_root.join("outside");
+    let outside_file = outside_root.join("target.ts");
+    let link_path = report_root.join("linked.ts");
+
+    std::fs::create_dir_all(&report_root).expect("report root should exist");
+    std::fs::create_dir_all(&outside_root).expect("outside root should exist");
+    std::fs::write(&outside_file, "export const secret = true;\n")
+        .expect("outside file should write");
+    symlink_file(&outside_file, &link_path);
+
+    let mut report = ReportV2::new(report_root.clone());
+    report
+        .findings
+        .deletion_candidates
+        .push(DeletionCandidateFinding {
+            file: link_path.clone(),
+            reason: "linked candidate".to_string(),
+            confidence: 0.95,
+            safe: true,
+        });
+
+    let preview = build_clean_preview(&report, 0.5).expect("preview should build");
+
+    assert_eq!(preview.items.len(), 1);
+    assert_eq!(preview.items[0].file, link_path);
+    assert!(preview.items[0].exists);
+    assert_eq!(preview.items[0].preview_excerpt, UNREADABLE_PREVIEW_MARKER);
+}
+
+#[test]
+fn build_clean_preview_marks_dangling_symlink_targets_as_unavailable() {
+    let temp_root = temp_dir("clean-preview-dangling-symlink");
+    let report_root = temp_root.join("app");
+    let missing_target = temp_root.join("outside/missing.ts");
+    let link_path = report_root.join("dangling.ts");
+
+    std::fs::create_dir_all(&report_root).expect("report root should exist");
+    symlink_file(&missing_target, &link_path);
+
+    let mut report = ReportV2::new(report_root.clone());
+    report
+        .findings
+        .deletion_candidates
+        .push(DeletionCandidateFinding {
+            file: link_path.clone(),
+            reason: "dangling linked candidate".to_string(),
+            confidence: 0.95,
+            safe: true,
+        });
+
+    let preview = build_clean_preview(&report, 0.5).expect("preview should build");
+
+    assert_eq!(preview.items.len(), 1);
+    assert_eq!(preview.items[0].file, link_path);
+    assert!(preview.items[0].exists);
+    assert_eq!(preview.items[0].preview_excerpt, UNREADABLE_PREVIEW_MARKER);
+}
+
+fn report_with_candidates(root: &Path, candidates: &[(&str, f32, Option<&[u8]>)]) -> ReportV2 {
+    let mut report = ReportV2::new(root.to_path_buf());
+    std::fs::create_dir_all(root).expect("report root should exist");
+
+    report.findings.deletion_candidates = candidates
+        .iter()
+        .map(|(relative, confidence, bytes)| {
+            let path = root.join(relative);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).expect("candidate parent should exist");
+            }
+            if let Some(bytes) = bytes {
+                std::fs::write(&path, bytes).expect("candidate file should write");
+            }
+
+            DeletionCandidateFinding {
+                file: path,
+                reason: format!("{relative} candidate"),
+                confidence: *confidence,
+                safe: true,
+            }
+        })
+        .collect();
+
+    report
+}
+
+fn temp_dir(label: &str) -> PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be valid")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!("kratos-core-{label}-{unique}"));
+    std::fs::create_dir_all(&path).expect("temp dir should be created");
+    path
+}
+
+#[cfg(unix)]
+fn symlink_dir(target: &Path, link: &Path) {
+    std::os::unix::fs::symlink(target, link).expect("directory symlink should be created");
+}
+
+#[cfg(unix)]
+fn symlink_file(target: &Path, link: &Path) {
+    std::os::unix::fs::symlink(target, link).expect("file symlink should be created");
+}
+
+#[cfg(windows)]
+fn symlink_dir(target: &Path, link: &Path) {
+    std::os::windows::fs::symlink_dir(target, link).expect("directory symlink should be created");
+}
+
+#[cfg(windows)]
+fn symlink_file(target: &Path, link: &Path) {
+    std::os::windows::fs::symlink_file(target, link).expect("file symlink should be created");
+}

--- a/crates/kratos-core/tests/clean_safety.rs
+++ b/crates/kratos-core/tests/clean_safety.rs
@@ -47,7 +47,7 @@ fn clean_rejects_symlink_escape_candidates() {
 }
 
 #[test]
-fn clean_skips_dangling_symlink_candidates() {
+fn clean_deletes_dangling_symlink_candidates() {
     let temp_root = temp_dir("clean-dangling-symlink");
     let report_root = temp_root.join("app");
     let dangling_link = report_root.join("dangling.ts");
@@ -56,14 +56,39 @@ fn clean_skips_dangling_symlink_candidates() {
     symlink_file(Path::new("missing-target.ts"), &dangling_link);
 
     let report = report_with_candidate(&report_root, &dangling_link);
-    let outcome = clean_from_report(&report, true).expect("clean should skip dangling symlinks");
+    let outcome = clean_from_report(&report, true).expect("clean should delete dangling symlinks");
 
     assert!(
-        std::fs::symlink_metadata(&dangling_link).is_ok(),
-        "dangling symlink should remain untouched"
+        std::fs::symlink_metadata(&dangling_link).is_err(),
+        "dangling symlink should be deleted"
     );
-    assert_eq!(outcome.deleted_files, 0);
-    assert_eq!(outcome.skipped_files, 1);
+    assert_eq!(outcome.deleted_files, 1);
+    assert_eq!(outcome.skipped_files, 0);
+}
+
+#[test]
+fn clean_deletes_live_symlink_candidates_without_touching_targets() {
+    let temp_root = temp_dir("clean-live-symlink");
+    let report_root = temp_root.join("app");
+    let outside_root = temp_root.join("outside");
+    let outside_file = outside_root.join("target.ts");
+    let symlink_path = report_root.join("linked.ts");
+
+    std::fs::create_dir_all(&report_root).expect("report root should exist");
+    std::fs::create_dir_all(&outside_root).expect("outside root should exist");
+    std::fs::write(&outside_file, "export const keep = true;\n").expect("outside file writes");
+    symlink_file(&outside_file, &symlink_path);
+
+    let report = report_with_candidate(&report_root, &symlink_path);
+    let outcome = clean_from_report(&report, true).expect("clean should delete symlink entries");
+
+    assert!(
+        std::fs::symlink_metadata(&symlink_path).is_err(),
+        "symlink entry should be deleted"
+    );
+    assert!(outside_file.exists(), "target file should remain untouched");
+    assert_eq!(outcome.deleted_files, 1);
+    assert_eq!(outcome.skipped_files, 0);
 }
 
 #[test]


### PR DESCRIPTION
## 배경
- WOW-4B에서 `sweep`가 재사용할 수 있는 순수 preview planner가 필요했습니다.
- 기존 `clean` 실행 경로와 분리된 preview 계약을 먼저 고정해 두면 이후 CLI/UX 작업을 더 안전하게 쌓을 수 있습니다.

## 변경 사항
- `crates/kratos-core/src/clean_preview.rs`에 threshold 통과 대상만 다루는 preview planner를 추가했습니다.
- preview item 정렬을 `confidence` 내림차순, `relative_path` 오름차순으로 고정했습니다.
- excerpt는 최대 20줄로 제한하고, `binary` / `missing` / `unreadable` marker를 명시적으로 다루도록 했습니다.
- `clean`과 동일한 root-boundary safety를 preview에도 적용해서 symlink escape candidate는 actionable preview에서 제외하고 `unavailable_targets`로 분리했습니다.
- unreadable path는 marker를 유지하되, `symlink_metadata`로 존재가 확인될 때만 `exists=true`가 되도록 보정했습니다.
- 관련 계약 테스트를 `crates/kratos-core/tests/clean_preview.rs`에 추가했습니다.

## 검증
### ship 직전 재실행
- `cargo test --workspace`
- `npm run verify`

### review loop 중 추가 확인
- `cargo test -p kratos-core --test clean_preview`
- `cargo test -p kratos-core --test clean_safety`
- `cargo test -p kratos-core --test clean_thresholds`
- `git diff --check`

## 브랜치 / 워크트리
- 대상 브랜치: `codex/wow-4b-clean-preview-planner`
- base 브랜치: `master`
- 현재 워크트리: `/Users/pjw/workspace/kratos`

## 참고
- `npm run verify`의 native addon boot smoke는 `KRATOS_PACKAGE_SMOKE_NATIVE_LIB` 미설정으로 skip됐습니다.
- 워킹트리의 `PR_DESCRIPTION.codex__*.md`, `docs/plans/*.md` untracked 파일들은 이번 PR 범위에 포함하지 않았습니다.
