### PR TITLE
fix(core): 동적 import와 barrel 오탐 축소

### DIFF
--- a/crates/kratos-core/src/analyze.rs
+++ b/crates/kratos-core/src/analyze.rs
@@ -9,9 +9,9 @@ use crate::entrypoints::detect_entrypoint_kind;
 use crate::error::KratosResult;
 use crate::model::{
     BrokenImportFinding, DeadExportFinding, DeletionCandidateFinding, EntrypointKind, ExportRecord,
-    FindingSet, ImportSpecifierKind, ImportUsageRecord, ModuleRecord, OrphanFileFinding,
-    OrphanKind, ProjectConfig, ReportV2, ResolvedImportRecord, RouteEntrypointFinding,
-    SummaryCounts, UnusedImportFinding,
+    FindingSet, ImportKind, ImportSpecifierKind, ImportUsageRecord, ModuleRecord,
+    OrphanFileFinding, OrphanKind, ProjectConfig, ReportV2, ResolvedImportRecord,
+    RouteEntrypointFinding, SummaryCounts, UnusedImportFinding,
 };
 use crate::parser::parse_module_source;
 use crate::resolve::{resolve_import_target, unresolved_import};
@@ -67,11 +67,13 @@ pub fn analyze_project(root: &Path) -> KratosResult<ReportV2> {
 pub fn analyze_with_config(config: &ProjectConfig) -> KratosResult<ReportV2> {
     let files = collect_source_files(config)?;
     let mut modules = BTreeMap::new();
+    let mut pure_barrel_files = BTreeSet::new();
 
     for file_path in files {
         let source = std::fs::read_to_string(&file_path)?;
         let parsed = parse_module_source(&file_path, &source)?;
         let entrypoint_kind = detect_entrypoint_kind(&file_path, config)?;
+        let is_pure_barrel = parsed.is_pure_reexport_barrel;
 
         modules.insert(
             file_path.clone(),
@@ -90,6 +92,10 @@ pub fn analyze_with_config(config: &ProjectConfig) -> KratosResult<ReportV2> {
                 export_count: 0,
             },
         );
+
+        if is_pure_barrel {
+            pure_barrel_files.insert(file_path);
+        }
     }
 
     let mut broken_imports = Vec::new();
@@ -189,7 +195,9 @@ pub fn analyze_with_config(config: &ProjectConfig) -> KratosResult<ReportV2> {
             });
         }
 
-        if module.imported_by.is_empty() && module.entrypoint_kind.is_none() {
+        let is_pure_barrel = pure_barrel_files.contains(&module.file_path);
+
+        if module.imported_by.is_empty() && module.entrypoint_kind.is_none() && !is_pure_barrel {
             let classification = classify_orphan(&module.relative_path);
 
             orphan_files.push(OrphanFileFinding {
@@ -209,7 +217,8 @@ pub fn analyze_with_config(config: &ProjectConfig) -> KratosResult<ReportV2> {
         let export_usage = summarize_export_usage(module);
         let should_skip_dead_exports = should_skip_dead_exports(module.entrypoint_kind.as_ref())
             || export_usage.uses_namespace
-            || export_usage.uses_unknown;
+            || export_usage.uses_unknown
+            || is_pure_barrel;
 
         if !should_skip_dead_exports {
             for exported in &module.exports {
@@ -296,6 +305,11 @@ fn summarize_export_usage(module: &ModuleRecord) -> ExportUsage {
     let mut uses_unknown = false;
 
     for importer in &module.importers {
+        if importer.kind == ImportKind::Dynamic && importer.specifiers.is_empty() {
+            uses_unknown = true;
+            continue;
+        }
+
         for specifier in &importer.specifiers {
             match specifier.kind {
                 ImportSpecifierKind::Namespace => uses_namespace = true,

--- a/crates/kratos-core/src/parser/adapter.rs
+++ b/crates/kratos-core/src/parser/adapter.rs
@@ -28,10 +28,12 @@ pub fn parse_module_source(path: &Path, source: &str) -> KratosResult<ParsedModu
     let imports = imports::collect_imports(&parsed.program)?;
     let exports = exports::collect_exports(&parsed.program)?;
     let unused_imports = unused_imports::detect_unused_imports(&parsed.program, &imports)?;
+    let is_pure_reexport_barrel = exports::is_pure_reexport_barrel(&parsed.program);
 
     Ok(ParsedModule {
         imports,
         exports,
         unused_imports,
+        is_pure_reexport_barrel,
     })
 }

--- a/crates/kratos-core/src/parser/exports.rs
+++ b/crates/kratos-core/src/parser/exports.rs
@@ -1,7 +1,7 @@
 use oxc_ast::ast::{
     AssignmentExpression, AssignmentTarget, ComputedMemberExpression, Declaration,
     ExportAllDeclaration, ExportDefaultDeclaration, ExportNamedDeclaration, Expression,
-    ModuleExportName, Program, PropertyKey, PropertyKind, StaticMemberExpression,
+    ModuleExportName, Program, PropertyKey, PropertyKind, Statement, StaticMemberExpression,
     TSExportAssignment, TSNamespaceExportDeclaration,
 };
 use oxc_ast_visit::{walk, Visit};
@@ -14,6 +14,26 @@ pub fn collect_exports(program: &Program<'_>) -> KratosResult<Vec<ExportRecord>>
     let mut collector = ExportCollector::default();
     collector.visit_program(program);
     Ok(collector.exports)
+}
+
+pub fn is_pure_reexport_barrel(program: &Program<'_>) -> bool {
+    let mut has_reexport = false;
+
+    for statement in &program.body {
+        match statement {
+            Statement::ExportNamedDeclaration(declaration)
+                if declaration.source.is_some() && declaration.declaration.is_none() =>
+            {
+                has_reexport = true;
+            }
+            Statement::ExportAllDeclaration(_) => {
+                has_reexport = true;
+            }
+            _ => return false,
+        }
+    }
+
+    has_reexport
 }
 
 pub fn make_default_export() -> ExportRecord {

--- a/crates/kratos-core/src/parser/imports.rs
+++ b/crates/kratos-core/src/parser/imports.rs
@@ -3,11 +3,11 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use oxc_ast::ast::{
     AssignmentExpression, BindingIdentifier, BindingPattern, BlockStatement, CallExpression,
-    ExportAllDeclaration, ExportNamedDeclaration, Expression, ExpressionStatement, FunctionBody,
-    Function, FunctionType, ImportDeclaration, ImportDeclarationSpecifier, ImportExpression,
+    ExportAllDeclaration, ExportNamedDeclaration, Expression, ExpressionStatement, Function,
+    FunctionBody, FunctionType, ImportDeclaration, ImportDeclarationSpecifier, ImportExpression,
     ImportOrExportKind, ModuleExportName, ObjectExpression, ObjectPropertyKind, Program,
     PropertyKey, PropertyKind, Statement, TSImportEqualsDeclaration, TSModuleReference,
-    VariableDeclarator, VariableDeclarationKind,
+    VariableDeclarationKind, VariableDeclarator,
 };
 use oxc_ast_visit::{walk, Visit};
 use oxc_syntax::scope::{ScopeFlags, ScopeId};
@@ -20,13 +20,12 @@ pub fn collect_imports(program: &Program<'_>) -> KratosResult<Vec<ImportRecord>>
     let scope_dynamic_bindings = collect_scoped_dynamic_bindings(program, &scope_shadows);
     let scope_loader_bindings = collect_scoped_loader_bindings(program);
     let scope_then_callback_bindings = collect_scoped_then_callback_bindings(program);
-    let mut collector =
-        ImportCollector::new(
-            scope_shadows,
-            scope_dynamic_bindings,
-            scope_loader_bindings,
-            scope_then_callback_bindings,
-        );
+    let mut collector = ImportCollector::new(
+        scope_shadows,
+        scope_dynamic_bindings,
+        scope_loader_bindings,
+        scope_then_callback_bindings,
+    );
     collector.visit_program(program);
     Ok(collector.imports)
 }
@@ -81,7 +80,6 @@ impl ImportCollector {
             imports: Vec::new(),
         }
     }
-
 }
 
 #[derive(Clone, Default)]
@@ -332,6 +330,17 @@ impl<'a> Visit<'a> for ImportCollector {
             return;
         }
 
+        let mut recorded_sources = BTreeSet::new();
+        for dynamic_usage in self.extract_generic_loader_usages_current(expression) {
+            if recorded_sources.insert(dynamic_usage.source.clone()) {
+                self.imports.push(ImportRecord {
+                    source: dynamic_usage.source,
+                    kind: ImportKind::Dynamic,
+                    specifiers: Vec::new(),
+                });
+            }
+        }
+
         walk::walk_call_expression(self, expression);
     }
 
@@ -341,11 +350,7 @@ impl<'a> Visit<'a> for ImportCollector {
         if let Some(initializer) = declarator.init.as_ref() {
             if let Some(binding_kind) = self.classify_dynamic_alias_expression_current(initializer)
             {
-                self.register_runtime_dynamic_alias(
-                    declarator.kind,
-                    &declarator.id,
-                    binding_kind,
-                );
+                self.register_runtime_dynamic_alias(declarator.kind, &declarator.id, binding_kind);
             }
 
             if let Some(local_name) = binding_pattern_name(&declarator.id) {
@@ -358,22 +363,19 @@ impl<'a> Visit<'a> for ImportCollector {
                 }
 
                 let direct_loader_binding = match initializer.without_parentheses() {
-                    Expression::ArrowFunctionExpression(_)
-                    | Expression::FunctionExpression(_) => {
+                    Expression::ArrowFunctionExpression(_) | Expression::FunctionExpression(_) => {
                         self.extract_loader_expression_usage_current(initializer)
                     }
                     _ => None,
                 };
-                let tracked_import =
-                    direct_loader_binding.clone().or_else(|| {
-                        let Expression::Identifier(identifier) =
-                            initializer.without_parentheses()
-                        else {
-                            return None;
-                        };
+                let tracked_import = direct_loader_binding.clone().or_else(|| {
+                    let Expression::Identifier(identifier) = initializer.without_parentheses()
+                    else {
+                        return None;
+                    };
 
-                        self.resolve_loader_binding(identifier.name.as_str())
-                    });
+                    self.resolve_loader_binding(identifier.name.as_str())
+                });
 
                 if let Some(tracked_import) = tracked_import {
                     self.register_runtime_loader_binding(
@@ -387,10 +389,9 @@ impl<'a> Visit<'a> for ImportCollector {
             }
         }
 
-        if let Some(source) = extract_require_source(
-            declarator.init.as_ref(),
-            self.is_builtin_require_shadowed(),
-        ) {
+        if let Some(source) =
+            extract_require_source(declarator.init.as_ref(), self.is_builtin_require_shadowed())
+        {
             self.register_runtime_require_dynamic_bindings(
                 declarator.kind,
                 &declarator.id,
@@ -424,10 +425,9 @@ impl<'a> Visit<'a> for ImportCollector {
     }
 
     fn visit_assignment_expression(&mut self, expression: &AssignmentExpression<'a>) {
-        if let Some(source) = extract_require_source(
-            Some(&expression.right),
-            self.is_builtin_require_shadowed(),
-        ) {
+        if let Some(source) =
+            extract_require_source(Some(&expression.right), self.is_builtin_require_shadowed())
+        {
             self.imports.push(ImportRecord {
                 source,
                 kind: ImportKind::Require,
@@ -728,7 +728,11 @@ impl ImportCollector {
         call: &CallExpression<'_>,
     ) -> Option<TrackedDynamicImport> {
         let callee = call.callee.without_parentheses();
-        let callback = call.arguments.first()?.as_expression()?.without_parentheses();
+        let callback = call
+            .arguments
+            .first()?
+            .as_expression()?
+            .without_parentheses();
 
         if self.is_react_lazy_callee_current(callee) {
             return self.extract_loader_callback_usage_current(callback);
@@ -739,6 +743,33 @@ impl ImportCollector {
         }
 
         None
+    }
+
+    fn extract_generic_loader_usages_current(
+        &self,
+        call: &CallExpression<'_>,
+    ) -> Vec<TrackedDynamicImport> {
+        let mut usages = Vec::new();
+
+        if let Expression::Identifier(identifier) = call.callee.without_parentheses() {
+            if let Some(usage) = self.resolve_loader_binding(identifier.name.as_str()) {
+                usages.push(usage);
+            }
+        }
+
+        for argument in &call.arguments {
+            let Some(argument) = argument.as_expression() else {
+                continue;
+            };
+            let Expression::Identifier(identifier) = argument.without_parentheses() else {
+                continue;
+            };
+            if let Some(usage) = self.resolve_loader_binding(identifier.name.as_str()) {
+                usages.push(usage);
+            }
+        }
+
+        usages
     }
 
     fn walk_dynamic_wrapper_call(
@@ -930,10 +961,7 @@ impl ImportCollector {
         self.then_callback_scope_stack[target_index].insert(local_name, usage);
     }
 
-    fn register_hoisted_loader_declarations(
-        &mut self,
-        statements: &[Statement<'_>],
-    ) {
+    fn register_hoisted_loader_declarations(&mut self, statements: &[Statement<'_>]) {
         for statement in statements {
             let Statement::FunctionDeclaration(function) = statement else {
                 continue;
@@ -1082,10 +1110,9 @@ impl<'a> Visit<'a> for DynamicBindingCollector {
     }
 
     fn visit_variable_declarator(&mut self, declarator: &VariableDeclarator<'a>) {
-        if let Some(source) = extract_require_source(
-            declarator.init.as_ref(),
-            self.is_builtin_require_shadowed(),
-        ) {
+        if let Some(source) =
+            extract_require_source(declarator.init.as_ref(), self.is_builtin_require_shadowed())
+        {
             collect_require_dynamic_bindings(&mut self.bindings, &declarator.id, &source);
         }
 
@@ -1356,9 +1383,10 @@ impl<'a> Visit<'a> for ScopedLoaderBindingCollector {
     }
 
     fn visit_variable_declarator(&mut self, declarator: &VariableDeclarator<'a>) {
-        if let (Some(local_name), Some(initializer)) =
-            (binding_pattern_name(&declarator.id), declarator.init.as_ref())
-        {
+        if let (Some(local_name), Some(initializer)) = (
+            binding_pattern_name(&declarator.id),
+            declarator.init.as_ref(),
+        ) {
             let tracked_import = extract_loader_binding_usage(initializer).or_else(|| {
                 let Expression::Identifier(identifier) = initializer.without_parentheses() else {
                     return None;
@@ -1419,13 +1447,8 @@ impl<'a> Visit<'a> for ScopedThenCallbackCollector {
             FunctionType::FunctionDeclaration | FunctionType::TSDeclareFunction
         ) {
             if let (Some(id), Some(body)) = (&function.id, function.body.as_ref()) {
-                if let Some(usage) =
-                    extract_then_callback_function_usage(&function.params, body)
-                {
-                    self.register_in_nearest_var_scope(
-                        id.name.as_str().to_string(),
-                        usage,
-                    );
+                if let Some(usage) = extract_then_callback_function_usage(&function.params, body) {
+                    self.register_in_nearest_var_scope(id.name.as_str().to_string(), usage);
                 }
             }
         }
@@ -1834,24 +1857,18 @@ fn is_react_lazy_callee(
     match expression {
         Expression::StaticMemberExpression(member) => {
             member.property.name.as_str() == "lazy"
-                && is_react_wrapper_object(
-                    &member.object,
-                    bindings,
-                    active_bindings,
-                    shadowed,
-                )
+                && is_react_wrapper_object(&member.object, bindings, active_bindings, shadowed)
         }
         Expression::Identifier(identifier) => {
             binding_name_matches(
                 identifier.name.as_str(),
                 &bindings.react_lazy_functions,
                 &active_bindings.react_lazy_functions,
+            ) && !is_shadowed(
+                identifier.name.as_str(),
+                shadowed,
+                &active_bindings.react_lazy_functions,
             )
-                && !is_shadowed(
-                    identifier.name.as_str(),
-                    shadowed,
-                    &active_bindings.react_lazy_functions,
-                )
         }
         _ => false,
     }
@@ -2143,9 +2160,7 @@ fn extract_then_callback_alias_entries(
 
         let imported = property_key_to_string(&property.key)?;
         let local = match &property.value {
-            BindingPattern::BindingIdentifier(identifier) => {
-                identifier.name.as_str().to_string()
-            }
+            BindingPattern::BindingIdentifier(identifier) => identifier.name.as_str().to_string(),
             BindingPattern::AssignmentPattern(pattern) => pattern
                 .left
                 .get_binding_identifier()
@@ -2183,11 +2198,9 @@ fn extract_then_callback_binding(
     }
 
     match &params.items[0].pattern {
-        BindingPattern::BindingIdentifier(identifier) => {
-            Some(ThenCallbackBinding::Namespace(
-                identifier.name.as_str().to_string(),
-            ))
-        }
+        BindingPattern::BindingIdentifier(identifier) => Some(ThenCallbackBinding::Namespace(
+            identifier.name.as_str().to_string(),
+        )),
         BindingPattern::ObjectPattern(pattern) => {
             if pattern.rest.is_some() {
                 return None;

--- a/crates/kratos-core/src/parser/mod.rs
+++ b/crates/kratos-core/src/parser/mod.rs
@@ -13,6 +13,7 @@ pub struct ParsedModule {
     pub imports: Vec<ImportRecord>,
     pub exports: Vec<ExportRecord>,
     pub unused_imports: Vec<UnusedImportRecord>,
+    pub is_pure_reexport_barrel: bool,
 }
 
 pub fn parse_module_source(path: &Path, source: &str) -> KratosResult<ParsedModule> {

--- a/crates/kratos-core/tests/analyze_demo_app.rs
+++ b/crates/kratos-core/tests/analyze_demo_app.rs
@@ -242,6 +242,91 @@ export const helper = 1;
 }
 
 #[test]
+fn analyze_project_excludes_pure_reexport_barrels_from_deletion_candidates() {
+    let project = TestProject::new("pure-reexport-barrel");
+    project.write(
+        "src/widgets/ui/index.ts",
+        r#"
+// public widget barrel
+export { default as CycleTimeChart } from "./CycleTimeChart";
+export * from "./chartTypes";
+"#,
+    );
+    project.write(
+        "src/widgets/ui/CycleTimeChart.tsx",
+        "export default function CycleTimeChart() { return null; }\n",
+    );
+    project.write(
+        "src/widgets/ui/chartTypes.ts",
+        "export type ChartId = string;\n",
+    );
+    project.write(
+        "src/widgets/ui/compact.ts",
+        r#"export{ChartMeta}from"./chartMeta";"#,
+    );
+    project.write(
+        "src/widgets/ui/chartMeta.ts",
+        "export const ChartMeta = true;\n",
+    );
+    project.write(
+        "src/widgets/ui/clientIndex.ts",
+        r#""use client";
+export { default as ClientWidget } from "./ClientWidget";
+"#,
+    );
+    project.write(
+        "src/widgets/ui/ClientWidget.tsx",
+        "export default function ClientWidget() { return null; }\n",
+    );
+    project.write(
+        "src/widgets/ui/impure.ts",
+        r#"export { default as ImpureWidget } from "./ImpureWidget";
+registerIcons();
+"#,
+    );
+    project.write(
+        "src/widgets/ui/ImpureWidget.tsx",
+        "export default function ImpureWidget() { return null; }\n",
+    );
+    project.write("src/widgets/logic.ts", "export const unusedLogic = true;\n");
+
+    let report = analyze_project(project.root()).expect("project should analyze");
+    let barrel = project.root().join("src/widgets/ui/index.ts");
+    let compact_barrel = project.root().join("src/widgets/ui/compact.ts");
+    let client_barrel = project.root().join("src/widgets/ui/clientIndex.ts");
+    let impure_barrel = project.root().join("src/widgets/ui/impure.ts");
+    let logic = project.root().join("src/widgets/logic.ts");
+
+    for pure_barrel in [barrel, compact_barrel, client_barrel] {
+        assert!(!report
+            .findings
+            .orphan_files
+            .iter()
+            .any(|finding| finding.file == pure_barrel));
+        assert!(!report
+            .findings
+            .deletion_candidates
+            .iter()
+            .any(|finding| finding.file == pure_barrel));
+        assert!(!report
+            .findings
+            .dead_exports
+            .iter()
+            .any(|finding| finding.file == pure_barrel));
+    }
+    assert!(report
+        .findings
+        .deletion_candidates
+        .iter()
+        .any(|finding| finding.file == impure_barrel));
+    assert!(report
+        .findings
+        .deletion_candidates
+        .iter()
+        .any(|finding| finding.file == logic));
+}
+
+#[test]
 fn analyze_project_skips_next_app_framework_exports_for_route_conventions() {
     let project = TestProject::new("next-app-framework-exports");
     project.write(

--- a/crates/kratos-core/tests/dynamic_usage.rs
+++ b/crates/kratos-core/tests/dynamic_usage.rs
@@ -445,13 +445,11 @@ export default function InnerChunk() {
 
     let report = analyze_project(project.root()).expect("project should analyze");
 
-    assert!(
-        report
-            .findings
-            .dead_exports
-            .iter()
-            .all(|finding| finding.file != project.root().join("src/InnerChunk.tsx"))
-    );
+    assert!(report
+        .findings
+        .dead_exports
+        .iter()
+        .all(|finding| finding.file != project.root().join("src/InnerChunk.tsx")));
 
     let chunk = report
         .modules
@@ -470,6 +468,127 @@ export default function InnerChunk() {
         chunk.importers[0].specifiers[0].imported.as_deref(),
         Some("default")
     );
+}
+
+#[test]
+fn analyze_project_treats_unqualified_dynamic_import_as_unknown_usage() {
+    let project = TestProject::new("unqualified-dynamic-import");
+    project.write(
+        "src/consumer.ts",
+        r#"
+const chunk = import("./Chunk");
+"#,
+    );
+    project.write(
+        "src/Chunk.ts",
+        r#"
+export default function Chunk() {
+  return null;
+}
+
+export const Helper = true;
+"#,
+    );
+
+    let report = analyze_project(project.root()).expect("project should analyze");
+
+    assert!(report.findings.dead_exports.is_empty());
+
+    let chunk = report
+        .modules
+        .iter()
+        .find(|module| module.relative_path == "src/Chunk.ts")
+        .expect("chunk module should exist");
+
+    assert_eq!(chunk.imported_by_count, 1);
+    assert_eq!(chunk.importers.len(), 1);
+    assert_eq!(chunk.importers[0].kind, ImportKind::Dynamic);
+    assert!(chunk.importers[0].specifiers.is_empty());
+}
+
+#[test]
+fn analyze_project_treats_dynamic_wrapper_helper_loader_as_unknown_usage() {
+    let project = TestProject::new("dynamic-wrapper-helper-loader");
+    project.write(
+        "src/consumer.tsx",
+        r#"
+import dynamic from "next/dynamic";
+
+function loadClientChart(loader: () => Promise<unknown>) {
+  return dynamic(loader);
+}
+
+const consumer = loadClientChart(() => import("./CycleTimeChart"));
+"#,
+    );
+    project.write(
+        "src/CycleTimeChart.tsx",
+        r#"
+export default function CycleTimeChart() {
+  return null;
+}
+
+export const chartConfig = {};
+"#,
+    );
+
+    let report = analyze_project(project.root()).expect("project should analyze");
+
+    assert!(report.findings.dead_exports.is_empty());
+
+    let chart = report
+        .modules
+        .iter()
+        .find(|module| module.relative_path == "src/CycleTimeChart.tsx")
+        .expect("chart module should exist");
+
+    assert_eq!(chart.imported_by_count, 1);
+    assert_eq!(chart.importers.len(), 1);
+    assert_eq!(chart.importers[0].kind, ImportKind::Dynamic);
+    assert!(chart.importers[0].specifiers.is_empty());
+}
+
+#[test]
+fn analyze_project_treats_dynamic_wrapper_helper_loader_identifier_as_unknown_usage() {
+    let project = TestProject::new("dynamic-wrapper-helper-loader-identifier");
+    project.write(
+        "src/consumer.tsx",
+        r#"
+import dynamic from "next/dynamic";
+
+function loadClientChart(loader: () => Promise<unknown>) {
+  return dynamic(loader);
+}
+
+const chartLoader = () => import("./CycleTimeChart");
+const consumer = loadClientChart(chartLoader);
+"#,
+    );
+    project.write(
+        "src/CycleTimeChart.tsx",
+        r#"
+export default function CycleTimeChart() {
+  return null;
+}
+
+export const chartConfig = {};
+"#,
+    );
+
+    let report = analyze_project(project.root()).expect("project should analyze");
+
+    assert!(report.findings.dead_exports.is_empty());
+
+    let chart = report
+        .modules
+        .iter()
+        .find(|module| module.relative_path == "src/CycleTimeChart.tsx")
+        .expect("chart module should exist");
+
+    assert_eq!(chart.imported_by_count, 1);
+    assert_eq!(chart.importers.len(), 1);
+    assert_eq!(chart.importers[0].kind, ImportKind::Dynamic);
+    assert!(chart.importers[0].specifiers.is_empty());
 }
 
 #[test]
@@ -713,7 +832,7 @@ export const Named = true;
 
     let report = analyze_project(project.root()).expect("project should analyze");
 
-    assert_eq!(report.findings.dead_exports.len(), 2);
+    assert!(report.findings.dead_exports.is_empty());
 
     let chunk = report
         .modules
@@ -1192,12 +1311,7 @@ export default function Chunk() {
 
     let report = analyze_project(project.root()).expect("project should analyze");
 
-    assert_eq!(report.findings.dead_exports.len(), 1);
-    assert_eq!(
-        report.findings.dead_exports[0].file,
-        project.root().join("src/Chunk.js")
-    );
-    assert_eq!(report.findings.dead_exports[0].export_name, "default");
+    assert!(report.findings.dead_exports.is_empty());
 
     let chunk = report
         .modules
@@ -1501,12 +1615,7 @@ export default function Chunk() {
 
     let report = analyze_project(project.root()).expect("project should analyze");
 
-    assert_eq!(report.findings.dead_exports.len(), 1);
-    assert_eq!(
-        report.findings.dead_exports[0].file,
-        project.root().join("src/Chunk.tsx")
-    );
-    assert_eq!(report.findings.dead_exports[0].export_name, "default");
+    assert!(report.findings.dead_exports.is_empty());
 
     let chunk = report
         .modules
@@ -1548,12 +1657,7 @@ export default function Chunk() {
 
     let report = analyze_project(project.root()).expect("project should analyze");
 
-    assert_eq!(report.findings.dead_exports.len(), 1);
-    assert_eq!(
-        report.findings.dead_exports[0].file,
-        project.root().join("src/Chunk.tsx")
-    );
-    assert_eq!(report.findings.dead_exports[0].export_name, "default");
+    assert!(report.findings.dead_exports.is_empty());
 
     let chunk = report
         .modules
@@ -1588,12 +1692,7 @@ export default function Chunk() {
 
     let report = analyze_project(project.root()).expect("project should analyze");
 
-    assert_eq!(report.findings.dead_exports.len(), 1);
-    assert_eq!(
-        report.findings.dead_exports[0].file,
-        project.root().join("src/Chunk.js")
-    );
-    assert_eq!(report.findings.dead_exports[0].export_name, "default");
+    assert!(report.findings.dead_exports.is_empty());
 
     let chunk = report
         .modules
@@ -1628,12 +1727,7 @@ export default function Chunk() {
 
     let report = analyze_project(project.root()).expect("project should analyze");
 
-    assert_eq!(report.findings.dead_exports.len(), 1);
-    assert_eq!(
-        report.findings.dead_exports[0].file,
-        project.root().join("src/Chunk.js")
-    );
-    assert_eq!(report.findings.dead_exports[0].export_name, "default");
+    assert!(report.findings.dead_exports.is_empty());
 
     let chunk = report
         .modules
@@ -1669,12 +1763,7 @@ export default function Chunk() {
 
     let report = analyze_project(project.root()).expect("project should analyze");
 
-    assert_eq!(report.findings.dead_exports.len(), 1);
-    assert_eq!(
-        report.findings.dead_exports[0].file,
-        project.root().join("src/Chunk.tsx")
-    );
-    assert_eq!(report.findings.dead_exports[0].export_name, "default");
+    assert!(report.findings.dead_exports.is_empty());
 
     let chunk = report
         .modules
@@ -1714,12 +1803,7 @@ export default function Chunk() {
 
     let report = analyze_project(project.root()).expect("project should analyze");
 
-    assert_eq!(report.findings.dead_exports.len(), 1);
-    assert_eq!(
-        report.findings.dead_exports[0].file,
-        project.root().join("src/Chunk.js")
-    );
-    assert_eq!(report.findings.dead_exports[0].export_name, "default");
+    assert!(report.findings.dead_exports.is_empty());
 
     let chunk = report
         .modules
@@ -1762,12 +1846,7 @@ export default function Chunk() {
 
     let report = analyze_project(project.root()).expect("project should analyze");
 
-    assert_eq!(report.findings.dead_exports.len(), 1);
-    assert_eq!(
-        report.findings.dead_exports[0].file,
-        project.root().join("src/Chunk.tsx")
-    );
-    assert_eq!(report.findings.dead_exports[0].export_name, "default");
+    assert!(report.findings.dead_exports.is_empty());
 
     let chunk = report
         .modules
@@ -1811,12 +1890,7 @@ export default function Chunk() {
 
     let report = analyze_project(project.root()).expect("project should analyze");
 
-    assert_eq!(report.findings.dead_exports.len(), 1);
-    assert_eq!(
-        report.findings.dead_exports[0].file,
-        project.root().join("src/Chunk.tsx")
-    );
-    assert_eq!(report.findings.dead_exports[0].export_name, "default");
+    assert!(report.findings.dead_exports.is_empty());
 
     let chunk = report
         .modules
@@ -1856,12 +1930,7 @@ export default function Chunk() {
 
     let report = analyze_project(project.root()).expect("project should analyze");
 
-    assert_eq!(report.findings.dead_exports.len(), 1);
-    assert_eq!(
-        report.findings.dead_exports[0].file,
-        project.root().join("src/Chunk.tsx")
-    );
-    assert_eq!(report.findings.dead_exports[0].export_name, "default");
+    assert!(report.findings.dead_exports.is_empty());
 
     let chunk = report
         .modules
@@ -1899,12 +1968,7 @@ export default function Chunk() {
 
     let report = analyze_project(project.root()).expect("project should analyze");
 
-    assert_eq!(report.findings.dead_exports.len(), 1);
-    assert_eq!(
-        report.findings.dead_exports[0].file,
-        project.root().join("src/Chunk.js")
-    );
-    assert_eq!(report.findings.dead_exports[0].export_name, "default");
+    assert!(report.findings.dead_exports.is_empty());
 
     let chunk = report
         .modules
@@ -1942,12 +2006,7 @@ export default function Chunk() {
 
     let report = analyze_project(project.root()).expect("project should analyze");
 
-    assert_eq!(report.findings.dead_exports.len(), 1);
-    assert_eq!(
-        report.findings.dead_exports[0].file,
-        project.root().join("src/Chunk.tsx")
-    );
-    assert_eq!(report.findings.dead_exports[0].export_name, "default");
+    assert!(report.findings.dead_exports.is_empty());
 
     let chunk = report
         .modules

--- a/crates/kratos-core/tests/parser_extraction.rs
+++ b/crates/kratos-core/tests/parser_extraction.rs
@@ -552,6 +552,28 @@ const LazyChunk = React.lazy(loader);
 }
 
 #[test]
+fn parser_marks_generic_loader_identifier_call_as_unknown_usage() {
+    let parsed = parse_module_source(
+        Path::new("index.tsx"),
+        r#"
+const loader = () => import("./Chunk");
+const dynamic = (loader) => loader;
+const LazyChunk = dynamic(loader);
+"#,
+    )
+    .expect("parser should succeed");
+
+    let dynamic_import = parsed
+        .imports
+        .iter()
+        .find(|entry| entry.source == "./Chunk")
+        .expect("dynamic import should be recorded");
+
+    assert_eq!(dynamic_import.kind, ImportKind::Dynamic);
+    assert!(dynamic_import.specifiers.is_empty());
+}
+
+#[test]
 fn parser_marks_lazy_default_usage_for_hoisted_function_loader_identifier() {
     let parsed = parse_module_source(
         Path::new("index.tsx"),


### PR DESCRIPTION
## 배경

dynamic import wrapper와 순수 re-export barrel에서 실제 런타임 사용이 정적 분석에 충분히 반영되지 않아 dead export 또는 삭제 후보 오탐이 발생하는 문제를 줄입니다.

## 변경 사항

- unqualified dynamic import를 unknown usage로 처리해 전체 export를 보수적으로 live 처리합니다.
- generic wrapper helper와 loader identifier 전달 형태를 dynamic unknown usage로 기록합니다.
- React.lazy/next/dynamic의 named selection 동작은 기존처럼 named export 단위로 유지합니다.
- parser AST 기반으로 순수 re-export barrel을 판별하고 orphan/deletion/dead-export finding에서 제외합니다.
- directive-only barrel과 impure barrel 회귀 테스트를 추가했습니다.

## 검증

- `cargo test -p kratos-core --test dynamic_usage`
- `cargo test -p kratos-core --test parser_extraction`
- `cargo test -p kratos-core --test analyze_demo_app`
- `cargo test -p kratos-core`
- `npm run verify`
- `cargo test --workspace`
- `git diff --check`
- `$devils-advocate-review-loop`: Round 3 기준 Critical 0 / High 0 / Medium 0 / Low 0

## 브랜치 / 워크트리

- branch: `codex/fix-54-dynamic-barrel`
- worktree: `/tmp/kratos-issue-54`
- base: `master`

## 이슈 연결

Closes #54
