### PR TITLE
feat(report): report 사람용 출력을 한국어로 전환

### DIFF
--- a/crates/kratos-cli/tests/cli_smoke.rs
+++ b/crates/kratos-cli/tests/cli_smoke.rs
@@ -33,17 +33,19 @@ fn scan_report_and_clean_work_for_demo_fixture() {
     let scan = run_cli(&["scan", project_root.to_str().expect("path should be utf8")]);
     assert!(scan.status.success());
     let scan_stdout = String::from_utf8_lossy(&scan.stdout);
-    assert!(scan_stdout.contains("Kratos scan complete."));
+    assert!(scan_stdout.contains("Kratos 스캔 완료."));
     assert!(scan_stdout.contains(
-        "Impact: 6 actionable findings: 1 broken import, 2 cleanup candidates, 3 dead exports."
+        "영향: 조치할 항목 6개: 깨진 import 1개, 정리 후보 2개, 사용되지 않는 export 3개."
     ));
-    assert!(scan_stdout.contains("Best next move: Fix broken imports before deleting files."));
-    assert!(scan_stdout.contains("Files scanned: 5"));
-    assert!(scan_stdout.contains("Broken imports: 1"));
-    assert!(scan_stdout.contains("Route entrypoints: 1"));
-    assert!(scan_stdout.contains("Deletion candidates: 2"));
-    assert!(scan_stdout.contains("Next steps:"));
-    assert!(scan_stdout.contains("Top cleanup candidates:"));
+    assert!(
+        scan_stdout.contains("다음 권장 작업: 파일을 삭제하기 전에 깨진 import를 먼저 수정하세요.")
+    );
+    assert!(scan_stdout.contains("스캔한 파일: 5"));
+    assert!(scan_stdout.contains("깨진 import: 1"));
+    assert!(scan_stdout.contains("라우트 진입점: 1"));
+    assert!(scan_stdout.contains("삭제 후보: 2"));
+    assert!(scan_stdout.contains("다음 단계:"));
+    assert!(scan_stdout.contains("상위 정리 후보:"));
     assert!(scan_stdout.contains("- src/components/DeadWidget.tsx"));
     assert!(report_path.exists());
 
@@ -55,11 +57,11 @@ fn scan_report_and_clean_work_for_demo_fixture() {
     ]);
     assert!(report.status.success());
     let report_stdout = String::from_utf8_lossy(&report.stdout);
-    assert!(report_stdout.contains("# Kratos Report"));
-    assert!(report_stdout.contains("## Impact"));
-    assert!(report_stdout.contains("- Route entrypoints: 1"));
-    assert!(report_stdout.contains("## Broken imports"));
-    assert!(report_stdout.contains("## Route entrypoints"));
+    assert!(report_stdout.contains("# Kratos 리포트"));
+    assert!(report_stdout.contains("## 영향"));
+    assert!(report_stdout.contains("- 라우트 진입점: 1"));
+    assert!(report_stdout.contains("## 깨진 import"));
+    assert!(report_stdout.contains("## 라우트 진입점"));
     assert!(report_stdout.contains("DeadWidget"));
 
     let clean = run_cli(&["clean", report_path.to_str().expect("path should be utf8")]);
@@ -192,7 +194,7 @@ fn unknown_flags_and_surplus_positionals_match_js_baseline() {
         ],
     );
     assert!(report.status.success());
-    assert!(String::from_utf8_lossy(&report.stdout).contains("Kratos report."));
+    assert!(String::from_utf8_lossy(&report.stdout).contains("Kratos 리포트."));
 
     let clean = run_cli_in_dir(&project_root, &["clean", "--bogus"]);
     assert!(clean.status.success());
@@ -302,7 +304,7 @@ fn report_json_accepts_arbitrary_json_and_empty_or_missing_format_falls_back_to_
         ],
     );
     assert!(bare_format.status.success());
-    assert!(String::from_utf8_lossy(&bare_format.stdout).contains("Kratos report."));
+    assert!(String::from_utf8_lossy(&bare_format.stdout).contains("Kratos 리포트."));
 
     let empty_inline_format = run_cli_in_dir(
         &project_root,
@@ -313,11 +315,11 @@ fn report_json_accepts_arbitrary_json_and_empty_or_missing_format_falls_back_to_
         ],
     );
     assert!(empty_inline_format.status.success());
-    assert!(String::from_utf8_lossy(&empty_inline_format.stdout).contains("Kratos report."));
+    assert!(String::from_utf8_lossy(&empty_inline_format.stdout).contains("Kratos 리포트."));
 }
 
 #[test]
-fn report_markdown_uses_undefined_for_missing_generated_at() {
+fn report_markdown_uses_korean_fallback_for_missing_generated_at() {
     let project_root = copy_demo_app("cli-report-md-missing-generated");
     let report_path = project_root.join("report-no-generated.json");
     std::fs::write(
@@ -337,7 +339,7 @@ fn report_markdown_uses_undefined_for_missing_generated_at() {
     );
 
     assert!(output.status.success());
-    assert!(String::from_utf8_lossy(&output.stdout).contains("- Generated: undefined"));
+    assert!(String::from_utf8_lossy(&output.stdout).contains("- 생성 시각: 정의되지 않음"));
 }
 
 #[test]
@@ -360,7 +362,7 @@ fn report_summary_and_markdown_accept_future_schema_versions() {
         ],
     );
     assert!(summary.status.success());
-    assert!(String::from_utf8_lossy(&summary.stdout).contains("Kratos report."));
+    assert!(String::from_utf8_lossy(&summary.stdout).contains("Kratos 리포트."));
 
     let markdown = run_cli_in_dir(
         &project_root,
@@ -372,15 +374,18 @@ fn report_summary_and_markdown_accept_future_schema_versions() {
         ],
     );
     assert!(markdown.status.success());
-    assert!(String::from_utf8_lossy(&markdown.stdout).contains("# Kratos Report"));
+    assert!(String::from_utf8_lossy(&markdown.stdout).contains("# Kratos 리포트"));
 }
 
 #[test]
 fn report_incomplete_future_schema_fails_fast() {
     let project_root = copy_demo_app("cli-report-incomplete-future-schema");
     let report_path = project_root.join("report-v3-min.json");
-    std::fs::write(&report_path, "{\"schemaVersion\":3,\"project\":{\"root\":\"/tmp/demo\"}}\n")
-        .expect("report should write");
+    std::fs::write(
+        &report_path,
+        "{\"schemaVersion\":3,\"project\":{\"root\":\"/tmp/demo\"}}\n",
+    )
+    .expect("report should write");
 
     let summary = run_cli_in_dir(
         &project_root,
@@ -425,10 +430,7 @@ fn clean_accepts_future_schema_reports_when_the_shape_is_compatible() {
 
     let dry_run = run_cli_in_dir(
         &project_root,
-        &[
-            "clean",
-            report_path.to_str().expect("path should be utf8"),
-        ],
+        &["clean", report_path.to_str().expect("path should be utf8")],
     );
     assert!(dry_run.status.success());
     let dry_run_stdout = String::from_utf8_lossy(&dry_run.stdout);
@@ -515,7 +517,7 @@ fn empty_inline_boolean_flags_stay_falsey_like_js() {
     );
     assert!(scan.status.success());
     let scan_stdout = String::from_utf8_lossy(&scan.stdout);
-    assert!(scan_stdout.contains("Kratos scan complete."));
+    assert!(scan_stdout.contains("Kratos 스캔 완료."));
     assert!(!scan_stdout.trim_start().starts_with('{'));
 
     let prepare_report = run_cli_in_dir(&project_root, &["scan"]);

--- a/crates/kratos-core/src/report_format.rs
+++ b/crates/kratos-core/src/report_format.rs
@@ -11,60 +11,57 @@ pub fn format_summary_report(
 ) -> KratosResult<String> {
     let impact = impact_summary(report);
     let mut lines = vec![
-        title.to_string(),
+        display_title(title).to_string(),
         String::new(),
-        format!("Impact: {}", impact.headline),
-        format!("Best next move: {}", impact.best_next_move),
+        format!("영향: {}", impact.headline),
+        format!("다음 권장 작업: {}", impact.best_next_move),
         String::new(),
-        format!("Root: {}", path_to_string(&report.root)),
-        format!("Files scanned: {}", report.summary.files_scanned),
-        format!("Entrypoints: {}", report.summary.entrypoints),
-        format!("Broken imports: {}", report.summary.broken_imports),
-        format!("Orphan files: {}", report.summary.orphan_files),
-        format!("Dead exports: {}", report.summary.dead_exports),
-        format!("Unused imports: {}", report.summary.unused_imports),
-        format!("Route entrypoints: {}", report.summary.route_entrypoints),
-        format!(
-            "Deletion candidates: {}",
-            report.summary.deletion_candidates
-        ),
+        format!("루트: {}", path_to_string(&report.root)),
+        format!("스캔한 파일: {}", report.summary.files_scanned),
+        format!("진입점: {}", report.summary.entrypoints),
+        format!("깨진 import: {}", report.summary.broken_imports),
+        format!("고아 파일: {}", report.summary.orphan_files),
+        format!("사용되지 않는 export: {}", report.summary.dead_exports),
+        format!("사용되지 않는 import: {}", report.summary.unused_imports),
+        format!("라우트 진입점: {}", report.summary.route_entrypoints),
+        format!("삭제 후보: {}", report.summary.deletion_candidates),
     ];
     if report.summary.suppressed_findings > 0 {
         lines.push(format!(
-            "Suppressed findings: {}",
+            "숨김 처리된 항목: {}",
             report.summary.suppressed_findings
         ));
     }
     lines.push(String::new());
-    lines.push(format!("Saved report: {}", path_to_string(report_path)));
+    lines.push(format!("저장된 리포트: {}", path_to_string(report_path)));
     append_next_steps(&mut lines, report, report_path);
 
     append_preview(
         &mut lines,
-        "Broken imports",
+        "깨진 import",
         &report.findings.broken_imports,
         |item| format!("{} -> {}", display_path(report, &item.file), item.source),
     );
     append_deletion_preview(&mut lines, report);
     append_preview(
         &mut lines,
-        "Orphan files",
+        "고아 파일",
         &report.findings.orphan_files,
         |item| display_path(report, &item.file),
     );
     append_preview(
         &mut lines,
-        "Dead exports",
+        "사용되지 않는 export",
         &report.findings.dead_exports,
         |item| format!("{}#{}", display_path(report, &item.file), item.export_name),
     );
     append_preview(
         &mut lines,
-        "Unused imports",
+        "사용되지 않는 import",
         &report.findings.unused_imports,
         |item| {
             format!(
-                "{} -> {} from {}",
+                "{} -> {} (출처: {})",
                 display_path(report, &item.file),
                 item.local,
                 item.source
@@ -73,7 +70,7 @@ pub fn format_summary_report(
     );
     append_preview(
         &mut lines,
-        "Route entrypoints",
+        "라우트 진입점",
         &report.findings.route_entrypoints,
         |item| {
             format!(
@@ -89,34 +86,31 @@ pub fn format_summary_report(
 
 pub fn format_markdown_report(report: &ReportV2, report_path: &Path) -> KratosResult<String> {
     let mut lines = vec![
-        "# Kratos Report".to_string(),
+        "# Kratos 리포트".to_string(),
         String::new(),
         format!("> {}", impact_summary(report).headline),
         String::new(),
         format!(
-            "- Generated: {}",
-            report.generated_at.as_deref().unwrap_or("undefined")
+            "- 생성 시각: {}",
+            report.generated_at.as_deref().unwrap_or("정의되지 않음")
         ),
-        format!("- Root: {}", path_to_string(&report.root)),
-        format!("- Report: {}", path_to_string(report_path)),
+        format!("- 루트: {}", path_to_string(&report.root)),
+        format!("- 리포트: {}", path_to_string(report_path)),
         String::new(),
-        "## Summary".to_string(),
+        "## 요약".to_string(),
         String::new(),
-        format!("- Files scanned: {}", report.summary.files_scanned),
-        format!("- Entrypoints: {}", report.summary.entrypoints),
-        format!("- Broken imports: {}", report.summary.broken_imports),
-        format!("- Orphan files: {}", report.summary.orphan_files),
-        format!("- Dead exports: {}", report.summary.dead_exports),
-        format!("- Unused imports: {}", report.summary.unused_imports),
-        format!("- Route entrypoints: {}", report.summary.route_entrypoints),
-        format!(
-            "- Deletion candidates: {}",
-            report.summary.deletion_candidates
-        ),
+        format!("- 스캔한 파일: {}", report.summary.files_scanned),
+        format!("- 진입점: {}", report.summary.entrypoints),
+        format!("- 깨진 import: {}", report.summary.broken_imports),
+        format!("- 고아 파일: {}", report.summary.orphan_files),
+        format!("- 사용되지 않는 export: {}", report.summary.dead_exports),
+        format!("- 사용되지 않는 import: {}", report.summary.unused_imports),
+        format!("- 라우트 진입점: {}", report.summary.route_entrypoints),
+        format!("- 삭제 후보: {}", report.summary.deletion_candidates),
     ];
     if report.summary.suppressed_findings > 0 {
         lines.push(format!(
-            "- Suppressed findings: {}",
+            "- 숨김 처리된 항목: {}",
             report.summary.suppressed_findings
         ));
     }
@@ -125,19 +119,25 @@ pub fn format_markdown_report(report: &ReportV2, report_path: &Path) -> KratosRe
     push_markdown_impact(&mut lines, report, report_path);
     push_markdown_section(
         &mut lines,
-        "Broken imports",
+        "깨진 import",
         &report.findings.broken_imports,
         |item| format!("{} -> `{}`", display_path(report, &item.file), item.source),
     );
     push_markdown_section(
         &mut lines,
-        "Orphan files",
+        "고아 파일",
         &report.findings.orphan_files,
-        |item| format!("{} ({})", display_path(report, &item.file), item.reason),
+        |item| {
+            format!(
+                "{} ({})",
+                display_path(report, &item.file),
+                display_known_reason(&item.reason)
+            )
+        },
     );
     push_markdown_section(
         &mut lines,
-        "Dead exports",
+        "사용되지 않는 export",
         &report.findings.dead_exports,
         |item| {
             format!(
@@ -149,11 +149,11 @@ pub fn format_markdown_report(report: &ReportV2, report_path: &Path) -> KratosRe
     );
     push_markdown_section(
         &mut lines,
-        "Unused imports",
+        "사용되지 않는 import",
         &report.findings.unused_imports,
         |item| {
             format!(
-                "{} -> `{}` from `{}`",
+                "{} -> `{}` (출처: `{}`)",
                 display_path(report, &item.file),
                 item.local,
                 item.source
@@ -162,7 +162,7 @@ pub fn format_markdown_report(report: &ReportV2, report_path: &Path) -> KratosRe
     );
     push_markdown_section(
         &mut lines,
-        "Route entrypoints",
+        "라우트 진입점",
         &report.findings.route_entrypoints,
         |item| {
             format!(
@@ -174,13 +174,13 @@ pub fn format_markdown_report(report: &ReportV2, report_path: &Path) -> KratosRe
     );
     push_markdown_section(
         &mut lines,
-        "Deletion candidates",
+        "삭제 후보",
         &report.findings.deletion_candidates,
         |item| {
             format!(
-                "{} ({}, confidence {})",
+                "{} ({}, 신뢰도 {})",
                 display_path(report, &item.file),
-                item.reason,
+                display_known_reason(&item.reason),
                 item.confidence
             )
         },
@@ -203,53 +203,37 @@ fn impact_summary(report: &ReportV2) -> ImpactSummary {
 
     let headline = if actionable_total == 0 {
         format!(
-            "No actionable findings across {}.",
-            plural(
-                report.summary.files_scanned,
-                "scanned file",
-                "scanned files"
-            )
+            "스캔한 파일 {}개에서 조치할 항목이 없습니다.",
+            report.summary.files_scanned
         )
     } else {
         let mut parts = Vec::new();
         if breakages > 0 {
-            parts.push(plural(breakages, "broken import", "broken imports"));
+            parts.push(count_label(breakages, "깨진 import"));
         }
         if cleanup_candidates > 0 {
-            parts.push(plural(
-                cleanup_candidates,
-                "cleanup candidate",
-                "cleanup candidates",
-            ));
+            parts.push(count_label(cleanup_candidates, "정리 후보"));
         }
         if dead_exports > 0 {
-            parts.push(plural(dead_exports, "dead export", "dead exports"));
+            parts.push(count_label(dead_exports, "사용되지 않는 export"));
         }
         if unused_imports > 0 {
-            parts.push(plural(unused_imports, "unused import", "unused imports"));
+            parts.push(count_label(unused_imports, "사용되지 않는 import"));
         }
 
-        format!(
-            "{}: {}.",
-            plural(
-                actionable_total,
-                "actionable finding",
-                "actionable findings"
-            ),
-            parts.join(", ")
-        )
+        format!("조치할 항목 {}개: {}.", actionable_total, parts.join(", "))
     };
 
     let best_next_move = if breakages > 0 {
-        "Fix broken imports before deleting files.".to_string()
+        "파일을 삭제하기 전에 깨진 import를 먼저 수정하세요.".to_string()
     } else if cleanup_candidates > 0 {
-        "Run the clean preview and remove high-confidence dead files.".to_string()
+        "정리 미리보기를 실행하고 신뢰도 높은 미사용 파일을 제거하세요.".to_string()
     } else if dead_exports > 0 {
-        "Prune dead exports or confirm they are intentionally public API.".to_string()
+        "사용되지 않는 export를 제거하거나 의도된 공개 API인지 확인하세요.".to_string()
     } else if unused_imports > 0 {
-        "Remove unused imports to shrink noisy dependencies.".to_string()
+        "사용되지 않는 import를 제거해 불필요한 의존성을 줄이세요.".to_string()
     } else {
-        "Keep the JSON report as a baseline for future diffs.".to_string()
+        "향후 diff 기준선으로 JSON 리포트를 보관하세요.".to_string()
     };
 
     ImpactSummary {
@@ -258,25 +242,21 @@ fn impact_summary(report: &ReportV2) -> ImpactSummary {
     }
 }
 
-fn plural(count: usize, singular: &str, plural: &str) -> String {
-    if count == 1 {
-        format!("1 {singular}")
-    } else {
-        format!("{count} {plural}")
-    }
+fn count_label(count: usize, label: &str) -> String {
+    format!("{label} {count}개")
 }
 
 fn append_next_steps(lines: &mut Vec<String>, report: &ReportV2, report_path: &Path) {
     let report_arg = shell_arg(report_path);
 
     lines.push(String::new());
-    lines.push("Next steps:".to_string());
+    lines.push("다음 단계:".to_string());
 
     if report.summary.deletion_candidates > 0 {
-        lines.push(format!("- Preview cleanup: kratos clean {report_arg}"));
+        lines.push(format!("- 정리 미리보기: kratos clean {report_arg}"));
     }
     lines.push(format!(
-        "- Shareable markdown: kratos report {report_arg} --format md"
+        "- 공유용 Markdown: kratos report {report_arg} --format md"
     ));
 }
 
@@ -284,15 +264,15 @@ fn push_markdown_impact(lines: &mut Vec<String>, report: &ReportV2, report_path:
     let impact = impact_summary(report);
     let report_arg = shell_arg(report_path);
 
-    lines.push("## Impact".to_string());
+    lines.push("## 영향".to_string());
     lines.push(String::new());
     lines.push(format!("- {}", impact.headline));
-    lines.push(format!("- Best next move: {}", impact.best_next_move));
+    lines.push(format!("- 다음 권장 작업: {}", impact.best_next_move));
     if report.summary.deletion_candidates > 0 {
-        lines.push(format!("- Preview cleanup: `kratos clean {report_arg}`"));
+        lines.push(format!("- 정리 미리보기: `kratos clean {report_arg}`"));
     }
     lines.push(format!(
-        "- Refresh markdown: `kratos report {report_arg} --format md`"
+        "- Markdown 갱신: `kratos report {report_arg} --format md`"
     ));
     lines.push(String::new());
 }
@@ -303,20 +283,20 @@ fn append_deletion_preview(lines: &mut Vec<String>, report: &ReportV2) {
     }
 
     lines.push(String::new());
-    lines.push("Top cleanup candidates:".to_string());
+    lines.push("상위 정리 후보:".to_string());
 
     for item in report.findings.deletion_candidates.iter().take(5) {
         lines.push(format!(
-            "- {} (confidence {}, {})",
+            "- {} (신뢰도 {}, {})",
             display_path(report, &item.file),
             item.confidence,
-            item.reason
+            display_known_reason(&item.reason)
         ));
     }
 
     if report.findings.deletion_candidates.len() > 5 {
         lines.push(format!(
-            "- ...and {} more",
+            "- ...외 {}개",
             report.findings.deletion_candidates.len() - 5
         ));
     }
@@ -359,7 +339,7 @@ fn append_preview<T>(
     }
 
     if items.len() > 5 {
-        lines.push(format!("- ...and {} more", items.len() - 5));
+        lines.push(format!("- ...외 {}개", items.len() - 5));
     }
 }
 
@@ -373,7 +353,7 @@ fn push_markdown_section<T>(
     lines.push(String::new());
 
     if items.is_empty() {
-        lines.push("- None".to_string());
+        lines.push("- 없음".to_string());
         lines.push(String::new());
         return;
     }
@@ -383,4 +363,27 @@ fn push_markdown_section<T>(
     }
 
     lines.push(String::new());
+}
+
+fn display_title(title: &str) -> &str {
+    match title {
+        "Kratos scan complete." => "Kratos 스캔 완료.",
+        "Kratos report." => "Kratos 리포트.",
+        other => other,
+    }
+}
+
+pub fn display_known_reason(reason: &str) -> &str {
+    match reason {
+        "Component-like module has no inbound references." => {
+            "컴포넌트로 보이는 모듈에 참조가 없습니다."
+        }
+        "Route-like module is not connected to any router entry." => {
+            "라우트로 보이는 모듈이 어떤 라우터 진입점에도 연결되지 않았습니다."
+        }
+        "Module has no inbound references and is not treated as an entrypoint." => {
+            "모듈에 참조가 없고 진입점으로 취급되지 않습니다."
+        }
+        other => other,
+    }
 }

--- a/crates/kratos-core/tests/report_format.rs
+++ b/crates/kratos-core/tests/report_format.rs
@@ -14,13 +14,13 @@ fn summary_formatter_allows_custom_titles_without_changing_body_shape() {
     let rendered = format_summary_report(&report, &report_path, "Kratos scan complete.")
         .expect("summary should format");
 
-    assert!(rendered.starts_with("Kratos scan complete.\n\n"));
-    assert!(rendered.contains(&format!("Saved report: {}", report_path.display())));
-    assert!(rendered.contains("Broken imports:"));
+    assert!(rendered.starts_with("Kratos 스캔 완료.\n\n"));
+    assert!(rendered.contains(&format!("저장된 리포트: {}", report_path.display())));
+    assert!(rendered.contains("깨진 import:"));
 }
 
 #[test]
-fn markdown_formatter_uses_undefined_when_generated_at_is_missing() {
+fn markdown_formatter_uses_korean_fallback_when_generated_at_is_missing() {
     let report = parse_report_json(
         "{\"schemaVersion\":2,\"project\":{\"root\":\"/tmp/demo\",\"configPath\":null},\"summary\":{\"filesScanned\":0,\"entrypoints\":0,\"brokenImports\":0,\"orphanFiles\":0,\"deadExports\":0,\"unusedImports\":0,\"routeEntrypoints\":0,\"deletionCandidates\":0},\"findings\":{\"brokenImports\":[],\"orphanFiles\":[],\"deadExports\":[],\"unusedImports\":[],\"routeEntrypoints\":[],\"deletionCandidates\":[]},\"graph\":{\"modules\":[]}}",
     )
@@ -29,7 +29,7 @@ fn markdown_formatter_uses_undefined_when_generated_at_is_missing() {
     let rendered = format_markdown_report(&report, Path::new("/tmp/demo/report.json"))
         .expect("markdown should format");
 
-    assert!(rendered.contains("- Generated: undefined"));
+    assert!(rendered.contains("- 생성 시각: 정의되지 않음"));
 }
 
 #[test]
@@ -39,15 +39,19 @@ fn summary_and_markdown_formatters_accept_future_schema_versions() {
     )
     .expect("future-schema report should parse");
 
-    let summary = format_summary_report(&report, Path::new("/tmp/demo/report.json"), "Kratos report.")
-        .expect("summary should format");
+    let summary = format_summary_report(
+        &report,
+        Path::new("/tmp/demo/report.json"),
+        "Kratos report.",
+    )
+    .expect("summary should format");
     let markdown = format_markdown_report(&report, Path::new("/tmp/demo/report.json"))
         .expect("markdown should format");
 
-    assert!(summary.contains("Kratos report."));
-    assert!(summary.contains("Saved report: /tmp/demo/report.json"));
-    assert!(markdown.contains("# Kratos Report"));
-    assert!(markdown.contains("- Report: /tmp/demo/report.json"));
+    assert!(summary.contains("Kratos 리포트."));
+    assert!(summary.contains("저장된 리포트: /tmp/demo/report.json"));
+    assert!(markdown.contains("# Kratos 리포트"));
+    assert!(markdown.contains("- 리포트: /tmp/demo/report.json"));
 }
 
 #[test]

--- a/crates/kratos-core/tests/suppressions.rs
+++ b/crates/kratos-core/tests/suppressions.rs
@@ -243,8 +243,8 @@ fn analyze_project_surfaces_suppressed_findings_in_summary_and_formatters() {
     assert_eq!(report.findings.deletion_candidates.len(), 0);
     assert_eq!(report.summary.suppressed_findings, 3);
     assert_eq!(parsed.summary.suppressed_findings, 3);
-    assert!(summary.contains("Suppressed findings: 3"));
-    assert!(markdown.contains("- Suppressed findings: 3"));
+    assert!(summary.contains("숨김 처리된 항목: 3"));
+    assert!(markdown.contains("- 숨김 처리된 항목: 3"));
     assert!(
         serialized.contains("\"suppressedFindings\": 3"),
         "expected optional suppressed findings field in serialized report"

--- a/fixtures/parity/demo-app/report-markdown.md
+++ b/fixtures/parity/demo-app/report-markdown.md
@@ -1,53 +1,53 @@
-# Kratos Report
+# Kratos 리포트
 
-> 6 actionable findings: 1 broken import, 2 cleanup candidates, 3 dead exports.
+> 조치할 항목 6개: 깨진 import 1개, 정리 후보 2개, 사용되지 않는 export 3개.
 
-- Generated: <GENERATED_AT>
-- Root: <ROOT>
-- Report: <REPORT>
+- 생성 시각: <GENERATED_AT>
+- 루트: <ROOT>
+- 리포트: <REPORT>
 
-## Summary
+## 요약
 
-- Files scanned: 5
-- Entrypoints: 1
-- Broken imports: 1
-- Orphan files: 2
-- Dead exports: 3
-- Unused imports: 0
-- Route entrypoints: 1
-- Deletion candidates: 2
+- 스캔한 파일: 5
+- 진입점: 1
+- 깨진 import: 1
+- 고아 파일: 2
+- 사용되지 않는 export: 3
+- 사용되지 않는 import: 0
+- 라우트 진입점: 1
+- 삭제 후보: 2
 
-## Impact
+## 영향
 
-- 6 actionable findings: 1 broken import, 2 cleanup candidates, 3 dead exports.
-- Best next move: Fix broken imports before deleting files.
-- Preview cleanup: `kratos clean <REPORT>`
-- Refresh markdown: `kratos report <REPORT> --format md`
+- 조치할 항목 6개: 깨진 import 1개, 정리 후보 2개, 사용되지 않는 export 3개.
+- 다음 권장 작업: 파일을 삭제하기 전에 깨진 import를 먼저 수정하세요.
+- 정리 미리보기: `kratos clean <REPORT>`
+- Markdown 갱신: `kratos report <REPORT> --format md`
 
-## Broken imports
+## 깨진 import
 
 - src/lib/broken.ts -> `./missing-helper`
 
-## Orphan files
+## 고아 파일
 
-- src/components/DeadWidget.tsx (Component-like module has no inbound references.)
-- src/lib/broken.ts (Module has no inbound references and is not treated as an entrypoint.)
+- src/components/DeadWidget.tsx (컴포넌트로 보이는 모듈에 참조가 없습니다.)
+- src/lib/broken.ts (모듈에 참조가 없고 진입점으로 취급되지 않습니다.)
 
-## Dead exports
+## 사용되지 않는 export
 
 - src/components/DeadWidget.tsx -> `DeadWidget`
 - src/lib/broken.ts -> `brokenFeature`
 - src/lib/math.ts -> `multiply`
 
-## Unused imports
+## 사용되지 않는 import
 
-- None
+- 없음
 
-## Route entrypoints
+## 라우트 진입점
 
 - pages/home.tsx (next-pages-route)
 
-## Deletion candidates
+## 삭제 후보
 
-- src/components/DeadWidget.tsx (Component-like module has no inbound references., confidence 0.92)
-- src/lib/broken.ts (Module has no inbound references and is not treated as an entrypoint., confidence 0.88)
+- src/components/DeadWidget.tsx (컴포넌트로 보이는 모듈에 참조가 없습니다., 신뢰도 0.92)
+- src/lib/broken.ts (모듈에 참조가 없고 진입점으로 취급되지 않습니다., 신뢰도 0.88)

--- a/fixtures/parity/demo-app/report-summary.txt
+++ b/fixtures/parity/demo-app/report-summary.txt
@@ -1,39 +1,39 @@
-Kratos report.
+Kratos 리포트.
 
-Impact: 6 actionable findings: 1 broken import, 2 cleanup candidates, 3 dead exports.
-Best next move: Fix broken imports before deleting files.
+영향: 조치할 항목 6개: 깨진 import 1개, 정리 후보 2개, 사용되지 않는 export 3개.
+다음 권장 작업: 파일을 삭제하기 전에 깨진 import를 먼저 수정하세요.
 
-Root: <ROOT>
-Files scanned: 5
-Entrypoints: 1
-Broken imports: 1
-Orphan files: 2
-Dead exports: 3
-Unused imports: 0
-Route entrypoints: 1
-Deletion candidates: 2
+루트: <ROOT>
+스캔한 파일: 5
+진입점: 1
+깨진 import: 1
+고아 파일: 2
+사용되지 않는 export: 3
+사용되지 않는 import: 0
+라우트 진입점: 1
+삭제 후보: 2
 
-Saved report: <REPORT>
+저장된 리포트: <REPORT>
 
-Next steps:
-- Preview cleanup: kratos clean <REPORT>
-- Shareable markdown: kratos report <REPORT> --format md
+다음 단계:
+- 정리 미리보기: kratos clean <REPORT>
+- 공유용 Markdown: kratos report <REPORT> --format md
 
-Broken imports:
+깨진 import:
 - src/lib/broken.ts -> ./missing-helper
 
-Top cleanup candidates:
-- src/components/DeadWidget.tsx (confidence 0.92, Component-like module has no inbound references.)
-- src/lib/broken.ts (confidence 0.88, Module has no inbound references and is not treated as an entrypoint.)
+상위 정리 후보:
+- src/components/DeadWidget.tsx (신뢰도 0.92, 컴포넌트로 보이는 모듈에 참조가 없습니다.)
+- src/lib/broken.ts (신뢰도 0.88, 모듈에 참조가 없고 진입점으로 취급되지 않습니다.)
 
-Orphan files:
+고아 파일:
 - src/components/DeadWidget.tsx
 - src/lib/broken.ts
 
-Dead exports:
+사용되지 않는 export:
 - src/components/DeadWidget.tsx#DeadWidget
 - src/lib/broken.ts#brokenFeature
 - src/lib/math.ts#multiply
 
-Route entrypoints:
+라우트 진입점:
 - pages/home.tsx (next-pages-route)


### PR DESCRIPTION
## 배경

`scan`과 `report --format summary|md`의 사람이 읽는 report 결과물을 한국어 기본 출력으로 전환합니다.

## 변경 사항

- summary/Markdown 제목, 라벨, 영향 요약, 다음 권장 작업을 한국어로 변경
- 저장 JSON의 `reason` 값은 유지하고, formatter 표시 단계에서만 known reason을 한국어로 변환
- 누락된 생성 시각 fallback을 `정의되지 않음`으로 변경
- report parity fixture와 core/CLI 테스트 기대값 갱신

## 검증

- `cargo test -p kratos-core --test report_format`
- `cargo test -p kratos-core --test suppressions`
- `cargo test -p kratos-cli --test cli_smoke`
- `cargo test -p kratos-core --test report_v2`
- `rustfmt --edition 2021 --check crates/kratos-core/src/report_format.rs crates/kratos-core/tests/report_format.rs crates/kratos-core/tests/suppressions.rs crates/kratos-cli/tests/cli_smoke.rs`
- `git diff --check`
- `$devils-advocate-review-loop` delta review: Critical/High/Medium/Low 없음

## 브랜치 / 워크트리

- Branch: `feature/64-report-ko-output`
- Worktree: `/private/tmp/kratos-ko-output-wave1/issue-64`

## 이슈 연결

Closes #64
