### PR TITLE
chore: 0.3.1 수동 bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jeremyfellaz/kratos",
-  "version": "0.2.2",
+  "version": "0.3.1",
   "description": "Destroy dead code ruthlessly.",
   "author": "JeremyDev87",
   "type": "module",
@@ -47,11 +47,11 @@
     "analysis"
   ],
   "optionalDependencies": {
-    "@jeremyfellaz/kratos-darwin-arm64": "0.2.2",
-    "@jeremyfellaz/kratos-darwin-x64": "0.2.2",
-    "@jeremyfellaz/kratos-linux-x64-gnu": "0.2.2",
-    "@jeremyfellaz/kratos-linux-arm64-gnu": "0.2.2",
-    "@jeremyfellaz/kratos-win32-x64-msvc": "0.2.2"
+    "@jeremyfellaz/kratos-darwin-arm64": "0.3.1",
+    "@jeremyfellaz/kratos-darwin-x64": "0.3.1",
+    "@jeremyfellaz/kratos-linux-x64-gnu": "0.3.1",
+    "@jeremyfellaz/kratos-linux-arm64-gnu": "0.3.1",
+    "@jeremyfellaz/kratos-win32-x64-msvc": "0.3.1"
   },
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
## 배경 / Background

- v0.3.0 태그가 package.json 버전과 맞지 않는 SHA를 가리켜 publish job이 실패했습니다.
- 현재 master 최신(e90185c) 기준으로 root package를 0.3.1로 승격합니다.
- 실제 stable tag / publish는 이 bump가 검증된 same-commit 기준으로만 진행해야 합니다.

## 변경 사항 / Changes

- root package.json.version을 0.2.2에서 0.3.1로 올렸습니다.
- root optionalDependencies의 native addon 버전도 모두 0.3.1로 맞췄습니다.

## 검증 / Verification

- node ./scripts/release-plan.mjs v0.3.1
- node ./scripts/bump-release-version.mjs v0.3.1
- npm run verify
- cargo test --workspace

## 브랜치 / Branch

- base: master
- head: codex/manual-bump-master-v0-3-1-0fb62f07
- commit: 08491ac9b471877b0f574b9425da3c2ba15ffd59

## 후속

- same-commit 기준 GitHub Actions 검증 후 tag / publish 여부를 결정합니다.
- v0.3.0는 잘못된 SHA를 가리키고 있으므로 이 PR과는 분리해서 정리해야 합니다.