### PR TITLE
fix(core): 스크립트 entrypoint 자동 인식

### DIFF
--- a/crates/kratos-core/src/config.rs
+++ b/crates/kratos-core/src/config.rs
@@ -65,6 +65,8 @@ pub fn load_project_config(root: impl Into<PathBuf>) -> KratosResult<ProjectConf
         .map(|value| resolve_path(&root, value));
     let config_path = resolve_config_path(&root, DEFAULT_CONFIG_FILENAME);
 
+    let package_entries = collect_project_entry_files(&root, &package_json)?;
+
     Ok(ProjectConfig {
         root: root.clone(),
         config_path: config_path.exists().then_some(config_path),
@@ -76,7 +78,7 @@ pub fn load_project_config(root: impl Into<PathBuf>) -> KratosResult<ProjectConf
             extract_required_string_array(user_config.get("ignorePatterns"), "ignorePatterns")?,
         )?,
         explicit_entries: normalize_entry_paths(&root, user_config.get("entry"))?,
-        package_entries: collect_package_entry_files(&root, &package_json),
+        package_entries,
         path_aliases: normalize_path_aliases(
             &root,
             compiler_options.and_then(|value| value.get("paths")),
@@ -122,10 +124,7 @@ fn read_loose_json_file(file_path: &Path) -> KratosResult<Option<JsonValue>> {
     Ok(Some(parse_loose_json(&content)?))
 }
 
-fn normalize_ignore_patterns(
-    root: &Path,
-    user_patterns: Vec<String>,
-) -> KratosResult<Vec<String>> {
+fn normalize_ignore_patterns(root: &Path, user_patterns: Vec<String>) -> KratosResult<Vec<String>> {
     let mut patterns = read_gitignore_patterns(&resolve_config_path(root, GITIGNORE_FILENAME))?;
     patterns.extend(user_patterns);
     Ok(patterns)
@@ -137,7 +136,10 @@ fn read_gitignore_patterns(file_path: &Path) -> KratosResult<Vec<String>> {
     }
 
     let content = std::fs::read_to_string(file_path)?;
-    Ok(content.lines().filter_map(normalize_gitignore_line).collect())
+    Ok(content
+        .lines()
+        .filter_map(normalize_gitignore_line)
+        .collect())
 }
 
 fn normalize_gitignore_line(line: &str) -> Option<String> {
@@ -252,7 +254,10 @@ fn normalize_path_aliases(
     Ok(aliases)
 }
 
-fn collect_package_entry_files(root: &Path, package_json: &JsonValue) -> Vec<PathBuf> {
+fn collect_project_entry_files(
+    root: &Path,
+    package_json: &JsonValue,
+) -> KratosResult<Vec<PathBuf>> {
     let mut entries = Vec::new();
 
     add_entry_value(&mut entries, root, package_json.get("main"), false);
@@ -273,7 +278,489 @@ fn collect_package_entry_files(root: &Path, package_json: &JsonValue) -> Vec<Pat
         collect_exports(&mut entries, root, exports, false);
     }
 
-    entries
+    collect_package_script_entry_files(&mut entries, root, package_json, 0);
+    collect_workflow_run_entry_files(&mut entries, root, package_json)?;
+
+    Ok(entries)
+}
+
+fn collect_package_script_entry_files(
+    entries: &mut Vec<PathBuf>,
+    root: &Path,
+    package_json: &JsonValue,
+    depth: usize,
+) {
+    let Some(scripts) = package_json.get("scripts").and_then(JsonValue::as_object) else {
+        return;
+    };
+
+    for script in scripts.values().filter_map(JsonValue::as_str) {
+        collect_command_entry_files(entries, root, root, package_json, script, depth);
+    }
+}
+
+fn collect_workflow_run_entry_files(
+    entries: &mut Vec<PathBuf>,
+    root: &Path,
+    package_json: &JsonValue,
+) -> KratosResult<()> {
+    collect_yamlish_run_entries(
+        entries,
+        root,
+        package_json,
+        &root.join(".github/workflows"),
+        is_workflow_file,
+    )?;
+    collect_yamlish_run_entries(
+        entries,
+        root,
+        package_json,
+        &root.join(".github/actions"),
+        is_action_file,
+    )
+}
+
+fn collect_yamlish_run_entries(
+    entries: &mut Vec<PathBuf>,
+    root: &Path,
+    package_json: &JsonValue,
+    directory: &Path,
+    include_file: fn(&Path) -> bool,
+) -> KratosResult<()> {
+    if !directory.is_dir() {
+        return Ok(());
+    }
+
+    for entry in std::fs::read_dir(directory)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let path = entry.path();
+
+        if file_type.is_dir() {
+            collect_yamlish_run_entries(entries, root, package_json, &path, include_file)?;
+            continue;
+        }
+
+        if file_type.is_file() && include_file(&path) {
+            let content = std::fs::read_to_string(&path)?;
+            for command in extract_yamlish_run_commands(&content) {
+                let command_root = command
+                    .working_directory
+                    .as_deref()
+                    .map(|directory| resolve_path(root, directory))
+                    .unwrap_or_else(|| root.to_path_buf());
+                collect_command_entry_files(
+                    entries,
+                    root,
+                    &command_root,
+                    package_json,
+                    &command.command,
+                    0,
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn is_workflow_file(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|value| value.to_str()),
+        Some("yml" | "yaml")
+    )
+}
+
+fn is_action_file(path: &Path) -> bool {
+    matches!(
+        path.file_name().and_then(|value| value.to_str()),
+        Some("action.yml" | "action.yaml")
+    )
+}
+
+struct YamlishRunCommand {
+    command: String,
+    working_directory: Option<String>,
+}
+
+fn extract_yamlish_run_commands(content: &str) -> Vec<YamlishRunCommand> {
+    let lines = content.lines().collect::<Vec<_>>();
+    let mut commands = Vec::new();
+    let mut index = 0;
+
+    while index < lines.len() {
+        let line = lines[index];
+        let trimmed = line.trim_start();
+        let indent = line.len() - trimmed.len();
+        let run_index = index;
+        let Some(raw) = trimmed
+            .strip_prefix("run:")
+            .or_else(|| trimmed.strip_prefix("- run:"))
+        else {
+            index += 1;
+            continue;
+        };
+
+        let raw = raw.trim_start();
+        if raw.starts_with('|') || raw.starts_with('>') {
+            let mut block = String::new();
+            index += 1;
+            while index < lines.len() {
+                let next = lines[index];
+                if !next.trim().is_empty() && leading_spaces(next) <= indent {
+                    break;
+                }
+                block.push_str(next.trim());
+                block.push('\n');
+                index += 1;
+            }
+            commands.push(YamlishRunCommand {
+                command: block,
+                working_directory: find_yamlish_working_directory(&lines, run_index, indent),
+            });
+            continue;
+        }
+
+        commands.push(YamlishRunCommand {
+            command: unquote_yaml_scalar(raw).to_string(),
+            working_directory: find_yamlish_working_directory(&lines, run_index, indent),
+        });
+        index += 1;
+    }
+
+    commands
+}
+
+fn find_yamlish_working_directory(
+    lines: &[&str],
+    run_index: usize,
+    run_indent: usize,
+) -> Option<String> {
+    let mut start = run_index;
+    while start > 0 {
+        let previous = lines[start - 1];
+        let previous_indent = leading_spaces(previous);
+        let previous_trimmed = previous.trim_start();
+        if previous_indent < run_indent || previous_trimmed.starts_with("- ") {
+            if previous_trimmed.starts_with("- ") {
+                start -= 1;
+            }
+            break;
+        }
+        start -= 1;
+    }
+
+    let mut end = run_index + 1;
+    while end < lines.len() {
+        let next = lines[end];
+        let next_indent = leading_spaces(next);
+        let next_trimmed = next.trim_start();
+        if next_indent < run_indent || (next_indent == run_indent && next_trimmed.starts_with("- "))
+        {
+            break;
+        }
+        end += 1;
+    }
+
+    lines[start..end]
+        .iter()
+        .filter_map(|line| {
+            let trimmed = line.trim_start();
+            trimmed
+                .strip_prefix("working-directory:")
+                .or_else(|| trimmed.strip_prefix("- working-directory:"))
+                .map(str::trim)
+        })
+        .next()
+        .map(unquote_yaml_scalar)
+        .map(str::to_string)
+}
+
+fn leading_spaces(value: &str) -> usize {
+    value.len() - value.trim_start().len()
+}
+
+fn unquote_yaml_scalar(value: &str) -> &str {
+    value
+        .strip_prefix('"')
+        .and_then(|inner| inner.strip_suffix('"'))
+        .or_else(|| {
+            value
+                .strip_prefix('\'')
+                .and_then(|inner| inner.strip_suffix('\''))
+        })
+        .unwrap_or(value)
+}
+
+fn collect_command_entry_files(
+    entries: &mut Vec<PathBuf>,
+    project_root: &Path,
+    command_root: &Path,
+    package_json: &JsonValue,
+    command: &str,
+    depth: usize,
+) {
+    if depth > 4 {
+        return;
+    }
+
+    let tokens = shellish_tokens(command);
+    for (index, token) in tokens.iter().enumerate() {
+        if is_script_runner(token) {
+            if let Some(script_name) = package_script_name_after_runner(&tokens, index) {
+                if let Some(script) = package_script(package_json, script_name) {
+                    collect_command_entry_files(
+                        entries,
+                        project_root,
+                        project_root,
+                        package_json,
+                        script,
+                        depth + 1,
+                    );
+                }
+            }
+            continue;
+        }
+
+        if is_script_interpreter(token) {
+            collect_interpreter_entry_paths(entries, command_root, &tokens, index);
+            continue;
+        }
+
+        if looks_like_local_script_path(token) {
+            add_script_entry_path(entries, command_root, token);
+        }
+    }
+}
+
+fn shellish_tokens(command: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut quote = None;
+    let mut escaped = false;
+
+    for character in command.chars() {
+        if escaped {
+            current.push(character);
+            escaped = false;
+            continue;
+        }
+
+        if character == '\\' {
+            escaped = true;
+            continue;
+        }
+
+        if let Some(active_quote) = quote {
+            if character == active_quote {
+                quote = None;
+            } else {
+                current.push(character);
+            }
+            continue;
+        }
+
+        match character {
+            '\'' | '"' => quote = Some(character),
+            '\n' | '\r' | '\t' | ' ' | '&' | '|' | ';' | '(' | ')' => {
+                push_token(&mut tokens, &mut current);
+            }
+            '#' if current.is_empty() => {
+                push_token(&mut tokens, &mut current);
+            }
+            _ => current.push(character),
+        }
+    }
+
+    push_token(&mut tokens, &mut current);
+    tokens
+}
+
+fn push_token(tokens: &mut Vec<String>, current: &mut String) {
+    if !current.is_empty() {
+        tokens.push(std::mem::take(current));
+    }
+}
+
+fn is_script_runner(token: &str) -> bool {
+    matches!(
+        command_name(token),
+        "npm" | "pnpm" | "yarn" | "bun" | "corepack"
+    )
+}
+
+fn package_script_name_after_runner<'a>(tokens: &'a [String], index: usize) -> Option<&'a str> {
+    let runner = command_name(tokens.get(index)?);
+    let mut cursor = index + 1;
+
+    if runner == "corepack" {
+        cursor += 1;
+    }
+
+    if matches!(runner, "npm" | "pnpm" | "bun" | "corepack") {
+        if matches!(
+            tokens.get(cursor).map(|value| value.as_str()),
+            Some("run" | "run-script")
+        ) {
+            cursor += 1;
+        } else {
+            return None;
+        }
+    } else if matches!(tokens.get(cursor).map(|value| value.as_str()), Some("run")) {
+        cursor += 1;
+    }
+
+    while tokens
+        .get(cursor)
+        .is_some_and(|token| token.starts_with('-'))
+    {
+        cursor += 1;
+    }
+
+    tokens.get(cursor).map(String::as_str)
+}
+
+fn package_script<'a>(package_json: &'a JsonValue, name: &str) -> Option<&'a str> {
+    package_json
+        .get("scripts")
+        .and_then(JsonValue::as_object)?
+        .get(name)?
+        .as_str()
+}
+
+fn is_script_interpreter(token: &str) -> bool {
+    matches!(
+        command_name(token),
+        "node" | "tsx" | "ts-node" | "ts-node-esm" | "bash" | "sh" | "zsh"
+    )
+}
+
+fn collect_interpreter_entry_paths(
+    entries: &mut Vec<PathBuf>,
+    command_root: &Path,
+    tokens: &[String],
+    index: usize,
+) {
+    let mut cursor = index + 1;
+
+    while let Some(token) = tokens.get(cursor) {
+        if is_eval_like_option(token) {
+            return;
+        }
+
+        if option_takes_value(token) {
+            if let Some(value) = inline_option_value(token) {
+                if looks_like_interpreter_script_path(value) {
+                    add_script_entry_path(entries, command_root, value);
+                }
+                cursor += 1;
+            } else {
+                if let Some(value) = tokens.get(cursor + 1) {
+                    if looks_like_interpreter_script_path(value) {
+                        add_script_entry_path(entries, command_root, value);
+                    }
+                }
+                cursor += 2;
+            }
+            continue;
+        }
+
+        if token.starts_with('-') || token.contains('=') && !looks_like_local_script_path(token) {
+            cursor += 1;
+            continue;
+        }
+
+        if looks_like_interpreter_script_path(token) {
+            add_script_entry_path(entries, command_root, token);
+        }
+        return;
+    }
+}
+
+fn is_eval_like_option(token: &str) -> bool {
+    matches!(
+        token,
+        "-e" | "--eval" | "-p" | "--print" | "-c" | "--command"
+    )
+}
+
+fn option_takes_value(token: &str) -> bool {
+    let name = token.split_once('=').map(|(name, _)| name).unwrap_or(token);
+    matches!(
+        name,
+        "-r" | "--require" | "--import" | "--loader" | "--env-file" | "--project" | "--tsconfig"
+    )
+}
+
+fn inline_option_value(token: &str) -> Option<&str> {
+    if let Some((_, value)) = token.split_once('=') {
+        return Some(value);
+    }
+
+    if token.starts_with("-r") && token.len() > 2 {
+        return Some(&token[2..]);
+    }
+
+    None
+}
+
+fn add_script_entry_path(entries: &mut Vec<PathBuf>, root: &Path, value: &str) {
+    let value = value.trim_matches(|character| matches!(character, '"' | '\'' | '`'));
+    let resolved =
+        resolve_package_entry_path(root, value, false).unwrap_or_else(|| resolve_path(root, value));
+    push_unique_path(entries, resolved);
+}
+
+fn looks_like_local_script_path(token: &str) -> bool {
+    if token.starts_with('-')
+        || token.starts_with('$')
+        || token.starts_with("http://")
+        || token.starts_with("https://")
+        || token.contains('=')
+    {
+        return false;
+    }
+
+    let path = Path::new(token);
+    let Some(extension) = path.extension().and_then(|value| value.to_str()) else {
+        return false;
+    };
+
+    let has_local_shape = token.starts_with('.')
+        || token.starts_with('/')
+        || token.contains('/')
+        || token.contains('\\');
+    has_local_shape
+        && matches!(
+            extension,
+            "js" | "jsx" | "ts" | "tsx" | "mjs" | "cjs" | "mts" | "cts" | "sh"
+        )
+}
+
+fn looks_like_interpreter_script_path(token: &str) -> bool {
+    if looks_like_local_script_path(token) {
+        return true;
+    }
+
+    if token.starts_with('-')
+        || token.starts_with('$')
+        || token.starts_with("http://")
+        || token.starts_with("https://")
+        || token.contains('=')
+    {
+        return false;
+    }
+
+    matches!(
+        Path::new(token)
+            .extension()
+            .and_then(|value| value.to_str()),
+        Some("js" | "jsx" | "ts" | "tsx" | "mjs" | "cjs" | "mts" | "cts" | "sh")
+    )
+}
+
+fn command_name(token: &str) -> &str {
+    token.rsplit(['/', '\\']).next().unwrap_or(token)
 }
 
 fn collect_external_packages(package_json: &JsonValue) -> BTreeSet<String> {

--- a/crates/kratos-core/src/entrypoints.rs
+++ b/crates/kratos-core/src/entrypoints.rs
@@ -206,12 +206,15 @@ mod tests {
 
         let real_config = detect_entrypoint_kind(&root.join("next.config.js"), &config)
             .expect("entrypoint detection should succeed");
+        let eslint_config = detect_entrypoint_kind(&root.join("eslint.config.mjs"), &config)
+            .expect("entrypoint detection should succeed");
         let test_config = detect_entrypoint_kind(&root.join("next.config.test.ts"), &config)
             .expect("entrypoint detection should succeed");
         let backup_config = detect_entrypoint_kind(&root.join("vite.config.backup.js"), &config)
             .expect("entrypoint detection should succeed");
 
         assert_eq!(real_config, Some(EntrypointKind::ToolingEntry));
+        assert_eq!(eslint_config, Some(EntrypointKind::ToolingEntry));
         assert_eq!(test_config, None);
         assert_eq!(backup_config, None);
     }
@@ -241,6 +244,7 @@ fn is_tooling_entry(relative_path: &str) -> bool {
     let file_name = relative_path.rsplit('/').next().unwrap_or(relative_path);
     [
         "next",
+        "eslint",
         "vite",
         "webpack",
         "rollup",

--- a/crates/kratos-core/tests/config_and_discovery.rs
+++ b/crates/kratos-core/tests/config_and_discovery.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 
+use kratos_core::analyze::analyze_project;
 use kratos_core::config::load_clean_min_confidence;
 use kratos_core::config::load_project_config;
 use kratos_core::discover::collect_source_files;
@@ -198,7 +199,8 @@ fn load_clean_min_confidence_rejects_non_object_thresholds() {
 "#,
     );
 
-    let error = load_clean_min_confidence(project.root()).expect_err("thresholds shape should fail");
+    let error =
+        load_clean_min_confidence(project.root()).expect_err("thresholds shape should fail");
     assert!(
         error
             .to_string()
@@ -218,7 +220,8 @@ fn load_clean_min_confidence_rejects_missing_key_when_thresholds_is_present() {
 "#,
     );
 
-    let error = load_clean_min_confidence(project.root()).expect_err("missing threshold key should fail");
+    let error =
+        load_clean_min_confidence(project.root()).expect_err("missing threshold key should fail");
     assert!(
         error
             .to_string()
@@ -457,7 +460,10 @@ fn collect_source_files_honors_explicit_roots_even_when_root_name_is_ignored_by_
     let config = load_project_config(project.root()).expect("config should load");
     let discovered = collect_source_files(&config).expect("source discovery should succeed");
 
-    assert_eq!(discovered, vec![project.root().join("tests/unit/sample.ts")]);
+    assert_eq!(
+        discovered,
+        vec![project.root().join("tests/unit/sample.ts")]
+    );
 }
 
 #[test]
@@ -517,12 +523,18 @@ fn collect_source_files_does_not_reopen_unrelated_ignored_trees_for_negations() 
 "#,
     );
     project.write("src/generated/keep.ts", "export const keep = true;\n");
-    project.write("node_modules/pkg/src/generated/keep.ts", "export const nested = true;\n");
+    project.write(
+        "node_modules/pkg/src/generated/keep.ts",
+        "export const nested = true;\n",
+    );
 
     let config = load_project_config(project.root()).expect("config should load");
     let discovered = collect_source_files(&config).expect("source discovery should succeed");
 
-    assert_eq!(discovered, vec![project.root().join("src/generated/keep.ts")]);
+    assert_eq!(
+        discovered,
+        vec![project.root().join("src/generated/keep.ts")]
+    );
 }
 
 #[test]
@@ -536,7 +548,10 @@ fn collect_source_files_does_not_reopen_node_modules_for_broad_negations() {
 "#,
     );
     project.write("src/main.ts", "export const main = true;\n");
-    project.write("node_modules/@demo/index.ts", "export const dependency = true;\n");
+    project.write(
+        "node_modules/@demo/index.ts",
+        "export const dependency = true;\n",
+    );
 
     let config = load_project_config(project.root()).expect("config should load");
     let discovered = collect_source_files(&config).expect("source discovery should succeed");
@@ -915,6 +930,141 @@ fn load_project_config_resolves_extensionless_and_directory_package_entries() {
     assert!(config
         .package_entries
         .contains(&project.root().join("src/routes/index.ts")));
+}
+
+#[test]
+fn load_project_config_collects_script_and_workflow_entries() {
+    let project = TestProject::new("script-workflow-entries");
+    project.write(
+        "package.json",
+        r#"{
+  "scripts": {
+    "generate": "node scripts/generate-roster-json.mjs",
+    "build:report": "tsx scripts/build-report.ts",
+    "node:loader": "node --loader ts-node/esm scripts/loader-entry.ts",
+    "node:require": "node -r dotenv/config scripts/required-entry.mjs",
+    "node:import": "node --import ./scripts/register.mjs scripts/imported-entry.mjs",
+    "validate:setup": "bash scripts/cleanup-tokens.sh",
+    "nested": "npm run generate"
+  }
+}
+"#,
+    );
+    project.write(
+        ".github/workflows/pr-daily.yml",
+        r#"
+name: PR Daily
+jobs:
+  sync:
+    steps:
+      - run: node scripts/github-pr-daily-insert.mjs
+      - run: |
+          npm run build:report
+          sh scripts/workflow-cleanup.sh
+      - working-directory: scripts
+        run: node local-workflow.mjs
+"#,
+    );
+    project.write(
+        ".github/actions/sync/action.yml",
+        r#"
+runs:
+  using: composite
+  steps:
+    - run: node scripts/action-entry.mjs
+"#,
+    );
+    project.write(
+        "scripts/generate-roster-json.mjs",
+        "export const generate = true;\n",
+    );
+    project.write(
+        "scripts/build-report.ts",
+        "export const buildReport = true;\n",
+    );
+    project.write("scripts/loader-entry.ts", "export const loader = true;\n");
+    project.write(
+        "scripts/required-entry.mjs",
+        "export const required = true;\n",
+    );
+    project.write("scripts/register.mjs", "export const register = true;\n");
+    project.write(
+        "scripts/imported-entry.mjs",
+        "export const imported = true;\n",
+    );
+    project.write("scripts/cleanup-tokens.sh", "echo cleanup\n");
+    project.write(
+        "scripts/github-pr-daily-insert.mjs",
+        "export const sync = true;\n",
+    );
+    project.write("scripts/workflow-cleanup.sh", "echo workflow cleanup\n");
+    project.write("scripts/local-workflow.mjs", "export const local = true;\n");
+    project.write("scripts/action-entry.mjs", "export const action = true;\n");
+
+    let config = load_project_config(project.root()).expect("config should load");
+
+    for entry in [
+        "scripts/generate-roster-json.mjs",
+        "scripts/build-report.ts",
+        "scripts/loader-entry.ts",
+        "scripts/required-entry.mjs",
+        "scripts/register.mjs",
+        "scripts/imported-entry.mjs",
+        "scripts/cleanup-tokens.sh",
+        "scripts/github-pr-daily-insert.mjs",
+        "scripts/workflow-cleanup.sh",
+        "scripts/local-workflow.mjs",
+        "scripts/action-entry.mjs",
+    ] {
+        assert!(
+            config.package_entries.contains(&project.root().join(entry)),
+            "{entry} should be collected as an entrypoint"
+        );
+    }
+}
+
+#[test]
+fn analyze_project_excludes_script_workflow_and_tooling_entries_from_deletion_candidates() {
+    let project = TestProject::new("script-workflow-analysis");
+    project.write(
+        "package.json",
+        r#"{
+  "scripts": {
+    "generate": "node scripts/generate.mjs"
+  }
+}
+"#,
+    );
+    project.write(
+        ".github/workflows/sync.yml",
+        r#"
+name: Sync
+jobs:
+  run:
+    steps:
+      - run: node scripts/from-workflow.mjs
+"#,
+    );
+    project.write("scripts/generate.mjs", "export const generate = true;\n");
+    project.write(
+        "scripts/from-workflow.mjs",
+        "export const fromWorkflow = true;\n",
+    );
+    project.write("eslint.config.mjs", "export default [];\n");
+    project.write("src/unused.ts", "export const unused = true;\n");
+
+    let report = analyze_project(project.root()).expect("project should analyze");
+    let deletion_candidates = report
+        .findings
+        .deletion_candidates
+        .iter()
+        .map(|finding| finding.file.clone())
+        .collect::<Vec<_>>();
+
+    assert!(!deletion_candidates.contains(&project.root().join("scripts/generate.mjs")));
+    assert!(!deletion_candidates.contains(&project.root().join("scripts/from-workflow.mjs")));
+    assert!(!deletion_candidates.contains(&project.root().join("eslint.config.mjs")));
+    assert!(deletion_candidates.contains(&project.root().join("src/unused.ts")));
 }
 
 #[test]


### PR DESCRIPTION
## 배경

package.json scripts와 GitHub Actions run command에서만 참조되는 스크립트가 entrypoint로 잡히지 않아 삭제 후보로 남는 문제를 줄입니다.

## 변경 사항

- package.json scripts에서 node/tsx/ts-node/bash 계열 실행 파일을 entrypoint로 수집합니다.
- npm/pnpm/yarn/bun/corepack script runner를 따라가며 중첩 script 명령도 수집합니다.
- GitHub workflow와 composite action의 `run` command를 스캔하고 step-local `working-directory`를 반영합니다.
- `eslint.config.*` 계열 tooling entrypoint 감지를 추가했습니다.

## 검증

- `cargo test -p kratos-core --test config_and_discovery`
- `cargo test -p kratos-core entrypoints::tests::tooling_entry_requires_single_extension_suffix`
- `cargo test -p kratos-core --test report_v2`
- `cargo test -p kratos-core`
- `npm run verify`
- `cargo test --workspace`
- `git diff --check`
- `$devils-advocate-review-loop`: Round 2 기준 Critical 0 / High 0 / Medium 1 / Low 0

## 리뷰 메모

- Medium 후속 후보: workflow/job-level `defaults.run.working-directory` 상속까지는 이번 PR에 포함하지 않았습니다. 현재 PR은 step-local `working-directory`와 package/workflow script entrypoint 자동 인식 범위를 닫습니다.

## 브랜치 / 워크트리

- branch: `codex/fix-53-script-entrypoints`
- worktree: `/tmp/kratos-issue-53`
- base: `master`

## 이슈 연결

Closes #53
