### PR TITLE
ci: release publish와 게시 후 감사를 분리

### DIFF
--- a/.github/workflows/manual-release-bump.yml
+++ b/.github/workflows/manual-release-bump.yml
@@ -164,11 +164,11 @@ jobs:
           DEFAULT_GH_TOKEN: ${{ github.token }}
           PR_CREATE_TOKEN: ${{ secrets.KRATOS_RELEASE_BOT_TOKEN }}
         run: |
-          cat > pr-body.md <<EOF
+          cat > pr-body.md <<'EOF'
           ## 배경 / Background
 
           - manual release bump workflow로 \`${{ steps.meta.outputs.currentVersion }}\`에서 \`${{ steps.meta.outputs.version }}\`으로 승격합니다.
-          - 실제 tag / publish는 이 PR merge 이후 별도 release workflow에서 진행합니다.
+          - 실제 tag / publish는 이 PR merge 이후 별도 `Release Publish` workflow에서 진행합니다.
 
           ## 변경 사항 / Changes
 

--- a/.github/workflows/release-published-follow-up.yml
+++ b/.github/workflows/release-published-follow-up.yml
@@ -1,0 +1,225 @@
+name: Release Published Follow-up
+run-name: Release Published Follow-up ${{ github.event_name == 'workflow_dispatch' && (startsWith(inputs.tag, 'v') && inputs.tag || format('v{0}', inputs.tag)) || github.event.release.tag_name }}
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Published git tag or version to audit, for example v0.1.0
+        required: true
+        type: string
+
+concurrency:
+  group: release-published-${{ github.event_name == 'workflow_dispatch' && (startsWith(inputs.tag, 'v') && inputs.tag || format('v{0}', inputs.tag)) || github.event.release.tag_name }}
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  audit:
+    name: Audit Published Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+
+    steps:
+      - name: Resolve target release
+        id: meta
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            tag="${{ github.event.release.tag_name }}"
+            release_url="${{ github.event.release.html_url }}"
+            published_at="${{ github.event.release.published_at }}"
+          else
+            tag="${{ inputs.tag }}"
+            if [[ "$tag" != v* ]]; then
+              tag="v$tag"
+            fi
+
+            release_json=$(gh release view "$tag" --json url,publishedAt)
+            release_url=$(printf '%s' "$release_json" | jq -r '.url')
+            published_at=$(printf '%s' "$release_json" | jq -r '.publishedAt // ""')
+          fi
+
+          if [[ "$tag" != v* ]]; then
+            tag="v$tag"
+          fi
+
+          {
+            echo "tag=$tag"
+            echo "releaseUrl=$release_url"
+            echo "publishedAt=$published_at"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Locate matching release publish run
+        id: publish_run
+        shell: bash
+        env:
+          TARGET_TAG: ${{ steps.meta.outputs.tag }}
+        run: |
+          expected_title="Release Publish ${TARGET_TAG}"
+          page=1
+          matched_run=""
+
+          while :; do
+            runs_json=$(gh api "/repos/${GH_REPO}/actions/workflows/release.yml/runs?per_page=100&page=${page}")
+            run_count=$(printf '%s' "$runs_json" | jq '.workflow_runs | length')
+
+            if [ "$run_count" -eq 0 ]; then
+              break
+            fi
+
+            matched_run=$(printf '%s' "$runs_json" | jq -c --arg title "$expected_title" --arg tag "$TARGET_TAG" '
+              .workflow_runs
+              | map({
+                  databaseId: .id,
+                  displayTitle: .display_title,
+                  event: .event,
+                  headBranch: (.head_branch // ""),
+                  status: .status,
+                  conclusion: (.conclusion // ""),
+                  url: .html_url,
+                  createdAt: .created_at
+                })
+              | (map(select(.displayTitle == $title)) | sort_by(.createdAt) | reverse | .[0]) //
+                (map(select(.headBranch == $tag)) | sort_by(.createdAt) | reverse | .[0]) //
+                empty
+            ')
+
+            if [ -n "$matched_run" ]; then
+              break
+            fi
+
+            if [ "$run_count" -lt 100 ]; then
+              break
+            fi
+
+            page=$((page + 1))
+          done
+
+          if [ -z "$matched_run" ]; then
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          {
+            echo "found=true"
+            echo "databaseId=$(printf '%s' "$matched_run" | jq -r '.databaseId')"
+            echo "displayTitle=$(printf '%s' "$matched_run" | jq -r '.displayTitle')"
+            echo "event=$(printf '%s' "$matched_run" | jq -r '.event')"
+            echo "headBranch=$(printf '%s' "$matched_run" | jq -r '.headBranch // \"\"')"
+            echo "status=$(printf '%s' "$matched_run" | jq -r '.status')"
+            echo "conclusion=$(printf '%s' "$matched_run" | jq -r '.conclusion // \"\"')"
+            echo "url=$(printf '%s' "$matched_run" | jq -r '.url')"
+            echo "createdAt=$(printf '%s' "$matched_run" | jq -r '.createdAt')"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Wait for matching release publish run
+        if: ${{ steps.publish_run.outputs.found == 'true' && steps.publish_run.outputs.status != 'completed' }}
+        continue-on-error: true
+        shell: bash
+        run: gh run watch "${{ steps.publish_run.outputs.databaseId }}" --interval 10 --exit-status
+
+      - name: Refresh matching release publish run state
+        if: ${{ steps.publish_run.outputs.found == 'true' }}
+        id: publish_run_final
+        shell: bash
+        run: |
+          run_json=$(gh run view "${{ steps.publish_run.outputs.databaseId }}" --json databaseId,displayTitle,event,headBranch,status,conclusion,url,createdAt)
+
+          {
+            echo "databaseId=$(printf '%s' "$run_json" | jq -r '.databaseId')"
+            echo "displayTitle=$(printf '%s' "$run_json" | jq -r '.displayTitle')"
+            echo "event=$(printf '%s' "$run_json" | jq -r '.event')"
+            echo "headBranch=$(printf '%s' "$run_json" | jq -r '.headBranch // \"\"')"
+            echo "status=$(printf '%s' "$run_json" | jq -r '.status')"
+            echo "conclusion=$(printf '%s' "$run_json" | jq -r '.conclusion // \"\"')"
+            echo "url=$(printf '%s' "$run_json" | jq -r '.url')"
+            echo "createdAt=$(printf '%s' "$run_json" | jq -r '.createdAt')"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Refresh published release metadata after publish run settles
+        id: release_final
+        shell: bash
+        run: |
+          release_json=$(gh release view "${{ steps.meta.outputs.tag }}" --json assets,targetCommitish)
+          asset_count=$(printf '%s' "$release_json" | jq '.assets | length')
+          target_commitish=$(printf '%s' "$release_json" | jq -r '.targetCommitish // ""')
+
+          {
+            echo "assetCount=$asset_count"
+            echo "targetCommitish=$target_commitish"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Fail when no matching release publish run exists
+        if: ${{ steps.publish_run.outputs.found != 'true' }}
+        shell: bash
+        run: |
+          {
+            echo "### Published release follow-up failed"
+            echo
+            echo "- release: ${{ steps.meta.outputs.releaseUrl }}"
+            echo "- tag: \`${{ steps.meta.outputs.tag }}\`"
+            echo "- reason: no matching \`release.yml\` publish run was found for this tag"
+            echo
+            echo "This workflow does not publish packages or create release assets."
+            echo "Run \`Release Publish\` manually with tag \`${{ steps.meta.outputs.tag }}\` if the tag was created or the release was published outside the normal publish lane."
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 1
+
+      - name: Fail when the latest release publish run did not succeed
+        if: ${{ steps.publish_run_final.outputs.conclusion != 'success' }}
+        shell: bash
+        run: |
+          {
+            echo "### Published release follow-up failed"
+            echo
+            echo "- release: ${{ steps.meta.outputs.releaseUrl }}"
+            echo "- tag: \`${{ steps.meta.outputs.tag }}\`"
+            echo "- publish run: ${{ steps.publish_run_final.outputs.url }}"
+            echo "- status: \`${{ steps.publish_run_final.outputs.status }}\`"
+            echo "- conclusion: \`${{ steps.publish_run_final.outputs.conclusion }}\`"
+            echo
+            echo "This workflow does not retry publish work. Fix the failed publish lane first, then rerun \`Release Publish\` manually for \`${{ steps.meta.outputs.tag }}\` if needed."
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 1
+
+      - name: Fail when the published release has no assets
+        if: ${{ steps.release_final.outputs.assetCount == '0' }}
+        shell: bash
+        run: |
+          {
+            echo "### Published release follow-up failed"
+            echo
+            echo "- release: ${{ steps.meta.outputs.releaseUrl }}"
+            echo "- tag: \`${{ steps.meta.outputs.tag }}\`"
+            echo "- publish run: ${{ steps.publish_run_final.outputs.url }}"
+            echo "- reason: published GitHub Release has zero assets"
+            echo
+            echo "This usually means the release was created outside the normal publish lane or asset upload was skipped."
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 1
+
+      - name: Summarize published release audit
+        shell: bash
+        run: |
+          {
+            echo "### Published release follow-up passed"
+            echo
+            echo "- release: ${{ steps.meta.outputs.releaseUrl }}"
+            echo "- tag: \`${{ steps.meta.outputs.tag }}\`"
+            echo "- published at: \`${{ steps.meta.outputs.publishedAt }}\`"
+            echo "- target commitish: \`${{ steps.release_final.outputs.targetCommitish }}\`"
+            echo "- publish run: ${{ steps.publish_run_final.outputs.url }}"
+            echo "- release assets: \`${{ steps.release_final.outputs.assetCount }}\`"
+            echo
+            echo "This workflow audits the published release state only. It does not publish packages, upload release assets, or mutate tags."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
-name: Release
+name: Release Publish
+run-name: Release Publish ${{ github.event_name == 'workflow_dispatch' && (startsWith(inputs.tag, 'v') && inputs.tag || format('v{0}', inputs.tag)) || github.ref_name }}
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -161,13 +161,19 @@ Alpha 후보 준비:
 - 태그를 만들기 전 `cargo test --workspace`, `npm run verify`, `npm run smoke`, fixture 기반 `scan/report/clean` smoke를 완료합니다
 - alpha 태그 생성과 push는 유지보수자 확인 후 진행합니다
 
-릴리스 workflow는 태그 push 또는 기존 태그를 지정한 수동 실행에서 아래를 수행합니다.
+`Release Publish` workflow는 태그 push 또는 기존 태그를 지정한 수동 실행에서 아래를 수행합니다.
 
 - release metadata를 해석하고 prerelease면 npm dist-tag를 `next`로 잡습니다
 - Node package verification과 Rust workspace test를 분리해서 실행합니다
 - macOS arm64/x64, Linux x64/arm64, Windows x64용 native artifact를 빌드합니다
 - platform addon npm package를 pack/smoke한 뒤 먼저 publish합니다
 - 마지막에 root `kratos` package를 publish하고 GitHub Release를 생성합니다
+
+`Release Published Follow-up` workflow는 GitHub Release가 published 되었을 때 아래를 수행합니다.
+
+- 해당 release tag에 대응하는 `Release Publish` run이 실제로 있었는지 확인합니다
+- 가장 최근 publish run이 success인지, release asset이 비어 있지 않은지 점검합니다
+- 이 workflow는 publish를 다시 하지 않고, release 게시 이후 상태만 감사(audit)합니다
 
 Stable 승격:
 


### PR DESCRIPTION
## 배경

- `release.yml`은 실제로 tag push 또는 수동 실행에서 publish를 수행하는 workflow인데, 이름과 문서만 보면 GitHub Release가 게시된 뒤에도 같은 workflow가 다시 반응할 것처럼 읽힐 여지가 있었습니다.
- 실제로 `v0.3.0` 사례에서는 GitHub Release가 생겼을 때 왜 `release.yml`이 다시 돌지 않는지 혼선이 있었고, 게시 이후 상태를 감사할 별도 lane이 없었습니다.

## 변경 사항

- 기존 `release.yml`의 이름과 `run-name`을 `Release Publish`로 명확히 했습니다.
- 새 `.github/workflows/release-published-follow-up.yml`을 추가해 `release.published` 또는 수동 실행 시 published release를 감사하도록 분리했습니다.
- 이 follow-up workflow는 다음만 확인합니다.
  - 해당 tag에 대응하는 `Release Publish` run 존재 여부
  - 가장 최근 matching publish run의 성공 여부
  - published GitHub Release asset 비어 있음 여부
- follow-up workflow는 publish, tag 변경, release asset 업로드를 다시 수행하지 않습니다.
- `manual-release-bump.yml` PR 본문과 `README.md`도 새 역할 분리에 맞게 정리했습니다.

## 검증

- `actionlint .github/workflows/release.yml .github/workflows/release-published-follow-up.yml .github/workflows/manual-release-bump.yml`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); YAML.load_file('.github/workflows/release-published-follow-up.yml'); YAML.load_file('.github/workflows/manual-release-bump.yml'); puts 'yaml ok'"`
- `git diff --check`
- live smoke: `gh release view v0.3.0 --json assets,targetCommitish,publishedAt,url`
- live smoke: paginated `release.yml` run lookup로 `v0.3.0` 대응 publish run 매칭 확인
- 독립 Devil's Advocate review 2라운드
  - Round 1에서 stale asset count 조회와 20-run 검색 창 제한을 수정
  - Round 2에서 추가 blocker 없음 확인

## 브랜치 / 워크트리

- base: `master`
- branch: `codex/release-published-follow-up`
- current worktree: `/Users/pjw/workspace/kratos`

## 리스크 또는 후속 확인

- 새 `Release Published Follow-up` workflow는 아직 GitHub-hosted runner에서 실제 실행되진 않았습니다.
- 현재 변경은 publish lane을 분리하지 않고 역할만 명확히 나누는 방향이라, 실제 publish semantics는 유지됩니다.
