### PR TITLE
fix: manual bump workflow에 CI target_sha 전달

### DIFF
--- a/.github/workflows/manual-release-bump.yml
+++ b/.github/workflows/manual-release-bump.yml
@@ -138,7 +138,12 @@ jobs:
 
       - name: Dispatch CI for bump branch
         if: ${{ !inputs.dry_run }}
-        run: gh workflow run ci.yml --ref "${{ steps.meta.outputs.branch }}"
+        shell: bash
+        run: |
+          bump_sha=$(git rev-parse HEAD)
+          gh workflow run ci.yml \
+            --ref "${{ steps.meta.outputs.branch }}" \
+            -f target_sha="$bump_sha"
 
       - name: Ensure skip-changelog label exists
         if: ${{ !inputs.dry_run }}


### PR DESCRIPTION
## 배경

- `CI` workflow가 수동 실행 시 `target_sha`를 필수로 받도록 바뀐 뒤, `Manual Release Bump` workflow의 `Dispatch CI for bump branch` 단계가 기존 호출을 유지하고 있었습니다.
- 그 결과 실제 run [#24842892618](https://github.com/JeremyDev87/kratos/actions/runs/24842892618/job/72721641064) 에서 `Required input 'target_sha' not provided` 422로 실패했습니다.

## 변경 사항

- `manual-release-bump.yml`의 bump branch CI dispatch에 현재 bump commit SHA를 `target_sha`로 전달합니다.
- dispatch는 기존처럼 bump branch ref를 기준으로 하되, same-commit 검증 계약도 함께 만족시킵니다.

## 검증

- `actionlint .github/workflows/manual-release-bump.yml .github/workflows/ci.yml .github/workflows/release-candidate.yml`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/manual-release-bump.yml'); YAML.load_file('.github/workflows/ci.yml'); YAML.load_file('.github/workflows/release-candidate.yml'); puts 'yaml ok'"`
- `git diff --check`
- `gh workflow run ci.yml --ref codex/manual-bump-ci-dispatch-target-sha -f target_sha=$(git rev-parse HEAD)`
- 실제 dispatch 생성 확인: [CI run #24843091634](https://github.com/JeremyDev87/kratos/actions/runs/24843091634)
