### PR TITLE
ci: release candidate 검증 경로 고정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,14 @@ on:
       - master
   pull_request:
   workflow_dispatch:
+    inputs:
+      target_sha:
+        description: Commit SHA to verify when dispatching CI manually
+        required: true
+        type: string
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && inputs.target_sha || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -33,8 +38,29 @@ jobs:
       contents: read
 
     steps:
+      - name: Validate manual target SHA
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        shell: bash
+        run: |
+          if ! [[ "${{ inputs.target_sha }}" =~ ^[0-9A-Fa-f]{40}$ ]]; then
+            echo "target_sha must be a full 40-character commit SHA."
+            exit 1
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.target_sha || github.ref }}
+
+      - name: Confirm checked out commit matches target SHA
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        shell: bash
+        run: |
+          checked_out_sha=$(git rev-parse HEAD)
+          if [ "$checked_out_sha" != "${{ inputs.target_sha }}" ]; then
+            echo "Expected checkout to resolve to ${{ inputs.target_sha }}, got $checked_out_sha"
+            exit 1
+          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -61,8 +87,29 @@ jobs:
       contents: read
 
     steps:
+      - name: Validate manual target SHA
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        shell: bash
+        run: |
+          if ! [[ "${{ inputs.target_sha }}" =~ ^[0-9A-Fa-f]{40}$ ]]; then
+            echo "target_sha must be a full 40-character commit SHA."
+            exit 1
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.target_sha || github.ref }}
+
+      - name: Confirm checked out commit matches target SHA
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        shell: bash
+        run: |
+          checked_out_sha=$(git rev-parse HEAD)
+          if [ "$checked_out_sha" != "${{ inputs.target_sha }}" ]; then
+            echo "Expected checkout to resolve to ${{ inputs.target_sha }}, got $checked_out_sha"
+            exit 1
+          fi
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -125,8 +172,29 @@ jobs:
             built_library: target/x86_64-pc-windows-msvc/release/kratos_node.dll
 
     steps:
+      - name: Validate manual target SHA
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        shell: bash
+        run: |
+          if ! [[ "${{ inputs.target_sha }}" =~ ^[0-9A-Fa-f]{40}$ ]]; then
+            echo "target_sha must be a full 40-character commit SHA."
+            exit 1
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.target_sha || github.ref }}
+
+      - name: Confirm checked out commit matches target SHA
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        shell: bash
+        run: |
+          checked_out_sha=$(git rev-parse HEAD)
+          if [ "$checked_out_sha" != "${{ inputs.target_sha }}" ]; then
+            echo "Expected checkout to resolve to ${{ inputs.target_sha }}, got $checked_out_sha"
+            exit 1
+          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/manual-release-bump.yml
+++ b/.github/workflows/manual-release-bump.yml
@@ -62,10 +62,20 @@ jobs:
 
           branch=$(node --input-type=module -e "import { createManualBumpBranchName } from './scripts/bump-release-version.mjs'; console.log(createManualBumpBranchName(process.argv[1], process.argv[2]));" "$tag" "${{ inputs.base_ref }}")
 
+          if [ "${{ inputs.base_ref }}" = "master" ]; then
+            candidate_verification_line="merge 후 \`Release Candidate Core Verification\` workflow가 \`master\`에서 자동 실행되어 tag 전 후보 commit을 검증합니다."
+            candidate_follow_up_line="실제 tag 전에는 검증된 same-commit의 \`CI\` workflow native packaging 결과도 green인지 확인해야 합니다."
+          else
+            candidate_verification_line="\`${{ inputs.base_ref }}\`는 자동 대상이 아니므로 merge 후 해당 merge commit SHA를 \`target_sha\`로 넣어 \`Release Candidate Core Verification\` workflow를 수동 실행해 후보 commit을 검증해야 합니다."
+            candidate_follow_up_line="실제 tag 전에는 같은 merge commit SHA를 \`target_sha\`로 넣어 \`CI\` workflow도 수동 실행하고, native packaging jobs까지 green인지 확인해야 합니다."
+          fi
+
           {
             echo "currentVersion=$current_version"
             echo "branch=$branch"
             echo "title=chore: ${tag#v} 수동 bump"
+            printf 'candidateVerificationLine=%s\n' "$candidate_verification_line"
+            printf 'candidateFollowupLine=%s\n' "$candidate_follow_up_line"
           } >> "$GITHUB_OUTPUT"
 
       - name: Apply version bump
@@ -165,6 +175,7 @@ jobs:
           - \`node ./scripts/release-plan.mjs ${{ steps.meta.outputs.tag }}\`
           - \`node ./scripts/bump-release-version.mjs ${{ steps.meta.outputs.tag }}\`
           - \`npm run verify\`
+          - ${{ steps.meta.outputs.candidateVerificationLine }}
 
           ## 브랜치 / 워크트리 / Branches and worktrees
 
@@ -174,6 +185,7 @@ jobs:
           ## 리스크 또는 확인 포인트 / Risks or follow-ups
 
           - stable tag / publish는 아직 실행하지 않았습니다.
+          - ${{ steps.meta.outputs.candidateFollowupLine }}
           - release 실행 전 최종 확인이 필요합니다.
           EOF
 

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,0 +1,174 @@
+name: Release Candidate Core Verification
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - package.json
+  workflow_dispatch:
+    inputs:
+      target_sha:
+        description: Merge commit SHA to verify as a release candidate
+        required: true
+        type: string
+
+concurrency:
+  group: release-candidate-${{ github.event_name == 'workflow_dispatch' && inputs.target_sha || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  verify_release_candidate:
+    name: Verify Release Candidate
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      NPM_CONFIG_CACHE: .npm-cache
+
+    steps:
+      - name: Validate manual target SHA
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        shell: bash
+        run: |
+          if ! [[ "${{ inputs.target_sha }}" =~ ^[0-9A-Fa-f]{40}$ ]]; then
+            echo "target_sha must be a full 40-character commit SHA."
+            exit 1
+          fi
+
+      - name: Checkout pinned release candidate commit
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.target_sha || github.sha }}
+          fetch-depth: 0
+
+      - name: Confirm checked out commit matches target SHA
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        shell: bash
+        run: |
+          checked_out_sha=$(git rev-parse HEAD)
+          if [ "$checked_out_sha" != "${{ inputs.target_sha }}" ]; then
+            echo "Expected checkout to resolve to ${{ inputs.target_sha }}, got $checked_out_sha"
+            exit 1
+          fi
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Resolve release candidate metadata
+        id: meta
+        shell: bash
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          version=$(node -p "require('./package.json').version")
+          tag="v$version"
+          previous_version=""
+          should_verify=true
+          verified_sha=$(git rev-parse HEAD)
+
+          node ./scripts/release-plan.mjs "$tag" >> "$GITHUB_OUTPUT"
+
+          if [ "${{ github.event_name }}" = "push" ] && [ -n "$BEFORE_SHA" ] && git cat-file -e "$BEFORE_SHA:package.json" 2>/dev/null; then
+            previous_version=$(git show "$BEFORE_SHA:package.json" | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).version")
+          fi
+
+          if [ "${{ github.event_name }}" = "push" ] && [ -n "$previous_version" ] && [ "$previous_version" = "$version" ]; then
+            should_verify=false
+          fi
+
+          {
+            echo "previousVersion=$previous_version"
+            echo "shouldVerify=$should_verify"
+            echo "verifiedSha=$verified_sha"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Skip when package version is unchanged
+        if: ${{ steps.meta.outputs.shouldVerify != 'true' }}
+        run: |
+          {
+            echo "### Release candidate core verification skipped"
+            echo
+            echo "- ref: \`${GITHUB_REF_NAME}\`"
+            echo "- reason: \`package.json\` changed, but version stayed at \`${{ steps.meta.outputs.version }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Ensure release tag does not already exist
+        if: ${{ steps.meta.outputs.shouldVerify == 'true' }}
+        shell: bash
+        run: |
+          if git rev-parse -q --verify "refs/tags/${{ steps.meta.outputs.tag }}" >/dev/null; then
+            echo "Release tag ${{ steps.meta.outputs.tag }} already exists. Create or update tags only after reviewing the current candidate commit."
+            exit 1
+          fi
+
+      - name: Verify package manifest alignment
+        if: ${{ steps.meta.outputs.shouldVerify == 'true' }}
+        shell: bash
+        run: |
+          node --input-type=module <<'NODE'
+          import fs from "node:fs";
+
+          const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+          const mismatches = Object.entries(pkg.optionalDependencies ?? {}).filter(
+            ([, version]) => version !== pkg.version,
+          );
+
+          if (mismatches.length > 0) {
+            const details = mismatches
+              .map(([name, version]) => `${name}@${version}`)
+              .join(", ");
+            throw new Error(`optionalDependencies must match package.json version ${pkg.version}: ${details}`);
+          }
+          NODE
+
+      - name: Install dependencies when needed
+        if: ${{ steps.meta.outputs.shouldVerify == 'true' }}
+        shell: bash
+        run: |
+          if [ -f package-lock.json ]; then
+            npm ci
+          else
+            npm install --no-package-lock
+          fi
+
+      - name: Run npm verification
+        if: ${{ steps.meta.outputs.shouldVerify == 'true' }}
+        run: npm run verify
+
+      - name: Run package smoke test
+        if: ${{ steps.meta.outputs.shouldVerify == 'true' }}
+        run: npm run smoke
+
+      - name: Setup Rust toolchain
+        if: ${{ steps.meta.outputs.shouldVerify == 'true' }}
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run Rust workspace tests
+        if: ${{ steps.meta.outputs.shouldVerify == 'true' }}
+        run: cargo test --workspace
+
+      - name: Publish release candidate summary
+        if: ${{ steps.meta.outputs.shouldVerify == 'true' }}
+        shell: bash
+        run: |
+          {
+            echo "### Release candidate core checks passed"
+            echo
+            echo "- ref: \`${{ github.event_name == 'workflow_dispatch' && inputs.target_sha || github.ref_name }}\`"
+            echo "- verified commit: \`${{ steps.meta.outputs.verifiedSha }}\`"
+            echo "- version: \`${{ steps.meta.outputs.version }}\`"
+            echo "- next tag: \`${{ steps.meta.outputs.tag }}\`"
+            echo
+            echo "This workflow verifies version/tag alignment and core release checks on the pinned candidate commit."
+            if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+              echo "Before creating the real tag, manually run the \`CI\` workflow for the same commit SHA and wait for native packaging jobs to pass."
+            else
+              echo "Before creating the real tag, also confirm the same commit is green in the \`CI\` workflow, including native packaging jobs."
+            fi
+            echo "Create the release tag only after maintainer confirmation and only from \`${{ steps.meta.outputs.verifiedSha }}\`."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## 배경

- `release.yml`은 실제 release tag가 이미 존재한다는 전제를 유지해야 합니다.
- 대신 version-only bump PR이 merge된 뒤, tag를 찍기 전에 후보 commit을 별도 workflow로 검증할 수 있는 경로가 필요했습니다.
- 기존에는 잘못된 commit을 검증하거나, non-master 경로에서 same-commit CI/native-packaging 확인이 불가능한 계약 구멍이 있었습니다.

## 변경 사항

- `Release Candidate Core Verification` workflow를 추가해 `master`의 version bump merge 이후 tag 전 후보 commit을 검증하도록 했습니다.
- 수동 실행 경로는 `target_sha`를 필수로 받아 commit SHA만 허용하고, checkout 결과가 같은 SHA인지 다시 검증하도록 했습니다.
- `CI` workflow에도 `target_sha` 입력과 pinned checkout을 추가해 non-master에서도 same-commit native-packaging 검증이 가능하도록 맞췄습니다.
- `Manual Release Bump` PR 본문은 `base_ref`에 따라 자동 검증 여부와 수동 follow-up 절차를 다르게 안내하도록 보정했습니다.

## 검증

- `actionlint .github/workflows/ci.yml .github/workflows/manual-release-bump.yml .github/workflows/release-candidate.yml`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); YAML.load_file('.github/workflows/manual-release-bump.yml'); YAML.load_file('.github/workflows/release-candidate.yml'); puts 'yaml ok'"`
- `git diff --check`
- `npm run verify`
- `npm run smoke`
- `cargo test --workspace`

## 브랜치 / 워크트리

- base branch: `master`
- head branch: `codex/release-candidate-core-gate`
- current worktree: `/Users/pjw/workspace/kratos`
- 추가 source branch/worktree 포함 없음

## 이슈 연결

- 별도 이슈 연결 없음

## 리스크 또는 확인 포인트

- GitHub-hosted workflow 실제 실행까지는 이 PR에서 수행하지 않았습니다.
- `Release Candidate Core Verification`과 수동 `CI` dispatch의 실제 GitHub UI 동작은 PR 머지 후 check-run에서 한 번 더 확인이 필요합니다.
