### PR TITLE
fix(core): Next route export 오탐 축소

### DIFF
--- a/crates/kratos-core/src/analyze.rs
+++ b/crates/kratos-core/src/analyze.rs
@@ -18,6 +18,46 @@ use crate::resolve::{resolve_import_target, unresolved_import};
 use crate::suppressions::{apply_suppressions, load_project_suppressions};
 
 const DEFAULT_CONFIG_FILENAME: &str = "kratos.config.json";
+const NEXT_APP_COMPONENT_DEFAULT_STEMS: &[&str] = &[
+    "page",
+    "layout",
+    "loading",
+    "error",
+    "not-found",
+    "global-not-found",
+    "forbidden",
+    "unauthorized",
+    "default",
+    "template",
+    "global-error",
+];
+const NEXT_APP_METADATA_DEFAULT_STEMS: &[&str] = &[
+    "robots",
+    "sitemap",
+    "icon",
+    "apple-icon",
+    "opengraph-image",
+    "twitter-image",
+    "manifest",
+];
+const NEXT_APP_METADATA_STEMS: &[&str] = &["page", "layout", "global-not-found"];
+const NEXT_APP_IMAGE_METADATA_STEMS: &[&str] =
+    &["icon", "apple-icon", "opengraph-image", "twitter-image"];
+const NEXT_APP_OPEN_GRAPH_IMAGE_STEMS: &[&str] = &["opengraph-image", "twitter-image"];
+const NEXT_APP_ICON_IMAGE_STEMS: &[&str] = &["icon", "apple-icon"];
+const NEXT_APP_STATIC_PARAMS_STEMS: &[&str] = &["page", "layout", "route"];
+const NEXT_APP_SEGMENT_CONFIG_STEMS: &[&str] = &[
+    "page",
+    "layout",
+    "route",
+    "robots",
+    "sitemap",
+    "icon",
+    "apple-icon",
+    "opengraph-image",
+    "twitter-image",
+    "manifest",
+];
 
 pub fn analyze_project(root: &Path) -> KratosResult<ReportV2> {
     let config = load_project_config(root)?;
@@ -177,6 +217,7 @@ pub fn analyze_with_config(config: &ProjectConfig) -> KratosResult<ReportV2> {
                     || export_usage.used_names.contains(&exported.name)
                     || is_framework_consumed_export(
                         module.entrypoint_kind.as_ref(),
+                        module.relative_path.as_str(),
                         exported.name.as_str(),
                     )
                 {
@@ -317,34 +358,13 @@ fn should_skip_dead_exports(entrypoint_kind: Option<&EntrypointKind>) -> bool {
 
 fn is_framework_consumed_export(
     entrypoint_kind: Option<&EntrypointKind>,
+    relative_path: &str,
     export_name: &str,
 ) -> bool {
     match entrypoint_kind {
-        Some(EntrypointKind::NextAppRoute) => matches!(
-            export_name,
-            "default"
-                | "metadata"
-                | "generateMetadata"
-                | "generateImageMetadata"
-                | "generateSitemaps"
-                | "viewport"
-                | "generateViewport"
-                | "generateStaticParams"
-                | "revalidate"
-                | "dynamic"
-                | "dynamicParams"
-                | "fetchCache"
-                | "runtime"
-                | "preferredRegion"
-                | "maxDuration"
-                | "GET"
-                | "POST"
-                | "PUT"
-                | "PATCH"
-                | "DELETE"
-                | "HEAD"
-                | "OPTIONS"
-        ),
+        Some(EntrypointKind::NextAppRoute) => {
+            is_next_app_framework_consumed_export(relative_path, export_name)
+        }
         Some(EntrypointKind::NextPagesRoute) => matches!(
             export_name,
             "default"
@@ -356,6 +376,49 @@ fn is_framework_consumed_export(
         ),
         _ => false,
     }
+}
+
+fn is_next_app_framework_consumed_export(relative_path: &str, export_name: &str) -> bool {
+    let Some(stem) = route_file_stem(relative_path) else {
+        return false;
+    };
+
+    match export_name {
+        "default" => {
+            matches_stem(stem, NEXT_APP_COMPONENT_DEFAULT_STEMS)
+                || matches_stem(stem, NEXT_APP_METADATA_DEFAULT_STEMS)
+        }
+        "metadata" | "generateMetadata" | "viewport" | "generateViewport" => {
+            matches_stem(stem, NEXT_APP_METADATA_STEMS)
+        }
+        "generateImageMetadata" => matches_stem(stem, NEXT_APP_IMAGE_METADATA_STEMS),
+        "generateSitemaps" => stem == "sitemap",
+        "alt" => matches_stem(stem, NEXT_APP_OPEN_GRAPH_IMAGE_STEMS),
+        "size" | "contentType" => {
+            matches_stem(stem, NEXT_APP_OPEN_GRAPH_IMAGE_STEMS)
+                || matches_stem(stem, NEXT_APP_ICON_IMAGE_STEMS)
+        }
+        "generateStaticParams" => matches_stem(stem, NEXT_APP_STATIC_PARAMS_STEMS),
+        "revalidate" | "dynamic" | "dynamicParams" | "fetchCache" | "runtime"
+        | "preferredRegion" | "maxDuration" => matches_stem(stem, NEXT_APP_SEGMENT_CONFIG_STEMS),
+        "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "HEAD" | "OPTIONS" => stem == "route",
+        _ => false,
+    }
+}
+
+fn route_file_stem(relative_path: &str) -> Option<&str> {
+    let file_name = relative_path.rsplit('/').next().unwrap_or(relative_path);
+    let (stem, extension) = file_name.rsplit_once('.')?;
+
+    if stem.is_empty() || extension.is_empty() || stem.contains('.') || extension.contains('.') {
+        return None;
+    }
+
+    Some(stem)
+}
+
+fn matches_stem(stem: &str, candidates: &[&str]) -> bool {
+    candidates.iter().any(|candidate| *candidate == stem)
 }
 
 fn is_route_like_file_name(file_name: &str) -> bool {
@@ -461,26 +524,92 @@ mod tests {
     fn next_route_entrypoints_only_skip_framework_consumed_exports() {
         assert!(is_framework_consumed_export(
             Some(&EntrypointKind::NextAppRoute),
+            "app/page.tsx",
+            "default"
+        ));
+        assert!(is_framework_consumed_export(
+            Some(&EntrypointKind::NextAppRoute),
+            "app/page.tsx",
             "generateMetadata"
         ));
         assert!(is_framework_consumed_export(
             Some(&EntrypointKind::NextAppRoute),
+            "app/opengraph-image.tsx",
             "generateImageMetadata"
         ));
         assert!(is_framework_consumed_export(
             Some(&EntrypointKind::NextAppRoute),
+            "app/opengraph-image.tsx",
+            "alt"
+        ));
+        assert!(is_framework_consumed_export(
+            Some(&EntrypointKind::NextAppRoute),
+            "app/opengraph-image.tsx",
+            "contentType"
+        ));
+        assert!(is_framework_consumed_export(
+            Some(&EntrypointKind::NextAppRoute),
+            "app/icon.tsx",
+            "size"
+        ));
+        assert!(is_framework_consumed_export(
+            Some(&EntrypointKind::NextAppRoute),
+            "app/icon.tsx",
+            "runtime"
+        ));
+        assert!(is_framework_consumed_export(
+            Some(&EntrypointKind::NextAppRoute),
+            "app/sitemap.ts",
             "generateSitemaps"
         ));
         assert!(is_framework_consumed_export(
+            Some(&EntrypointKind::NextAppRoute),
+            "app/global-not-found.tsx",
+            "metadata"
+        ));
+        assert!(is_framework_consumed_export(
+            Some(&EntrypointKind::NextAppRoute),
+            "app/forbidden.tsx",
+            "default"
+        ));
+        assert!(is_framework_consumed_export(
+            Some(&EntrypointKind::NextAppRoute),
+            "app/api/route.ts",
+            "GET"
+        ));
+        assert!(is_framework_consumed_export(
+            Some(&EntrypointKind::NextAppRoute),
+            "app/api/route.ts",
+            "dynamic"
+        ));
+        assert!(is_framework_consumed_export(
             Some(&EntrypointKind::NextPagesRoute),
+            "pages/index.tsx",
             "getStaticProps"
         ));
         assert!(is_framework_consumed_export(
             Some(&EntrypointKind::NextPagesRoute),
+            "pages/index.tsx",
             "getInitialProps"
         ));
         assert!(!is_framework_consumed_export(
             Some(&EntrypointKind::NextAppRoute),
+            "app/page.tsx",
+            "GET"
+        ));
+        assert!(!is_framework_consumed_export(
+            Some(&EntrypointKind::NextAppRoute),
+            "app/loading.tsx",
+            "dynamic"
+        ));
+        assert!(!is_framework_consumed_export(
+            Some(&EntrypointKind::NextAppRoute),
+            "app/page.tsx",
+            "alt"
+        ));
+        assert!(!is_framework_consumed_export(
+            Some(&EntrypointKind::NextAppRoute),
+            "app/page.tsx",
             "helper"
         ));
         assert!(!should_skip_dead_exports(Some(

--- a/crates/kratos-core/src/entrypoints.rs
+++ b/crates/kratos-core/src/entrypoints.rs
@@ -3,6 +3,28 @@ use std::path::Path;
 use crate::error::KratosResult;
 use crate::model::{EntrypointKind, ProjectConfig};
 
+const NEXT_APP_ROUTE_STEMS: &[&str] = &[
+    "page",
+    "route",
+    "layout",
+    "loading",
+    "error",
+    "not-found",
+    "global-not-found",
+    "forbidden",
+    "unauthorized",
+    "default",
+    "template",
+    "global-error",
+    "robots",
+    "sitemap",
+    "icon",
+    "apple-icon",
+    "opengraph-image",
+    "twitter-image",
+    "manifest",
+];
+
 pub fn detect_entrypoint_kind(
     file_path: &Path,
     config: &ProjectConfig,
@@ -63,24 +85,7 @@ fn is_next_app_route(relative_path: &str) -> bool {
         && segments.len() >= 2
         && matches_file_stem(
             segments.last().copied().unwrap_or_default(),
-            &[
-                "page",
-                "route",
-                "layout",
-                "loading",
-                "error",
-                "not-found",
-                "default",
-                "template",
-                "global-error",
-                "robots",
-                "sitemap",
-                "icon",
-                "apple-icon",
-                "opengraph-image",
-                "twitter-image",
-                "manifest",
-            ],
+            NEXT_APP_ROUTE_STEMS,
         )
 }
 
@@ -104,6 +109,13 @@ mod tests {
         let template = detect_entrypoint_kind(&root.join("app/template.tsx"), &config)
             .expect("entrypoint detection should succeed");
         let global_error = detect_entrypoint_kind(&root.join("src/app/global-error.tsx"), &config)
+            .expect("entrypoint detection should succeed");
+        let global_not_found =
+            detect_entrypoint_kind(&root.join("src/app/global-not-found.tsx"), &config)
+                .expect("entrypoint detection should succeed");
+        let forbidden = detect_entrypoint_kind(&root.join("src/app/forbidden.tsx"), &config)
+            .expect("entrypoint detection should succeed");
+        let unauthorized = detect_entrypoint_kind(&root.join("src/app/unauthorized.tsx"), &config)
             .expect("entrypoint detection should succeed");
         let parallel_default =
             detect_entrypoint_kind(&root.join("app/@modal/default.tsx"), &config)
@@ -130,6 +142,9 @@ mod tests {
         assert_eq!(nested, Some(EntrypointKind::NextAppRoute));
         assert_eq!(template, Some(EntrypointKind::NextAppRoute));
         assert_eq!(global_error, Some(EntrypointKind::NextAppRoute));
+        assert_eq!(global_not_found, Some(EntrypointKind::NextAppRoute));
+        assert_eq!(forbidden, Some(EntrypointKind::NextAppRoute));
+        assert_eq!(unauthorized, Some(EntrypointKind::NextAppRoute));
         assert_eq!(parallel_default, Some(EntrypointKind::NextAppRoute));
         assert_eq!(robots, Some(EntrypointKind::NextAppRoute));
         assert_eq!(opengraph, Some(EntrypointKind::NextAppRoute));

--- a/crates/kratos-core/tests/analyze_demo_app.rs
+++ b/crates/kratos-core/tests/analyze_demo_app.rs
@@ -242,6 +242,136 @@ export const helper = 1;
 }
 
 #[test]
+fn analyze_project_skips_next_app_framework_exports_for_route_conventions() {
+    let project = TestProject::new("next-app-framework-exports");
+    project.write(
+        "src/app/page.tsx",
+        r#"export const metadata = { title: "Home" };
+export const viewport = { themeColor: "black" };
+export const dynamic = "force-static";
+export async function generateStaticParams() { return []; }
+export default function Page() { return null; }
+export const helperPage = 1;
+"#,
+    );
+    project.write(
+        "src/app/layout.tsx",
+        r#"export function generateMetadata() { return { title: "Layout" }; }
+export function generateViewport() { return { themeColor: "white" }; }
+export const revalidate = 60;
+export default function Layout({ children }: { children: unknown }) { return children; }
+export const helperLayout = 1;
+"#,
+    );
+    project.write(
+        "src/app/error.tsx",
+        r#"export default function ErrorPage() { return null; }
+export const helperError = 1;
+"#,
+    );
+    project.write(
+        "src/app/global-not-found.tsx",
+        r#"export const metadata = { title: "Not found" };
+export default function GlobalNotFound() { return <html><body>Not found</body></html>; }
+export const helperGlobalNotFound = 1;
+"#,
+    );
+    project.write(
+        "src/app/forbidden.tsx",
+        r#"export default function Forbidden() { return null; }
+export const helperForbidden = 1;
+"#,
+    );
+    project.write(
+        "src/app/unauthorized.tsx",
+        r#"export default function Unauthorized() { return null; }
+export const helperUnauthorized = 1;
+"#,
+    );
+    project.write(
+        "src/app/loading.tsx",
+        r#"export default function Loading() { return null; }
+export const helperLoading = 1;
+"#,
+    );
+    project.write(
+        "src/app/@modal/default.tsx",
+        r#"export default function ModalDefault() { return null; }
+export const helperDefault = 1;
+"#,
+    );
+    project.write(
+        "src/app/api/route.ts",
+        r#"export const runtime = "nodejs";
+export const maxDuration = 5;
+export async function generateStaticParams() { return []; }
+export async function GET() { return Response.json({ ok: true }); }
+export async function POST() { return Response.json({ ok: true }); }
+export const helperRoute = 1;
+"#,
+    );
+
+    let report = analyze_project(project.root()).expect("project should analyze");
+    let mut dead_exports = report
+        .findings
+        .dead_exports
+        .iter()
+        .map(|item| {
+            (
+                item.file
+                    .strip_prefix(project.root())
+                    .unwrap_or(&item.file)
+                    .to_path_buf(),
+                item.export_name.clone(),
+            )
+        })
+        .collect::<Vec<_>>();
+    dead_exports.sort();
+
+    assert_eq!(report.summary.entrypoints, 9);
+    assert_eq!(report.summary.route_entrypoints, 9);
+    assert_eq!(report.summary.dead_exports, 9);
+    assert_eq!(
+        dead_exports,
+        vec![
+            (
+                PathBuf::from("src/app/@modal/default.tsx"),
+                "helperDefault".to_string(),
+            ),
+            (
+                PathBuf::from("src/app/api/route.ts"),
+                "helperRoute".to_string(),
+            ),
+            (
+                PathBuf::from("src/app/error.tsx"),
+                "helperError".to_string(),
+            ),
+            (
+                PathBuf::from("src/app/forbidden.tsx"),
+                "helperForbidden".to_string(),
+            ),
+            (
+                PathBuf::from("src/app/global-not-found.tsx"),
+                "helperGlobalNotFound".to_string(),
+            ),
+            (
+                PathBuf::from("src/app/layout.tsx"),
+                "helperLayout".to_string(),
+            ),
+            (
+                PathBuf::from("src/app/loading.tsx"),
+                "helperLoading".to_string(),
+            ),
+            (PathBuf::from("src/app/page.tsx"), "helperPage".to_string(),),
+            (
+                PathBuf::from("src/app/unauthorized.tsx"),
+                "helperUnauthorized".to_string(),
+            ),
+        ]
+    );
+}
+
+#[test]
 fn analyze_project_skips_next_metadata_helpers_for_metadata_files() {
     let project = TestProject::new("metadata-helpers");
     project.write(
@@ -249,22 +379,55 @@ fn analyze_project_skips_next_metadata_helpers_for_metadata_files() {
         r#"export function generateImageMetadata() {
   return [{ id: "1", contentType: "image/png", size: { width: 1200, height: 630 } }];
 }
+export const alt = "About Acme";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+export const runtime = "edge";
 export default function Image() { return null; }
-export const helper = 1;
+export const helperImage = 1;
+"#,
+    );
+    project.write(
+        "app/icon.tsx",
+        r#"export const size = { width: 32, height: 32 };
+export const contentType = "image/png";
+export const preferredRegion = "global";
+export default function Icon() { return null; }
+export const helperIcon = 1;
 "#,
     );
 
     let report = analyze_project(project.root()).expect("project should analyze");
 
-    assert_eq!(report.summary.entrypoints, 1);
-    assert_eq!(report.summary.route_entrypoints, 1);
-    assert_eq!(report.summary.dead_exports, 1);
-    assert_eq!(report.findings.dead_exports.len(), 1);
+    let mut dead_exports = report
+        .findings
+        .dead_exports
+        .iter()
+        .map(|item| {
+            (
+                item.file
+                    .strip_prefix(project.root())
+                    .unwrap_or(&item.file)
+                    .to_path_buf(),
+                item.export_name.clone(),
+            )
+        })
+        .collect::<Vec<_>>();
+    dead_exports.sort();
+
+    assert_eq!(report.summary.entrypoints, 2);
+    assert_eq!(report.summary.route_entrypoints, 2);
+    assert_eq!(report.summary.dead_exports, 2);
     assert_eq!(
-        report.findings.dead_exports[0].file,
-        project.root().join("app/opengraph-image.tsx")
+        dead_exports,
+        vec![
+            (PathBuf::from("app/icon.tsx"), "helperIcon".to_string()),
+            (
+                PathBuf::from("app/opengraph-image.tsx"),
+                "helperImage".to_string(),
+            ),
+        ]
     );
-    assert_eq!(report.findings.dead_exports[0].export_name, "helper");
 }
 
 #[test]


### PR DESCRIPTION
## 배경

Orbit Dashboard 기준 scan에서 Next.js app route/file convention으로 소비되는 export가 `deadExports`에 섞이는 오탐을 줄이기 위한 #56 Wave 1 작업입니다.

## 변경 사항

- Next app route 파일 stem 목록을 상수화하고 `global-not-found`, `forbidden`, `unauthorized` convention을 추가했습니다.
- Next app route의 framework-consumed export 판정을 파일 stem별로 정밀화했습니다.
  - page/layout metadata, viewport, segment config
  - route handler HTTP verb와 segment config
  - metadata/image/icon route의 `default`, `generateImageMetadata`, `alt`, `size`, `contentType`, segment config
- route entrypoint 내부의 일반 helper export는 계속 `deadExports`로 보고되는 회귀 테스트를 추가했습니다.

## 검증

- `rustfmt --check crates/kratos-core/src/analyze.rs crates/kratos-core/src/entrypoints.rs crates/kratos-core/tests/analyze_demo_app.rs`
- `cargo test -p kratos-core`
- `npm run verify`
- `cargo test --workspace`
- `$devils-advocate-review-loop`
  - Round 1: High 1건 수용 후 수정
  - Round 2: Critical 0 / High 0

## 브랜치 / 워크트리

- Base: `master`
- Branch: `codex/fix-56-next-route-exports`
- Worktree: `/tmp/kratos-issue-56`

## 이슈 연결

Closes #56
