### PR TITLE
fix(core): Orbit Dashboard 회귀 보호 보강

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -20,6 +20,10 @@ Kratos is an analysis tool for a safe cleanup workflow, not an automatic deletio
 - Apply Next.js `app/` / `pages/` route entrypoint heuristics
 - Resolve `tsconfig.json` / `jsconfig.json` `baseUrl` and `paths` aliases
 - Resolve `package.json` `main`, `module`, `types`, `bin`, and `exports` entrypoints
+- Protect local script entrypoints executed by `package.json` scripts and GitHub Actions workflow/composite action `run` commands
+- Protect manual verification scripts shaped like `scripts/verify-*`, `scripts/*smoke*`, and `scripts/*validation*`
+- Exclude `*.test.*`, `*.spec.*`, and `src/__tests__/**` test files inside the scanned source tree from deletion candidates while preserving their import edges
+- Conservatively handle Next.js framework-consumed exports, recognized dynamic import wrappers, and pure re-export barrels
 - Print saved reports as summary, JSON, or Markdown
 - Compare finding changes between two reports
 - Preview safe deletion candidates with a confidence threshold
@@ -289,4 +293,4 @@ Kratos is open source under the MIT license.
 
 ## Note
 
-Kratos combines conservative static analysis with heuristics. Dynamic imports, framework conventions, generated files, and runtime-only entrypoints can vary by project, so review the report and diff before running `--apply`.
+Kratos combines conservative static analysis with heuristics. The current implementation protects known Next.js route exports, package/workflow/action script entrypoints, manual verification scripts, tooling config files, test files, recognized `React.lazy`/`next/dynamic` wrappers, and pure re-export barrels. Custom runtime entrypoints, generated files, and project-specific loaders may still sit outside static analysis, so declare them with `entry`/suppressions when needed and review the remaining deletion candidates with the report and diff before running `--apply`.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Kratos는 자동 삭제 도구라기보다 안전한 정리 흐름을 위한 분
 - Next.js `app/` / `pages/` route entrypoint 휴리스틱
 - `tsconfig.json` / `jsconfig.json`의 `baseUrl`, `paths` alias 해석
 - `package.json`의 `main`, `module`, `types`, `bin`, `exports` entrypoint 해석
+- `package.json` scripts, GitHub Actions workflow/composite action `run` 명령이 실행하는 로컬 script entrypoint 보호
+- `scripts/verify-*`, `scripts/*smoke*`, `scripts/*validation*` 형태의 수동 검증 script 보호
+- 스캔 대상 source tree 안의 `*.test.*`, `*.spec.*`, `src/__tests__/**` 테스트 파일을 삭제 후보에서 제외하고 테스트 import edge 반영
+- Next.js framework-consumed export, 인식 가능한 dynamic import wrapper, 순수 re-export barrel 보수 처리
 - 저장된 리포트 요약, JSON, Markdown 출력
 - 두 리포트 간 finding 변화 비교
 - 신뢰도 기준값을 적용한 안전 삭제 후보 미리보기
@@ -289,4 +293,4 @@ Kratos는 MIT 라이선스로 공개되는 오픈소스 프로젝트입니다.
 
 ## 주의
 
-Kratos는 보수적인 정적 분석과 휴리스틱을 함께 사용합니다. 동적 import, framework convention, 생성 파일, runtime-only entrypoint는 프로젝트마다 다르게 해석될 수 있으므로 `--apply` 전에 report와 diff를 검토하는 흐름을 권장합니다.
+Kratos는 보수적인 정적 분석과 휴리스틱을 함께 사용합니다. 현재 구현은 알려진 Next.js route export, package/workflow/action script entrypoint, 수동 검증 script, tooling config, 테스트 파일, 인식 가능한 `React.lazy`/`next/dynamic` wrapper, 순수 re-export barrel을 보호합니다. 그래도 custom runtime entrypoint, 생성 파일, 프로젝트 고유 loader는 정적 분석 밖에 있을 수 있으므로 필요하면 `entry`/suppression으로 명시하고, 남은 deletion candidate는 `--apply` 전에 report와 diff로 확인하세요.

--- a/crates/kratos-core/src/config.rs
+++ b/crates/kratos-core/src/config.rs
@@ -36,7 +36,6 @@ const DEFAULT_IGNORED_DIRS: &[&str] = &[
     "test",
     "tests",
     "__fixtures__",
-    "__tests__",
 ];
 
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -344,6 +343,11 @@ fn collect_yamlish_run_entries(
         if file_type.is_file() && include_file(&path) {
             let content = std::fs::read_to_string(&path)?;
             for command in extract_yamlish_run_commands(&content) {
+                let command_text = if is_action_file(&path) {
+                    rewrite_action_path_references(&command.command, &path)
+                } else {
+                    command.command
+                };
                 let command_root = command
                     .working_directory
                     .as_deref()
@@ -354,7 +358,7 @@ fn collect_yamlish_run_entries(
                     root,
                     &command_root,
                     package_json,
-                    &command.command,
+                    &command_text,
                     0,
                 );
             }
@@ -376,6 +380,44 @@ fn is_action_file(path: &Path) -> bool {
         path.file_name().and_then(|value| value.to_str()),
         Some("action.yml" | "action.yaml")
     )
+}
+
+fn rewrite_action_path_references(command: &str, action_file: &Path) -> String {
+    let Some(action_dir) = action_file.parent() else {
+        return command.to_string();
+    };
+    let action_path = normalize_path(action_dir.to_path_buf())
+        .to_string_lossy()
+        .replace('\\', "/");
+
+    rewrite_github_action_path_expressions(command, &action_path)
+        .replace("${ACTION_PATH}", &action_path)
+        .replace("$ACTION_PATH", &action_path)
+}
+
+fn rewrite_github_action_path_expressions(command: &str, action_path: &str) -> String {
+    let mut output = String::new();
+    let mut rest = command;
+
+    while let Some(start) = rest.find("${{") {
+        output.push_str(&rest[..start]);
+        let expression_start = start + "${{".len();
+        let Some(end) = rest[expression_start..].find("}}") else {
+            output.push_str(&rest[start..]);
+            return output;
+        };
+        let expression_end = expression_start + end;
+        let expression = &rest[expression_start..expression_end];
+        if expression.trim() == "github.action_path" {
+            output.push_str(action_path);
+        } else {
+            output.push_str(&rest[start..expression_end + "}}".len()]);
+        }
+        rest = &rest[expression_end + "}}".len()..];
+    }
+
+    output.push_str(rest);
+    output
 }
 
 struct YamlishRunCommand {

--- a/crates/kratos-core/src/entrypoints.rs
+++ b/crates/kratos-core/src/entrypoints.rs
@@ -63,6 +63,14 @@ pub fn detect_entrypoint_kind(
         return Ok(Some(EntrypointKind::ToolingEntry));
     }
 
+    if is_test_entry(&relative_path) {
+        return Ok(Some(EntrypointKind::ToolingEntry));
+    }
+
+    if is_manual_script_entry(&relative_path) {
+        return Ok(Some(EntrypointKind::ToolingEntry));
+    }
+
     if is_framework_entry(&relative_path) {
         return Ok(Some(EntrypointKind::FrameworkEntry));
     }
@@ -150,8 +158,8 @@ mod tests {
         assert_eq!(opengraph, Some(EntrypointKind::NextAppRoute));
         assert_eq!(package_root, Some(EntrypointKind::NextAppRoute));
         assert_eq!(nested_package, Some(EntrypointKind::NextAppRoute));
-        assert_eq!(nested_test, None);
-        assert_eq!(nested_spec, None);
+        assert_eq!(nested_test, Some(EntrypointKind::ToolingEntry));
+        assert_eq!(nested_spec, Some(EntrypointKind::ToolingEntry));
     }
 
     #[test]
@@ -208,15 +216,61 @@ mod tests {
             .expect("entrypoint detection should succeed");
         let eslint_config = detect_entrypoint_kind(&root.join("eslint.config.mjs"), &config)
             .expect("entrypoint detection should succeed");
-        let test_config = detect_entrypoint_kind(&root.join("next.config.test.ts"), &config)
-            .expect("entrypoint detection should succeed");
+        let extra_dotted_config =
+            detect_entrypoint_kind(&root.join("next.config.local.ts"), &config)
+                .expect("entrypoint detection should succeed");
         let backup_config = detect_entrypoint_kind(&root.join("vite.config.backup.js"), &config)
             .expect("entrypoint detection should succeed");
 
         assert_eq!(real_config, Some(EntrypointKind::ToolingEntry));
         assert_eq!(eslint_config, Some(EntrypointKind::ToolingEntry));
-        assert_eq!(test_config, None);
+        assert_eq!(extra_dotted_config, None);
         assert_eq!(backup_config, None);
+    }
+
+    #[test]
+    fn test_entry_supports_common_file_patterns() {
+        let root = PathBuf::from("/tmp/kratos-entrypoints");
+        let config = ProjectConfig::new(root.clone());
+
+        for path in [
+            "src/app/admin/data/_tabs.test.ts",
+            "src/components/Card.spec.tsx",
+            "src/__tests__/lib/validators.test.ts",
+        ] {
+            let detected = detect_entrypoint_kind(&root.join(path), &config)
+                .expect("entrypoint detection should succeed");
+            assert_eq!(
+                detected,
+                Some(EntrypointKind::ToolingEntry),
+                "{path} should be protected as a test entrypoint"
+            );
+        }
+    }
+
+    #[test]
+    fn manual_script_entry_supports_verify_smoke_and_validation_scripts() {
+        let root = PathBuf::from("/tmp/kratos-entrypoints");
+        let config = ProjectConfig::new(root.clone());
+
+        for path in [
+            "scripts/verify-beta-smoke.mjs",
+            "scripts/verify-integrated-insights-smoke.mjs",
+            "scripts/run-validation.ts",
+        ] {
+            let detected = detect_entrypoint_kind(&root.join(path), &config)
+                .expect("entrypoint detection should succeed");
+            assert_eq!(
+                detected,
+                Some(EntrypointKind::ToolingEntry),
+                "{path} should be protected as a manual verification entrypoint"
+            );
+        }
+
+        let ordinary_script =
+            detect_entrypoint_kind(&root.join("scripts/unused-helper.mjs"), &config)
+                .expect("entrypoint detection should succeed");
+        assert_eq!(ordinary_script, None);
     }
 }
 
@@ -262,6 +316,62 @@ fn is_tooling_entry(relative_path: &str) -> bool {
             .strip_prefix(&format!("{tool}.config."))
             .is_some_and(|extension| !extension.is_empty() && !extension.contains('.'))
     })
+}
+
+fn is_test_entry(relative_path: &str) -> bool {
+    let normalized_path = relative_path.replace('\\', "/").to_ascii_lowercase();
+    let file_name = normalized_path
+        .rsplit('/')
+        .next()
+        .unwrap_or(normalized_path.as_str());
+
+    normalized_path
+        .split('/')
+        .any(|segment| segment == "__tests__")
+        || TEST_FILE_SUFFIXES
+            .iter()
+            .any(|suffix| file_name.ends_with(suffix))
+}
+
+const TEST_FILE_SUFFIXES: &[&str] = &[
+    ".test.js",
+    ".test.jsx",
+    ".test.ts",
+    ".test.tsx",
+    ".test.mjs",
+    ".test.mts",
+    ".test.cjs",
+    ".test.cts",
+    ".spec.js",
+    ".spec.jsx",
+    ".spec.ts",
+    ".spec.tsx",
+    ".spec.mjs",
+    ".spec.mts",
+    ".spec.cjs",
+    ".spec.cts",
+];
+
+fn is_manual_script_entry(relative_path: &str) -> bool {
+    let normalized_path = relative_path.replace('\\', "/").to_ascii_lowercase();
+    let Some(file_name) = normalized_path.rsplit('/').next() else {
+        return false;
+    };
+
+    normalized_path.starts_with("scripts/")
+        && has_script_extension(file_name)
+        && (file_name.starts_with("verify-")
+            || file_name.contains("smoke")
+            || file_name.contains("validation"))
+}
+
+fn has_script_extension(file_name: &str) -> bool {
+    matches!(
+        Path::new(file_name)
+            .extension()
+            .and_then(|value| value.to_str()),
+        Some("js" | "jsx" | "ts" | "tsx" | "mjs" | "cjs" | "mts" | "cts" | "sh")
+    )
 }
 
 fn has_supported_segment(segments: &[&str], name: &str) -> bool {

--- a/crates/kratos-core/tests/analyze_demo_app.rs
+++ b/crates/kratos-core/tests/analyze_demo_app.rs
@@ -516,6 +516,296 @@ export const helperIcon = 1;
 }
 
 #[test]
+fn analyze_project_protects_orbit_dashboard_regression_surface() {
+    let project = TestProject::new("orbit-dashboard-regression");
+    project.write(
+        "package.json",
+        r#"{
+  "scripts": {
+    "generate:roster": "node scripts/generate-roster-json.mjs",
+    "sync:pr-daily": "npm run sync:pr-reviews",
+    "sync:pr-reviews": "node scripts/github-pr-reviews-daily-insert.mjs"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest"
+  }
+}
+"#,
+    );
+    project.write(
+        ".github/workflows/pr-weekly-snapshot.yml",
+        r#"
+name: PR weekly snapshot
+jobs:
+  snapshot:
+    steps:
+      - run: node scripts/github-pr-weekly-snapshot.mjs
+"#,
+    );
+    project.write(
+        ".github/actions/ai-readiness-scan/action.yml",
+        r#"
+runs:
+  using: composite
+  steps:
+    - run: node "$ACTION_PATH/../../../scripts/ai-readiness-submit.mjs"
+    - run: node ${{github.action_path}}/../../../scripts/ai-readiness-submit-expression.mjs
+    - working-directory: scripts
+      run: node "$ACTION_PATH/../../../scripts/ai-readiness-submit-working-dir.mjs"
+"#,
+    );
+    project.write("eslint.config.mjs", "export default [];\n");
+    project.write(
+        "scripts/generate-roster-json.mjs",
+        "console.log('generate roster');\n",
+    );
+    project.write(
+        "scripts/github-pr-reviews-daily-insert.mjs",
+        "console.log('daily reviews');\n",
+    );
+    project.write(
+        "scripts/github-pr-weekly-snapshot.mjs",
+        "console.log('weekly snapshot');\n",
+    );
+    project.write(
+        "scripts/ai-readiness-submit.mjs",
+        "export function submitPayload() { return true; }\n",
+    );
+    project.write(
+        "scripts/ai-readiness-submit-expression.mjs",
+        "export function submitExpressionPayload() { return true; }\n",
+    );
+    project.write(
+        "scripts/ai-readiness-submit-working-dir.mjs",
+        "export function submitWorkingDirPayload() { return true; }\n",
+    );
+    project.write(
+        "scripts/verify-beta-smoke.mjs",
+        "export function verifyBetaSmoke() { return true; }\n",
+    );
+    project.write(
+        "scripts/verify-integrated-insights-smoke.mjs",
+        "export function verifyIntegratedInsightsSmoke() { return true; }\n",
+    );
+    project.write(
+        "src/__tests__/scripts/verify-beta-smoke.test.ts",
+        r#"import { verifyBetaSmoke } from "../../../scripts/verify-beta-smoke.mjs";
+
+verifyBetaSmoke();
+"#,
+    );
+    project.write(
+        "src/shared/lib/validators.ts",
+        "export function validateEngineer() { return true; }\n",
+    );
+    project.write(
+        "src/__tests__/lib/validators.test.ts",
+        r#"import { validateEngineer } from "../../shared/lib/validators";
+
+validateEngineer();
+"#,
+    );
+    project.write(
+        "src/app/admin/data/_tabs.test.ts",
+        "export const adminTabsTest = true;\n",
+    );
+    project.write(
+        "src/app/admin/page.tsx",
+        r#"import dynamic from "next/dynamic";
+
+function loadDashboard(loader: () => Promise<unknown>) {
+  return dynamic(loader);
+}
+
+const AdminPanel = loadDashboard(() => import("../../features/admin/AdminPanel"));
+
+export const metadata = { title: "Admin" };
+export default function AdminPage() { return <AdminPanel />; }
+export const localHelper = true;
+"#,
+    );
+    project.write(
+        "src/features/admin/AdminPanel.tsx",
+        r#"export default function AdminPanel() { return null; }
+export const panelConfig = {};
+"#,
+    );
+    project.write(
+        "src/Widgets/CycleTime/ui/index.ts",
+        "export { default as CycleTimeChart } from \"./CycleTimeChart\";\n",
+    );
+    project.write(
+        "src/Widgets/CycleTime/ui/CycleTimeChart.tsx",
+        "export default function CycleTimeChart() { return null; }\n",
+    );
+    project.write(
+        "src/Widgets/CycleTime/model/stale.ts",
+        "export const staleWidgetModel = true;\n",
+    );
+
+    let report = analyze_project(project.root()).expect("project should analyze");
+
+    let deletion_candidates = relative_finding_files(
+        project.root(),
+        report
+            .findings
+            .deletion_candidates
+            .iter()
+            .map(|finding| &finding.file),
+    );
+    let orphan_files = relative_finding_files(
+        project.root(),
+        report
+            .findings
+            .orphan_files
+            .iter()
+            .map(|finding| &finding.file),
+    );
+    let dead_exports = report
+        .findings
+        .dead_exports
+        .iter()
+        .map(|finding| {
+            (
+                to_relative_path(project.root(), &finding.file),
+                finding.export_name.clone(),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    for protected in [
+        "eslint.config.mjs",
+        "scripts/generate-roster-json.mjs",
+        "scripts/github-pr-reviews-daily-insert.mjs",
+        "scripts/github-pr-weekly-snapshot.mjs",
+        "scripts/ai-readiness-submit.mjs",
+        "scripts/ai-readiness-submit-expression.mjs",
+        "scripts/ai-readiness-submit-working-dir.mjs",
+        "scripts/verify-beta-smoke.mjs",
+        "scripts/verify-integrated-insights-smoke.mjs",
+        "src/__tests__/scripts/verify-beta-smoke.test.ts",
+        "src/shared/lib/validators.ts",
+        "src/__tests__/lib/validators.test.ts",
+        "src/app/admin/data/_tabs.test.ts",
+        "src/app/admin/page.tsx",
+        "src/features/admin/AdminPanel.tsx",
+        "src/Widgets/CycleTime/ui/index.ts",
+    ] {
+        assert!(
+            !deletion_candidates.contains(&protected.to_string()),
+            "{protected} should not be a deletion candidate"
+        );
+        assert!(
+            !orphan_files.contains(&protected.to_string()),
+            "{protected} should not be reported as an orphan file"
+        );
+    }
+
+    assert!(!dead_exports.contains(&(
+        "src/features/admin/AdminPanel.tsx".to_string(),
+        "default".to_string(),
+    )));
+    assert!(!dead_exports.contains(&(
+        "src/features/admin/AdminPanel.tsx".to_string(),
+        "panelConfig".to_string(),
+    )));
+    assert!(!dead_exports.contains(&(
+        "scripts/ai-readiness-submit.mjs".to_string(),
+        "submitPayload".to_string(),
+    )));
+    assert!(!dead_exports.contains(&(
+        "scripts/ai-readiness-submit-expression.mjs".to_string(),
+        "submitExpressionPayload".to_string(),
+    )));
+    assert!(!dead_exports.contains(&(
+        "scripts/ai-readiness-submit-working-dir.mjs".to_string(),
+        "submitWorkingDirPayload".to_string(),
+    )));
+    assert!(!dead_exports.contains(&(
+        "scripts/verify-beta-smoke.mjs".to_string(),
+        "verifyBetaSmoke".to_string(),
+    )));
+    assert!(!dead_exports.contains(&(
+        "scripts/verify-integrated-insights-smoke.mjs".to_string(),
+        "verifyIntegratedInsightsSmoke".to_string(),
+    )));
+    assert!(!dead_exports.contains(&(
+        "src/shared/lib/validators.ts".to_string(),
+        "validateEngineer".to_string(),
+    )));
+    assert!(!dead_exports
+        .iter()
+        .any(|(file, _)| file == "src/Widgets/CycleTime/ui/index.ts"));
+    assert!(dead_exports.contains(&(
+        "src/app/admin/page.tsx".to_string(),
+        "localHelper".to_string(),
+    )));
+    assert!(deletion_candidates.contains(&"src/Widgets/CycleTime/model/stale.ts".to_string()));
+
+    let entrypoint_kinds = report
+        .modules
+        .iter()
+        .filter_map(|module| {
+            module
+                .entrypoint_kind
+                .clone()
+                .map(|kind| (module.relative_path.clone(), kind))
+        })
+        .collect::<Vec<_>>();
+
+    for (path, kind) in [
+        (
+            "scripts/generate-roster-json.mjs",
+            EntrypointKind::PackageEntry,
+        ),
+        (
+            "scripts/github-pr-reviews-daily-insert.mjs",
+            EntrypointKind::PackageEntry,
+        ),
+        (
+            "scripts/github-pr-weekly-snapshot.mjs",
+            EntrypointKind::PackageEntry,
+        ),
+        (
+            "scripts/ai-readiness-submit.mjs",
+            EntrypointKind::PackageEntry,
+        ),
+        (
+            "scripts/ai-readiness-submit-expression.mjs",
+            EntrypointKind::PackageEntry,
+        ),
+        (
+            "scripts/ai-readiness-submit-working-dir.mjs",
+            EntrypointKind::PackageEntry,
+        ),
+        ("eslint.config.mjs", EntrypointKind::ToolingEntry),
+        (
+            "src/__tests__/scripts/verify-beta-smoke.test.ts",
+            EntrypointKind::ToolingEntry,
+        ),
+        (
+            "src/__tests__/lib/validators.test.ts",
+            EntrypointKind::ToolingEntry,
+        ),
+        (
+            "src/app/admin/data/_tabs.test.ts",
+            EntrypointKind::ToolingEntry,
+        ),
+        (
+            "scripts/verify-integrated-insights-smoke.mjs",
+            EntrypointKind::ToolingEntry,
+        ),
+        ("src/app/admin/page.tsx", EntrypointKind::NextAppRoute),
+    ] {
+        assert!(
+            entrypoint_kinds.contains(&(path.to_string(), kind.clone())),
+            "{path} should be classified as {kind:?}"
+        );
+    }
+}
+
+#[test]
 fn analyze_project_reports_missing_base_url_imports_as_broken() {
     let project = TestProject::new("missing-baseurl");
     project.write(
@@ -549,6 +839,20 @@ fn repo_root() -> PathBuf {
         .join("../..")
         .canonicalize()
         .expect("repo root should resolve")
+}
+
+fn relative_finding_files<'a>(
+    root: &Path,
+    files: impl Iterator<Item = &'a PathBuf>,
+) -> Vec<String> {
+    files.map(|file| to_relative_path(root, file)).collect()
+}
+
+fn to_relative_path(root: &Path, file: &Path) -> String {
+    file.strip_prefix(root)
+        .unwrap_or(file)
+        .to_string_lossy()
+        .replace('\\', "/")
 }
 
 struct TestProject {

--- a/crates/kratos-core/tests/config_and_discovery.rs
+++ b/crates/kratos-core/tests/config_and_discovery.rs
@@ -467,6 +467,29 @@ fn collect_source_files_honors_explicit_roots_even_when_root_name_is_ignored_by_
 }
 
 #[test]
+fn collect_source_files_keeps_src_tests_available_for_import_edges() {
+    let project = TestProject::new("src-tests-import-edges");
+    project.write(
+        "src/__tests__/scripts/verify-smoke.test.ts",
+        "import { runSmoke } from '../../../scripts/verify-smoke.mjs';\nrunSmoke();\n",
+    );
+    project.write(
+        "scripts/verify-smoke.mjs",
+        "export function runSmoke() { return true; }\n",
+    );
+
+    let config = load_project_config(project.root()).expect("config should load");
+    let discovered = collect_source_files(&config).expect("source discovery should succeed");
+
+    assert!(discovered.contains(
+        &project
+            .root()
+            .join("src/__tests__/scripts/verify-smoke.test.ts")
+    ));
+    assert!(discovered.contains(&project.root().join("scripts/verify-smoke.mjs")));
+}
+
+#[test]
 fn collect_source_files_still_respects_directory_only_ignore_patterns_inside_explicit_roots() {
     for pattern in ["tests/", "/tests/"] {
         let project_name = format!("explicit-roots-respect-patterns-{}", pattern.len());
@@ -972,6 +995,12 @@ runs:
   using: composite
   steps:
     - run: node scripts/action-entry.mjs
+    - run: node "$ACTION_PATH/../../../scripts/action-path-entry.mjs"
+    - run: node ${{github.action_path}}/../../../scripts/action-path-expression-entry.mjs
+    - working-directory: scripts
+      run: node "$ACTION_PATH/../../../scripts/action-path-working-dir-entry.mjs"
+    - working-directory: scripts
+      run: node ${{ github.action_path }}/../../../scripts/action-path-expression-working-dir-entry.mjs
 "#,
     );
     project.write(
@@ -1000,6 +1029,22 @@ runs:
     project.write("scripts/workflow-cleanup.sh", "echo workflow cleanup\n");
     project.write("scripts/local-workflow.mjs", "export const local = true;\n");
     project.write("scripts/action-entry.mjs", "export const action = true;\n");
+    project.write(
+        "scripts/action-path-entry.mjs",
+        "export const actionPath = true;\n",
+    );
+    project.write(
+        "scripts/action-path-expression-entry.mjs",
+        "export const actionPathExpression = true;\n",
+    );
+    project.write(
+        "scripts/action-path-working-dir-entry.mjs",
+        "export const actionPathWorkingDir = true;\n",
+    );
+    project.write(
+        "scripts/action-path-expression-working-dir-entry.mjs",
+        "export const actionPathExpressionWorkingDir = true;\n",
+    );
 
     let config = load_project_config(project.root()).expect("config should load");
 
@@ -1015,6 +1060,10 @@ runs:
         "scripts/workflow-cleanup.sh",
         "scripts/local-workflow.mjs",
         "scripts/action-entry.mjs",
+        "scripts/action-path-entry.mjs",
+        "scripts/action-path-expression-entry.mjs",
+        "scripts/action-path-working-dir-entry.mjs",
+        "scripts/action-path-expression-working-dir-entry.mjs",
     ] {
         assert!(
             config.package_entries.contains(&project.root().join(entry)),


### PR DESCRIPTION
## 배경

Orbit Dashboard 기준 false-positive cleanup 후보 축소 작업의 Wave 4입니다. 앞선 Next route, script entrypoint, dynamic import/barrel 보수 처리 결과가 다시 깨지지 않도록 대표 구조를 회귀 테스트와 문서에 고정합니다.

## 변경 사항

- composite action의 `$ACTION_PATH` / `${{ github.action_path }}` 기반 로컬 script 실행을 package entrypoint로 수집합니다.
- source tree 내부 테스트 파일과 `src/__tests__/**`를 삭제 후보에서 제외하고, 테스트가 참조하는 helper/script import edge를 분석에 반영합니다.
- `scripts/verify-*`, `scripts/*smoke*`, `scripts/*validation*` 형태의 수동 검증 script를 보수적으로 보호합니다.
- Orbit Dashboard 대표 구조를 focused regression fixture로 추가했습니다.
  - package script
  - GitHub workflow script
  - composite action script
  - Next app route export
  - dynamic wrapper
  - pure re-export barrel
  - test-file import edge
  - 실제 stale deletion candidate
- README / README.en의 conservative static-analysis 설명을 현재 보호 범위에 맞게 갱신했습니다.

## 검증

- `rustfmt --check crates/kratos-core/src/config.rs crates/kratos-core/src/entrypoints.rs crates/kratos-core/tests/analyze_demo_app.rs crates/kratos-core/tests/config_and_discovery.rs`
- `git diff --check`
- `cargo test -p kratos-core --test config_and_discovery load_project_config_collects_script_and_workflow_entries`
- `cargo test -p kratos-core --test config_and_discovery collect_source_files_keeps_src_tests_available_for_import_edges`
- `cargo test -p kratos-core --test analyze_demo_app analyze_project_protects_orbit_dashboard_regression_surface`
- `cargo test -p kratos-core entrypoints::tests::test_entry_supports_common_file_patterns`
- `cargo test -p kratos-core entrypoints::tests::manual_script_entry_supports_verify_smoke_and_validation_scripts`
- `cargo test -p kratos-core`
- `npm run verify`
- `cargo test --workspace`
- `$devils-advocate-review-loop`
  - Round 1: Medium 2건 수용 후 수정
  - Round 2: Critical 0 / High 0 / Medium 0 / Low 0

## 수동 검증

```text
cargo run -p kratos-cli -- scan /Users/pjw/workspace/io/orbit-dashboard --output /private/tmp/orbit-dashboard-kratos-issue-55-report-final.json
```

결과 요약:

- `filesScanned`: 1126
- `entrypoints`: 635
- `brokenImports`: 0
- `deletionCandidates`: 6

남은 deletion candidate는 script/framework/barrel/dynamic/test 오탐이 아니라 실제 미참조 후보로 보이는 항목입니다.

## 브랜치 / 워크트리

- Base: `origin/master`
- Branch: `codex/fix-55-orbit-regression-docs`
- Worktree: `/private/tmp/kratos-issue-55`

## 이슈 연결

Closes #55
