### PR TITLE
feat: scan report wow 출력 개선

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -97,6 +97,9 @@ Scanning `fixtures/demo-app` produces a summary like this.
 ```text
 Kratos scan complete.
 
+Impact: 6 actionable findings: 1 broken import, 2 cleanup candidates, 3 dead exports.
+Best next move: Fix broken imports before deleting files.
+
 Root: <root>
 Files scanned: 5
 Entrypoints: 1
@@ -109,17 +112,25 @@ Deletion candidates: 2
 
 Saved report: <root>/.kratos/latest-report.json
 
+Next steps:
+- Preview cleanup: kratos clean <root>/.kratos/latest-report.json
+- Shareable markdown: kratos report <root>/.kratos/latest-report.json --format md
+
 Broken imports:
-- <root>/src/lib/broken.ts -> ./missing-helper
+- src/lib/broken.ts -> ./missing-helper
+
+Top cleanup candidates:
+- src/components/DeadWidget.tsx (confidence 0.92, Component-like module has no inbound references.)
+- src/lib/broken.ts (confidence 0.88, Module has no inbound references and is not treated as an entrypoint.)
 
 Orphan files:
-- <root>/src/components/DeadWidget.tsx
-- <root>/src/lib/broken.ts
+- src/components/DeadWidget.tsx
+- src/lib/broken.ts
 
 Dead exports:
-- <root>/src/components/DeadWidget.tsx#DeadWidget
-- <root>/src/lib/broken.ts#brokenFeature
-- <root>/src/lib/math.ts#multiply
+- src/components/DeadWidget.tsx#DeadWidget
+- src/lib/broken.ts#brokenFeature
+- src/lib/math.ts#multiply
 ```
 
 `clean --min-confidence 0.9` separates deletion targets from candidates skipped by the threshold.

--- a/README.es.md
+++ b/README.es.md
@@ -97,6 +97,9 @@ Al escanear `fixtures/demo-app`, el resumen tiene esta forma.
 ```text
 Kratos scan complete.
 
+Impact: 6 actionable findings: 1 broken import, 2 cleanup candidates, 3 dead exports.
+Best next move: Fix broken imports before deleting files.
+
 Root: <root>
 Files scanned: 5
 Entrypoints: 1
@@ -109,17 +112,25 @@ Deletion candidates: 2
 
 Saved report: <root>/.kratos/latest-report.json
 
+Next steps:
+- Preview cleanup: kratos clean <root>/.kratos/latest-report.json
+- Shareable markdown: kratos report <root>/.kratos/latest-report.json --format md
+
 Broken imports:
-- <root>/src/lib/broken.ts -> ./missing-helper
+- src/lib/broken.ts -> ./missing-helper
+
+Top cleanup candidates:
+- src/components/DeadWidget.tsx (confidence 0.92, Component-like module has no inbound references.)
+- src/lib/broken.ts (confidence 0.88, Module has no inbound references and is not treated as an entrypoint.)
 
 Orphan files:
-- <root>/src/components/DeadWidget.tsx
-- <root>/src/lib/broken.ts
+- src/components/DeadWidget.tsx
+- src/lib/broken.ts
 
 Dead exports:
-- <root>/src/components/DeadWidget.tsx#DeadWidget
-- <root>/src/lib/broken.ts#brokenFeature
-- <root>/src/lib/math.ts#multiply
+- src/components/DeadWidget.tsx#DeadWidget
+- src/lib/broken.ts#brokenFeature
+- src/lib/math.ts#multiply
 ```
 
 `clean --min-confidence 0.9` separa los objetivos de eliminación de los candidatos omitidos por el umbral.

--- a/README.ja.md
+++ b/README.ja.md
@@ -97,6 +97,9 @@ npx @jeremyfellaz/kratos diff ./my-app/.kratos/before.json ./my-app/.kratos/afte
 ```text
 Kratos scan complete.
 
+Impact: 6 actionable findings: 1 broken import, 2 cleanup candidates, 3 dead exports.
+Best next move: Fix broken imports before deleting files.
+
 Root: <root>
 Files scanned: 5
 Entrypoints: 1
@@ -109,17 +112,25 @@ Deletion candidates: 2
 
 Saved report: <root>/.kratos/latest-report.json
 
+Next steps:
+- Preview cleanup: kratos clean <root>/.kratos/latest-report.json
+- Shareable markdown: kratos report <root>/.kratos/latest-report.json --format md
+
 Broken imports:
-- <root>/src/lib/broken.ts -> ./missing-helper
+- src/lib/broken.ts -> ./missing-helper
+
+Top cleanup candidates:
+- src/components/DeadWidget.tsx (confidence 0.92, Component-like module has no inbound references.)
+- src/lib/broken.ts (confidence 0.88, Module has no inbound references and is not treated as an entrypoint.)
 
 Orphan files:
-- <root>/src/components/DeadWidget.tsx
-- <root>/src/lib/broken.ts
+- src/components/DeadWidget.tsx
+- src/lib/broken.ts
 
 Dead exports:
-- <root>/src/components/DeadWidget.tsx#DeadWidget
-- <root>/src/lib/broken.ts#brokenFeature
-- <root>/src/lib/math.ts#multiply
+- src/components/DeadWidget.tsx#DeadWidget
+- src/lib/broken.ts#brokenFeature
+- src/lib/math.ts#multiply
 ```
 
 `clean --min-confidence 0.9` は、削除対象としきい値により除外された候補を分けて表示します。

--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ npx @jeremyfellaz/kratos diff ./my-app/.kratos/before.json ./my-app/.kratos/afte
 ```text
 Kratos scan complete.
 
+Impact: 6 actionable findings: 1 broken import, 2 cleanup candidates, 3 dead exports.
+Best next move: Fix broken imports before deleting files.
+
 Root: <root>
 Files scanned: 5
 Entrypoints: 1
@@ -109,17 +112,25 @@ Deletion candidates: 2
 
 Saved report: <root>/.kratos/latest-report.json
 
+Next steps:
+- Preview cleanup: kratos clean <root>/.kratos/latest-report.json
+- Shareable markdown: kratos report <root>/.kratos/latest-report.json --format md
+
 Broken imports:
-- <root>/src/lib/broken.ts -> ./missing-helper
+- src/lib/broken.ts -> ./missing-helper
+
+Top cleanup candidates:
+- src/components/DeadWidget.tsx (confidence 0.92, Component-like module has no inbound references.)
+- src/lib/broken.ts (confidence 0.88, Module has no inbound references and is not treated as an entrypoint.)
 
 Orphan files:
-- <root>/src/components/DeadWidget.tsx
-- <root>/src/lib/broken.ts
+- src/components/DeadWidget.tsx
+- src/lib/broken.ts
 
 Dead exports:
-- <root>/src/components/DeadWidget.tsx#DeadWidget
-- <root>/src/lib/broken.ts#brokenFeature
-- <root>/src/lib/math.ts#multiply
+- src/components/DeadWidget.tsx#DeadWidget
+- src/lib/broken.ts#brokenFeature
+- src/lib/math.ts#multiply
 ```
 
 `clean --min-confidence 0.9`는 신뢰도 기준값을 통과한 삭제 후보와 제외된 후보를 나눠 보여줍니다.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -97,6 +97,9 @@ npx @jeremyfellaz/kratos diff ./my-app/.kratos/before.json ./my-app/.kratos/afte
 ```text
 Kratos scan complete.
 
+Impact: 6 actionable findings: 1 broken import, 2 cleanup candidates, 3 dead exports.
+Best next move: Fix broken imports before deleting files.
+
 Root: <root>
 Files scanned: 5
 Entrypoints: 1
@@ -109,17 +112,25 @@ Deletion candidates: 2
 
 Saved report: <root>/.kratos/latest-report.json
 
+Next steps:
+- Preview cleanup: kratos clean <root>/.kratos/latest-report.json
+- Shareable markdown: kratos report <root>/.kratos/latest-report.json --format md
+
 Broken imports:
-- <root>/src/lib/broken.ts -> ./missing-helper
+- src/lib/broken.ts -> ./missing-helper
+
+Top cleanup candidates:
+- src/components/DeadWidget.tsx (confidence 0.92, Component-like module has no inbound references.)
+- src/lib/broken.ts (confidence 0.88, Module has no inbound references and is not treated as an entrypoint.)
 
 Orphan files:
-- <root>/src/components/DeadWidget.tsx
-- <root>/src/lib/broken.ts
+- src/components/DeadWidget.tsx
+- src/lib/broken.ts
 
 Dead exports:
-- <root>/src/components/DeadWidget.tsx#DeadWidget
-- <root>/src/lib/broken.ts#brokenFeature
-- <root>/src/lib/math.ts#multiply
+- src/components/DeadWidget.tsx#DeadWidget
+- src/lib/broken.ts#brokenFeature
+- src/lib/math.ts#multiply
 ```
 
 `clean --min-confidence 0.9` 会把删除目标和因阈值被跳过的候选项分开显示。

--- a/crates/kratos-cli/tests/cli_smoke.rs
+++ b/crates/kratos-cli/tests/cli_smoke.rs
@@ -34,10 +34,17 @@ fn scan_report_and_clean_work_for_demo_fixture() {
     assert!(scan.status.success());
     let scan_stdout = String::from_utf8_lossy(&scan.stdout);
     assert!(scan_stdout.contains("Kratos scan complete."));
+    assert!(scan_stdout.contains(
+        "Impact: 6 actionable findings: 1 broken import, 2 cleanup candidates, 3 dead exports."
+    ));
+    assert!(scan_stdout.contains("Best next move: Fix broken imports before deleting files."));
     assert!(scan_stdout.contains("Files scanned: 5"));
     assert!(scan_stdout.contains("Broken imports: 1"));
     assert!(scan_stdout.contains("Route entrypoints: 1"));
     assert!(scan_stdout.contains("Deletion candidates: 2"));
+    assert!(scan_stdout.contains("Next steps:"));
+    assert!(scan_stdout.contains("Top cleanup candidates:"));
+    assert!(scan_stdout.contains("- src/components/DeadWidget.tsx"));
     assert!(report_path.exists());
 
     let report = run_cli(&[
@@ -49,6 +56,7 @@ fn scan_report_and_clean_work_for_demo_fixture() {
     assert!(report.status.success());
     let report_stdout = String::from_utf8_lossy(&report.stdout);
     assert!(report_stdout.contains("# Kratos Report"));
+    assert!(report_stdout.contains("## Impact"));
     assert!(report_stdout.contains("- Route entrypoints: 1"));
     assert!(report_stdout.contains("## Broken imports"));
     assert!(report_stdout.contains("## Route entrypoints"));

--- a/crates/kratos-core/src/report_format.rs
+++ b/crates/kratos-core/src/report_format.rs
@@ -9,8 +9,12 @@ pub fn format_summary_report(
     report_path: &Path,
     title: &str,
 ) -> KratosResult<String> {
+    let impact = impact_summary(report);
     let mut lines = vec![
         title.to_string(),
+        String::new(),
+        format!("Impact: {}", impact.headline),
+        format!("Best next move: {}", impact.best_next_move),
         String::new(),
         format!("Root: {}", path_to_string(&report.root)),
         format!("Files scanned: {}", report.summary.files_scanned),
@@ -33,24 +37,39 @@ pub fn format_summary_report(
     }
     lines.push(String::new());
     lines.push(format!("Saved report: {}", path_to_string(report_path)));
+    append_next_steps(&mut lines, report, report_path);
 
     append_preview(
         &mut lines,
         "Broken imports",
         &report.findings.broken_imports,
-        |item| format!("{} -> {}", path_to_string(&item.file), item.source),
+        |item| format!("{} -> {}", display_path(report, &item.file), item.source),
     );
+    append_deletion_preview(&mut lines, report);
     append_preview(
         &mut lines,
         "Orphan files",
         &report.findings.orphan_files,
-        |item| path_to_string(&item.file),
+        |item| display_path(report, &item.file),
     );
     append_preview(
         &mut lines,
         "Dead exports",
         &report.findings.dead_exports,
-        |item| format!("{}#{}", path_to_string(&item.file), item.export_name),
+        |item| format!("{}#{}", display_path(report, &item.file), item.export_name),
+    );
+    append_preview(
+        &mut lines,
+        "Unused imports",
+        &report.findings.unused_imports,
+        |item| {
+            format!(
+                "{} -> {} from {}",
+                display_path(report, &item.file),
+                item.local,
+                item.source
+            )
+        },
     );
     append_preview(
         &mut lines,
@@ -59,7 +78,7 @@ pub fn format_summary_report(
         |item| {
             format!(
                 "{} ({})",
-                path_to_string(&item.file),
+                display_path(report, &item.file),
                 entrypoint_kind_to_string(&item.kind)
             )
         },
@@ -71,6 +90,8 @@ pub fn format_summary_report(
 pub fn format_markdown_report(report: &ReportV2, report_path: &Path) -> KratosResult<String> {
     let mut lines = vec![
         "# Kratos Report".to_string(),
+        String::new(),
+        format!("> {}", impact_summary(report).headline),
         String::new(),
         format!(
             "- Generated: {}",
@@ -101,23 +122,30 @@ pub fn format_markdown_report(report: &ReportV2, report_path: &Path) -> KratosRe
     }
     lines.push(String::new());
 
+    push_markdown_impact(&mut lines, report, report_path);
     push_markdown_section(
         &mut lines,
         "Broken imports",
         &report.findings.broken_imports,
-        |item| format!("{} -> `{}`", path_to_string(&item.file), item.source),
+        |item| format!("{} -> `{}`", display_path(report, &item.file), item.source),
     );
     push_markdown_section(
         &mut lines,
         "Orphan files",
         &report.findings.orphan_files,
-        |item| format!("{} ({})", path_to_string(&item.file), item.reason),
+        |item| format!("{} ({})", display_path(report, &item.file), item.reason),
     );
     push_markdown_section(
         &mut lines,
         "Dead exports",
         &report.findings.dead_exports,
-        |item| format!("{} -> `{}`", path_to_string(&item.file), item.export_name),
+        |item| {
+            format!(
+                "{} -> `{}`",
+                display_path(report, &item.file),
+                item.export_name
+            )
+        },
     );
     push_markdown_section(
         &mut lines,
@@ -126,7 +154,7 @@ pub fn format_markdown_report(report: &ReportV2, report_path: &Path) -> KratosRe
         |item| {
             format!(
                 "{} -> `{}` from `{}`",
-                path_to_string(&item.file),
+                display_path(report, &item.file),
                 item.local,
                 item.source
             )
@@ -139,7 +167,7 @@ pub fn format_markdown_report(report: &ReportV2, report_path: &Path) -> KratosRe
         |item| {
             format!(
                 "{} ({})",
-                path_to_string(&item.file),
+                display_path(report, &item.file),
                 entrypoint_kind_to_string(&item.kind)
             )
         },
@@ -151,7 +179,7 @@ pub fn format_markdown_report(report: &ReportV2, report_path: &Path) -> KratosRe
         |item| {
             format!(
                 "{} ({}, confidence {})",
-                path_to_string(&item.file),
+                display_path(report, &item.file),
                 item.reason,
                 item.confidence
             )
@@ -159,6 +187,158 @@ pub fn format_markdown_report(report: &ReportV2, report_path: &Path) -> KratosRe
     );
 
     Ok(lines.join("\n"))
+}
+
+struct ImpactSummary {
+    headline: String,
+    best_next_move: String,
+}
+
+fn impact_summary(report: &ReportV2) -> ImpactSummary {
+    let breakages = report.summary.broken_imports;
+    let cleanup_candidates = report.summary.deletion_candidates;
+    let dead_exports = report.summary.dead_exports;
+    let unused_imports = report.summary.unused_imports;
+    let actionable_total = breakages + cleanup_candidates + dead_exports + unused_imports;
+
+    let headline = if actionable_total == 0 {
+        format!(
+            "No actionable findings across {}.",
+            plural(
+                report.summary.files_scanned,
+                "scanned file",
+                "scanned files"
+            )
+        )
+    } else {
+        let mut parts = Vec::new();
+        if breakages > 0 {
+            parts.push(plural(breakages, "broken import", "broken imports"));
+        }
+        if cleanup_candidates > 0 {
+            parts.push(plural(
+                cleanup_candidates,
+                "cleanup candidate",
+                "cleanup candidates",
+            ));
+        }
+        if dead_exports > 0 {
+            parts.push(plural(dead_exports, "dead export", "dead exports"));
+        }
+        if unused_imports > 0 {
+            parts.push(plural(unused_imports, "unused import", "unused imports"));
+        }
+
+        format!(
+            "{}: {}.",
+            plural(
+                actionable_total,
+                "actionable finding",
+                "actionable findings"
+            ),
+            parts.join(", ")
+        )
+    };
+
+    let best_next_move = if breakages > 0 {
+        "Fix broken imports before deleting files.".to_string()
+    } else if cleanup_candidates > 0 {
+        "Run the clean preview and remove high-confidence dead files.".to_string()
+    } else if dead_exports > 0 {
+        "Prune dead exports or confirm they are intentionally public API.".to_string()
+    } else if unused_imports > 0 {
+        "Remove unused imports to shrink noisy dependencies.".to_string()
+    } else {
+        "Keep the JSON report as a baseline for future diffs.".to_string()
+    };
+
+    ImpactSummary {
+        headline,
+        best_next_move,
+    }
+}
+
+fn plural(count: usize, singular: &str, plural: &str) -> String {
+    if count == 1 {
+        format!("1 {singular}")
+    } else {
+        format!("{count} {plural}")
+    }
+}
+
+fn append_next_steps(lines: &mut Vec<String>, report: &ReportV2, report_path: &Path) {
+    let report_arg = shell_arg(report_path);
+
+    lines.push(String::new());
+    lines.push("Next steps:".to_string());
+
+    if report.summary.deletion_candidates > 0 {
+        lines.push(format!("- Preview cleanup: kratos clean {report_arg}"));
+    }
+    lines.push(format!(
+        "- Shareable markdown: kratos report {report_arg} --format md"
+    ));
+}
+
+fn push_markdown_impact(lines: &mut Vec<String>, report: &ReportV2, report_path: &Path) {
+    let impact = impact_summary(report);
+    let report_arg = shell_arg(report_path);
+
+    lines.push("## Impact".to_string());
+    lines.push(String::new());
+    lines.push(format!("- {}", impact.headline));
+    lines.push(format!("- Best next move: {}", impact.best_next_move));
+    if report.summary.deletion_candidates > 0 {
+        lines.push(format!("- Preview cleanup: `kratos clean {report_arg}`"));
+    }
+    lines.push(format!(
+        "- Refresh markdown: `kratos report {report_arg} --format md`"
+    ));
+    lines.push(String::new());
+}
+
+fn append_deletion_preview(lines: &mut Vec<String>, report: &ReportV2) {
+    if report.findings.deletion_candidates.is_empty() {
+        return;
+    }
+
+    lines.push(String::new());
+    lines.push("Top cleanup candidates:".to_string());
+
+    for item in report.findings.deletion_candidates.iter().take(5) {
+        lines.push(format!(
+            "- {} (confidence {}, {})",
+            display_path(report, &item.file),
+            item.confidence,
+            item.reason
+        ));
+    }
+
+    if report.findings.deletion_candidates.len() > 5 {
+        lines.push(format!(
+            "- ...and {} more",
+            report.findings.deletion_candidates.len() - 5
+        ));
+    }
+}
+
+fn display_path(report: &ReportV2, path: &Path) -> String {
+    match path.strip_prefix(&report.root) {
+        Ok(relative) if !relative.as_os_str().is_empty() => path_to_string(relative),
+        _ => path_to_string(path),
+    }
+}
+
+fn shell_arg(path: &Path) -> String {
+    let raw = path_to_string(path);
+    if raw
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || "/._-".contains(character))
+    {
+        raw
+    } else {
+        format!("'{}'", raw.replace('\'', "'\\''"))
+    }
 }
 
 fn append_preview<T>(

--- a/fixtures/parity/demo-app/report-markdown.md
+++ b/fixtures/parity/demo-app/report-markdown.md
@@ -1,5 +1,7 @@
 # Kratos Report
 
+> 6 actionable findings: 1 broken import, 2 cleanup candidates, 3 dead exports.
+
 - Generated: <GENERATED_AT>
 - Root: <ROOT>
 - Report: <REPORT>
@@ -15,20 +17,27 @@
 - Route entrypoints: 1
 - Deletion candidates: 2
 
+## Impact
+
+- 6 actionable findings: 1 broken import, 2 cleanup candidates, 3 dead exports.
+- Best next move: Fix broken imports before deleting files.
+- Preview cleanup: `kratos clean <REPORT>`
+- Refresh markdown: `kratos report <REPORT> --format md`
+
 ## Broken imports
 
-- <ROOT>/src/lib/broken.ts -> `./missing-helper`
+- src/lib/broken.ts -> `./missing-helper`
 
 ## Orphan files
 
-- <ROOT>/src/components/DeadWidget.tsx (Component-like module has no inbound references.)
-- <ROOT>/src/lib/broken.ts (Module has no inbound references and is not treated as an entrypoint.)
+- src/components/DeadWidget.tsx (Component-like module has no inbound references.)
+- src/lib/broken.ts (Module has no inbound references and is not treated as an entrypoint.)
 
 ## Dead exports
 
-- <ROOT>/src/components/DeadWidget.tsx -> `DeadWidget`
-- <ROOT>/src/lib/broken.ts -> `brokenFeature`
-- <ROOT>/src/lib/math.ts -> `multiply`
+- src/components/DeadWidget.tsx -> `DeadWidget`
+- src/lib/broken.ts -> `brokenFeature`
+- src/lib/math.ts -> `multiply`
 
 ## Unused imports
 
@@ -36,9 +45,9 @@
 
 ## Route entrypoints
 
-- <ROOT>/pages/home.tsx (next-pages-route)
+- pages/home.tsx (next-pages-route)
 
 ## Deletion candidates
 
-- <ROOT>/src/components/DeadWidget.tsx (Component-like module has no inbound references., confidence 0.92)
-- <ROOT>/src/lib/broken.ts (Module has no inbound references and is not treated as an entrypoint., confidence 0.88)
+- src/components/DeadWidget.tsx (Component-like module has no inbound references., confidence 0.92)
+- src/lib/broken.ts (Module has no inbound references and is not treated as an entrypoint., confidence 0.88)

--- a/fixtures/parity/demo-app/report-summary.txt
+++ b/fixtures/parity/demo-app/report-summary.txt
@@ -1,5 +1,8 @@
 Kratos report.
 
+Impact: 6 actionable findings: 1 broken import, 2 cleanup candidates, 3 dead exports.
+Best next move: Fix broken imports before deleting files.
+
 Root: <ROOT>
 Files scanned: 5
 Entrypoints: 1
@@ -12,17 +15,25 @@ Deletion candidates: 2
 
 Saved report: <REPORT>
 
+Next steps:
+- Preview cleanup: kratos clean <REPORT>
+- Shareable markdown: kratos report <REPORT> --format md
+
 Broken imports:
-- <ROOT>/src/lib/broken.ts -> ./missing-helper
+- src/lib/broken.ts -> ./missing-helper
+
+Top cleanup candidates:
+- src/components/DeadWidget.tsx (confidence 0.92, Component-like module has no inbound references.)
+- src/lib/broken.ts (confidence 0.88, Module has no inbound references and is not treated as an entrypoint.)
 
 Orphan files:
-- <ROOT>/src/components/DeadWidget.tsx
-- <ROOT>/src/lib/broken.ts
+- src/components/DeadWidget.tsx
+- src/lib/broken.ts
 
 Dead exports:
-- <ROOT>/src/components/DeadWidget.tsx#DeadWidget
-- <ROOT>/src/lib/broken.ts#brokenFeature
-- <ROOT>/src/lib/math.ts#multiply
+- src/components/DeadWidget.tsx#DeadWidget
+- src/lib/broken.ts#brokenFeature
+- src/lib/math.ts#multiply
 
 Route entrypoints:
-- <ROOT>/pages/home.tsx (next-pages-route)
+- pages/home.tsx (next-pages-route)


### PR DESCRIPTION
## 배경

`kratos scan`과 `kratos report`의 기본 human 출력이 수치와 목록 위주라, 실행 직후 사용자가 바로 다음 행동을 파악하기 어려웠습니다.

## 변경 사항

- summary/markdown report 출력에 `Impact`, `Best next move`, `Next steps`를 추가했습니다.
- finding preview 경로를 프로젝트 상대 경로 중심으로 줄여 읽기 쉽게 했습니다.
- 삭제 후보 상위 목록을 summary 출력에 바로 노출했습니다.
- parity fixture, CLI smoke 테스트, README 다국어 예시를 새 출력 계약에 맞췄습니다.

## 검증

- `cargo run -p kratos-cli -- scan fixtures/demo-app`
- `cargo run -p kratos-cli -- report fixtures/demo-app/.kratos/latest-report.json --format md`
- `cargo test --workspace`
- `npm run verify`
- `git diff --check`

## 브랜치 / 워크트리

- base: `master`
- head: `codex/scan-report-wow-output`
- worktree: `/Users/pjw/workspace/kratos`

## 참고

- 별도 독립 Devil's Advocate review gate는 실행하지 않았고, 요청된 `$ship` 흐름으로 현재 검증 결과를 기준으로 draft PR을 열었습니다.