### PR TITLE
feat: .gitignore 기반 스캔 제외 반영

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -208,6 +208,7 @@ You can place `kratos.config.json` in the project root. JSONC-style comments and
 
 - `ignore`: directory names added to the default ignore list.
 - `ignorePatterns`: `.gitignore`-style path patterns. Use `!` negation for exceptions.
+- After the default ignored directories, Kratos also reads the project root `.gitignore` automatically, then applies `ignorePatterns` for exceptions or overrides.
 - `entry`: root-relative files forced to be entrypoints.
 - `roots`: root-relative directories that limit scan scope.
 - `thresholds.cleanMinConfidence`: default confidence threshold for `clean`.

--- a/README.es.md
+++ b/README.es.md
@@ -208,6 +208,7 @@ Puedes colocar `kratos.config.json` en la raíz del proyecto. Se aceptan comenta
 
 - `ignore`: nombres de directorios añadidos a la lista de ignore por defecto.
 - `ignorePatterns`: patrones de ruta estilo `.gitignore`. Usa negación con `!` para excepciones.
+- Después de los directorios ignorados por defecto, Kratos también lee automáticamente el `.gitignore` de la raíz del proyecto y luego aplica `ignorePatterns` para excepciones u overrides.
 - `entry`: archivos relativos a la raíz del proyecto que deben forzarse como entrypoints.
 - `roots`: directorios relativos a la raíz del proyecto que limitan el alcance del escaneo.
 - `thresholds.cleanMinConfidence`: umbral de confianza por defecto para `clean`.

--- a/README.ja.md
+++ b/README.ja.md
@@ -208,6 +208,7 @@ Totals: introduced 0, resolved 0, persisted 9
 
 - `ignore`: デフォルト ignore 一覧に追加するディレクトリ名です。
 - `ignorePatterns`: `.gitignore` スタイルのパスパターンです。`!` で例外を指定できます。
+- Kratos はデフォルトの ignored directory の後にプロジェクト root の `.gitignore` も自動的に読み込み、その後で `ignorePatterns` を適用して例外や override を追加できます。
 - `entry`: entrypoint として強制する、プロジェクト root からの相対ファイルです。
 - `roots`: スキャン範囲を制限する、プロジェクト root からの相対ディレクトリです。
 - `thresholds.cleanMinConfidence`: `clean` のデフォルト信頼度しきい値です。

--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Totals: introduced 0, resolved 0, persisted 9
 
 - `ignore`: 기본 ignore 목록에 추가할 디렉터리 이름입니다.
 - `ignorePatterns`: `.gitignore` 스타일 경로 패턴입니다. `!`로 예외를 둘 수 있습니다.
+- Kratos는 기본 ignore 디렉터리 이후 프로젝트 root의 `.gitignore`를 자동으로 읽고, 그 다음 `ignorePatterns`를 적용해 예외/override를 줄 수 있습니다.
 - `entry`: entrypoint로 강제 지정할 프로젝트 root 기준 상대 파일 경로입니다.
 - `roots`: 스캔 범위를 제한할 프로젝트 root 기준 상대 디렉터리입니다.
 - `thresholds.cleanMinConfidence`: `clean`의 기본 신뢰도 기준값입니다.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -208,6 +208,7 @@ Totals: introduced 0, resolved 0, persisted 9
 
 - `ignore`：添加到默认 ignore 列表的目录名。
 - `ignorePatterns`：`.gitignore` 风格的路径 pattern。可用 `!` 表示例外。
+- 在默认 ignored directory 之后，Kratos 也会自动读取项目 root 下的 `.gitignore`，随后应用 `ignorePatterns` 来添加例外或 override。
 - `entry`：强制作为 entrypoint 的项目 root 相对文件。
 - `roots`：限制扫描范围的项目 root 相对目录。
 - `thresholds.cleanMinConfidence`：`clean` 的默认置信度阈值。

--- a/crates/kratos-cli/tests/cli_smoke.rs
+++ b/crates/kratos-cli/tests/cli_smoke.rs
@@ -62,6 +62,73 @@ fn scan_report_and_clean_work_for_demo_fixture() {
 }
 
 #[test]
+fn scan_does_not_reopen_node_modules_for_broad_negated_ignore_patterns() {
+    let project_root = copy_demo_app("cli-node-modules-ignore");
+    std::fs::write(
+        project_root.join("kratos.config.json"),
+        r#"{
+  "ignorePatterns": ["!**/*.ts"]
+}
+"#,
+    )
+    .expect("config should write");
+    let dependency_dir = project_root.join("node_modules/@demo");
+    std::fs::create_dir_all(&dependency_dir).expect("node_modules fixture should write");
+    std::fs::write(
+        dependency_dir.join("index.ts"),
+        "export const dependency = true;\n",
+    )
+    .expect("dependency fixture should write");
+
+    let scan = run_cli_in_dir(&project_root, &["scan", "--json"]);
+
+    assert!(scan.status.success());
+    let report: serde_json::Value =
+        serde_json::from_slice(&scan.stdout).expect("scan json should parse");
+    assert_eq!(report["summary"]["filesScanned"], 5);
+    let modules = report["graph"]["modules"]
+        .as_array()
+        .expect("modules should be an array");
+    assert!(
+        modules.iter().all(|module| !module["relativePath"]
+            .as_str()
+            .unwrap_or_default()
+            .starts_with("node_modules/")),
+        "scan report should not include node_modules modules: {modules:#?}"
+    );
+}
+
+#[test]
+fn scan_respects_gitignore_and_config_overrides() {
+    let project_root = copy_demo_app("cli-gitignore");
+    std::fs::write(project_root.join(".gitignore"), "src/lib/**\n!src/lib/\n")
+        .expect("gitignore should write");
+    std::fs::write(
+        project_root.join("kratos.config.json"),
+        r#"{
+  "ignorePatterns": ["!src/lib/math.ts"]
+}
+"#,
+    )
+    .expect("config should write");
+
+    let scan = run_cli_in_dir(&project_root, &["scan", "--json"]);
+
+    assert!(scan.status.success());
+    let report: serde_json::Value =
+        serde_json::from_slice(&scan.stdout).expect("scan json should parse");
+    assert_eq!(report["summary"]["filesScanned"], 4);
+    let relative_paths = report["graph"]["modules"]
+        .as_array()
+        .expect("modules should be an array")
+        .iter()
+        .filter_map(|module| module["relativePath"].as_str())
+        .collect::<Vec<_>>();
+    assert!(relative_paths.contains(&"src/lib/math.ts"));
+    assert!(!relative_paths.contains(&"src/lib/broken.ts"));
+}
+
+#[test]
 fn clean_accepts_legacy_v1_reports_through_cli() {
     let project_root = copy_demo_app("cli-clean-v1-report");
     let source_report = repo_root().join("fixtures/parity/demo-app/latest-report.v1.json");

--- a/crates/kratos-core/src/config.rs
+++ b/crates/kratos-core/src/config.rs
@@ -8,6 +8,7 @@ use crate::model::{PathAlias, ProjectConfig};
 use crate::suppressions::{parse_suppression_rules, SuppressionSource};
 
 const DEFAULT_CONFIG_FILENAME: &str = "kratos.config.json";
+const GITIGNORE_FILENAME: &str = ".gitignore";
 const PACKAGE_ENTRY_EXTENSIONS: &[&str] = &[
     ".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".mts", ".cts", ".d.ts", ".d.mts", ".d.cts",
 ];
@@ -70,9 +71,9 @@ pub fn load_project_config(root: impl Into<PathBuf>) -> KratosResult<ProjectConf
         base_url: base_url.clone(),
         roots: normalize_roots(&root, user_config.get("roots"))?,
         ignored_directories: normalize_ignored_directories(user_config.get("ignore")),
-        ignore_patterns: extract_required_string_array(
-            user_config.get("ignorePatterns"),
-            "ignorePatterns",
+        ignore_patterns: normalize_ignore_patterns(
+            &root,
+            extract_required_string_array(user_config.get("ignorePatterns"), "ignorePatterns")?,
         )?,
         explicit_entries: normalize_entry_paths(&root, user_config.get("entry"))?,
         package_entries: collect_package_entry_files(&root, &package_json),
@@ -119,6 +120,33 @@ fn read_loose_json_file(file_path: &Path) -> KratosResult<Option<JsonValue>> {
 
     let content = std::fs::read_to_string(file_path)?;
     Ok(Some(parse_loose_json(&content)?))
+}
+
+fn normalize_ignore_patterns(
+    root: &Path,
+    user_patterns: Vec<String>,
+) -> KratosResult<Vec<String>> {
+    let mut patterns = read_gitignore_patterns(&resolve_config_path(root, GITIGNORE_FILENAME))?;
+    patterns.extend(user_patterns);
+    Ok(patterns)
+}
+
+fn read_gitignore_patterns(file_path: &Path) -> KratosResult<Vec<String>> {
+    if !file_path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let content = std::fs::read_to_string(file_path)?;
+    Ok(content.lines().filter_map(normalize_gitignore_line).collect())
+}
+
+fn normalize_gitignore_line(line: &str) -> Option<String> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() || trimmed.starts_with('#') {
+        return None;
+    }
+
+    Some(trimmed.to_string())
 }
 
 fn read_clean_min_confidence(user_config: &JsonValue) -> KratosResult<f32> {

--- a/crates/kratos-core/src/ignore.rs
+++ b/crates/kratos-core/src/ignore.rs
@@ -57,6 +57,8 @@ impl IgnoreMatcher {
         traversal_root: Option<&str>,
     ) -> bool {
         let normalized = normalize_relative_path(relative_dir);
+        let ignored_by_directory_name_rule =
+            self.is_ignored_by_directory_name_rule(&normalized, traversal_root);
         if !self.is_ignored_from_root(&normalized, true, traversal_root)
             && !self.ignores_descendants(&normalized, traversal_root)
         {
@@ -65,6 +67,9 @@ impl IgnoreMatcher {
 
         self.rules.iter().any(|rule| {
             if !rule.negated || !rule.may_match_descendant(&normalized) {
+                return false;
+            }
+            if ignored_by_directory_name_rule && !rule.has_explicit_path_prefix() {
                 return false;
             }
 
@@ -79,6 +84,20 @@ impl IgnoreMatcher {
     fn ignores_descendants(&self, relative_dir: &str, traversal_root: Option<&str>) -> bool {
         let probe = descendant_probe_path(relative_dir);
         !probe.is_empty() && self.is_ignored_from_root(&probe, false, traversal_root)
+    }
+
+    fn is_ignored_by_directory_name_rule(
+        &self,
+        relative_dir: &str,
+        traversal_root: Option<&str>,
+    ) -> bool {
+        let normalized_root = traversal_root.map(normalize_relative_path);
+        self.rules.iter().any(|rule| {
+            !rule.negated
+                && rule.directory_only
+                && rule.scoped_to_traversal_root
+                && rule.matches(relative_dir, true, normalized_root.as_deref())
+        })
     }
 }
 
@@ -165,6 +184,10 @@ impl IgnoreRule {
                 return self.matches_path(scoped_path);
             }
 
+            if self.negated {
+                return false;
+            }
+
             for ancestor in ancestor_directories(scoped_path) {
                 if self.matches_path(ancestor) {
                     return true;
@@ -172,6 +195,14 @@ impl IgnoreRule {
             }
 
             return false;
+        }
+
+        if !is_dir && !self.negated {
+            for ancestor in ancestor_directories(scoped_path) {
+                if self.matches_path(ancestor) {
+                    return true;
+                }
+            }
         }
 
         self.matches_path(scoped_path)
@@ -216,6 +247,10 @@ impl IgnoreRule {
         let prefix_with_slash = format!("{prefix}/");
 
         prefix == dir || prefix.starts_with(&dir_prefix) || dir.starts_with(&prefix_with_slash)
+    }
+
+    fn has_explicit_path_prefix(&self) -> bool {
+        self.has_slash && !self.literal_prefix.is_empty()
     }
 
     fn sample_path_at_or_below(&self, relative_dir: &str) -> Option<(String, bool)> {
@@ -709,5 +744,59 @@ mod tests {
         assert!(matcher.should_traverse_dir("src/foo"));
         assert!(!matcher.is_ignored("src/foo/keep.ts", false));
         assert!(matcher.is_ignored("src/foo/drop.ts", false));
+    }
+
+    #[test]
+    fn broad_wildcard_negations_do_not_reopen_default_ignored_directories() {
+        let matcher = IgnoreMatcher::new(
+            &["node_modules".to_string()],
+            &["!**/*.ts".to_string(), "!*.tsx".to_string()],
+        );
+
+        assert!(!matcher.should_traverse_dir("node_modules"));
+        assert!(!matcher.should_traverse_dir("node_modules/@demo"));
+    }
+
+    #[test]
+    fn negated_directory_only_patterns_reopen_traversal_without_reopening_all_descendants() {
+        let matcher = IgnoreMatcher::new(
+            &[],
+            &[
+                "src/generated/**".to_string(),
+                "!src/generated/".to_string(),
+                "!src/generated/keep.ts".to_string(),
+            ],
+        );
+
+        assert!(matcher.should_traverse_dir("src/generated"));
+        assert!(!matcher.is_ignored("src/generated/keep.ts", false));
+        assert!(matcher.is_ignored("src/generated/drop.ts", false));
+    }
+
+    #[test]
+    fn basename_negations_can_reopen_raw_ignored_descendants() {
+        let matcher = IgnoreMatcher::new(
+            &[],
+            &["src/generated/**".to_string(), "!keep.ts".to_string()],
+        );
+
+        assert!(matcher.should_traverse_dir("src/generated"));
+        assert!(!matcher.is_ignored("src/generated/keep.ts", false));
+        assert!(matcher.is_ignored("src/generated/drop.ts", false));
+    }
+
+    #[test]
+    fn slash_patterns_that_match_directories_still_ignore_descendant_files() {
+        let matcher = IgnoreMatcher::new(
+            &[],
+            &[
+                "src/generated".to_string(),
+                "!src/generated/keep.ts".to_string(),
+            ],
+        );
+
+        assert!(matcher.should_traverse_dir("src/generated"));
+        assert!(!matcher.is_ignored("src/generated/keep.ts", false));
+        assert!(matcher.is_ignored("src/generated/drop.ts", false));
     }
 }

--- a/crates/kratos-core/tests/config_and_discovery.rs
+++ b/crates/kratos-core/tests/config_and_discovery.rs
@@ -109,6 +109,38 @@ fn load_project_config_parses_comments_and_collects_entries() {
 }
 
 #[test]
+fn load_project_config_merges_gitignore_before_user_ignore_patterns() {
+    let project = TestProject::new("gitignore-config-merge");
+    project.write(
+        ".gitignore",
+        r#"
+# Generated code
+src/generated/**
+
+dist/
+"#,
+    );
+    project.write(
+        "kratos.config.json",
+        r#"{
+  "ignorePatterns": ["!src/generated/keep.ts"]
+}
+"#,
+    );
+
+    let config = load_project_config(project.root()).expect("config should load");
+
+    assert_eq!(
+        config.ignore_patterns,
+        vec![
+            "src/generated/**".to_string(),
+            "dist/".to_string(),
+            "!src/generated/keep.ts".to_string()
+        ]
+    );
+}
+
+#[test]
 fn load_clean_min_confidence_defaults_to_zero_and_reads_thresholds() {
     let project = TestProject::new("clean-confidence-defaults");
 
@@ -312,6 +344,103 @@ fn collect_source_files_supports_gitignore_style_negated_patterns() {
 }
 
 #[test]
+fn collect_source_files_respects_gitignore_and_user_config_overrides() {
+    let project = TestProject::new("gitignore-discovery");
+    project.write(".gitignore", "src/generated/**\n");
+    project.write(
+        "kratos.config.json",
+        r#"{
+  "ignorePatterns": ["!src/generated/keep.ts"]
+}
+"#,
+    );
+    project.write("src/main.ts", "export const main = true;\n");
+    project.write("src/generated/keep.ts", "export const keep = true;\n");
+    project.write("src/generated/drop.ts", "export const drop = true;\n");
+
+    let config = load_project_config(project.root()).expect("config should load");
+    let discovered = collect_source_files(&config).expect("source discovery should succeed");
+
+    assert_eq!(
+        discovered,
+        vec![
+            project.root().join("src/generated/keep.ts"),
+            project.root().join("src/main.ts")
+        ]
+    );
+}
+
+#[test]
+fn collect_source_files_treats_gitignore_directory_negation_as_traversal_only() {
+    let project = TestProject::new("gitignore-directory-negation");
+    project.write(
+        ".gitignore",
+        "src/generated/**\n!src/generated/\n!src/generated/keep.ts\n",
+    );
+    project.write("src/main.ts", "export const main = true;\n");
+    project.write("src/generated/keep.ts", "export const keep = true;\n");
+    project.write("src/generated/drop.ts", "export const drop = true;\n");
+
+    let config = load_project_config(project.root()).expect("config should load");
+    let discovered = collect_source_files(&config).expect("source discovery should succeed");
+
+    assert_eq!(
+        discovered,
+        vec![
+            project.root().join("src/generated/keep.ts"),
+            project.root().join("src/main.ts")
+        ]
+    );
+}
+
+#[test]
+fn collect_source_files_allows_basename_negation_to_reopen_gitignored_descendant() {
+    let project = TestProject::new("gitignore-basename-negation");
+    project.write(".gitignore", "src/generated/**\n!keep.ts\n");
+    project.write("src/main.ts", "export const main = true;\n");
+    project.write("src/generated/keep.ts", "export const keep = true;\n");
+    project.write("src/generated/drop.ts", "export const drop = true;\n");
+
+    let config = load_project_config(project.root()).expect("config should load");
+    let discovered = collect_source_files(&config).expect("source discovery should succeed");
+
+    assert_eq!(
+        discovered,
+        vec![
+            project.root().join("src/generated/keep.ts"),
+            project.root().join("src/main.ts")
+        ]
+    );
+}
+
+#[test]
+fn collect_source_files_treats_slash_gitignore_directory_match_as_directory_tree() {
+    let project = TestProject::new("gitignore-slash-directory-tree");
+    project.write(".gitignore", "src/generated\n");
+    project.write(
+        "kratos.config.json",
+        r#"{
+  "ignorePatterns": ["!src/generated/keep.ts"]
+}
+"#,
+    );
+    project.write("src/main.ts", "export const main = true;\n");
+    project.write("src/generated/keep.ts", "export const keep = true;\n");
+    project.write("src/generated/drop.ts", "export const drop = true;\n");
+
+    let config = load_project_config(project.root()).expect("config should load");
+    let discovered = collect_source_files(&config).expect("source discovery should succeed");
+
+    assert_eq!(
+        discovered,
+        vec![
+            project.root().join("src/generated/keep.ts"),
+            project.root().join("src/main.ts")
+        ]
+    );
+}
+
+#[test]
 fn collect_source_files_honors_explicit_roots_even_when_root_name_is_ignored_by_default() {
     let project = TestProject::new("explicit-roots-override-default-ignores");
     project.write(
@@ -394,6 +523,25 @@ fn collect_source_files_does_not_reopen_unrelated_ignored_trees_for_negations() 
     let discovered = collect_source_files(&config).expect("source discovery should succeed");
 
     assert_eq!(discovered, vec![project.root().join("src/generated/keep.ts")]);
+}
+
+#[test]
+fn collect_source_files_does_not_reopen_node_modules_for_broad_negations() {
+    let project = TestProject::new("broad-negation-does-not-reopen-node-modules");
+    project.write(
+        "kratos.config.json",
+        r#"{
+  "ignorePatterns": ["!**/*.ts"]
+}
+"#,
+    );
+    project.write("src/main.ts", "export const main = true;\n");
+    project.write("node_modules/@demo/index.ts", "export const dependency = true;\n");
+
+    let config = load_project_config(project.root()).expect("config should load");
+    let discovered = collect_source_files(&config).expect("source discovery should succeed");
+
+    assert_eq!(discovered, vec![project.root().join("src/main.ts")]);
 }
 
 #[test]


### PR DESCRIPTION
## 배경

Kratos 스캔이 프로젝트의 `.gitignore`를 반영하지 않아 `node_modules`나 생성물 제외 정책과 실제 스캔 범위가 어긋날 수 있었습니다.

## 변경 사항

- 프로젝트 root의 `.gitignore`를 읽어 `ignorePatterns` 앞에 병합했습니다.
- 적용 순서를 `기본 ignore 디렉터리 -> .gitignore -> kratos.config.json ignorePatterns`로 유지했습니다.
- broad negation이 `node_modules` 같은 기본 제외 디렉터리를 다시 열지 않도록 traversal 판단을 보강했습니다.
- directory-only negation, basename negation, slash pattern이 디렉터리를 가리키는 케이스를 회귀 테스트로 고정했습니다.
- README 다국어 문서에 `.gitignore` 자동 반영과 config override 순서를 명시했습니다.

## 검증

- `cargo test -p kratos-core`
- `cargo test --workspace`
- `npm run verify`
- `git diff --check`
- `$devils-advocate-review-loop` 3라운드: Critical 0 / High 0

참고: `npm run verify`의 native addon smoke는 `KRATOS_PACKAGE_SMOKE_NATIVE_LIB` 미설정으로 기존처럼 skip되었습니다. cross-platform native packaging CI는 로컬에서 실행하지 않았습니다.

## 브랜치 / 워크트리

- branch: `codex/gitignore-scan-support`
- base: `master`
- worktree: `/Users/pjw/workspace/kratos`
