### PR TITLE
feat(diff): diff 사람용 출력을 한국어로 전환

### DIFF
--- a/crates/kratos-cli/tests/diff_cli.rs
+++ b/crates/kratos-cli/tests/diff_cli.rs
@@ -30,12 +30,12 @@ fn diff_accepts_project_roots_and_report_paths() {
 
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("# Kratos Diff"));
-    assert!(stdout.contains(&format!("Before: {}", before_report_path.display())));
-    assert!(stdout.contains(&format!("After: {}", after_report_path.display())));
-    assert!(stdout.contains("## Broken imports"));
-    assert!(stdout.contains("### Introduced (1)"));
-    assert!(stdout.contains("### Resolved (1)"));
+    assert!(stdout.contains("# Kratos Diff 결과"));
+    assert!(stdout.contains(&format!("이전: {}", before_report_path.display())));
+    assert!(stdout.contains(&format!("이후: {}", after_report_path.display())));
+    assert!(stdout.contains("## 깨진 import"));
+    assert!(stdout.contains("### 새로 발생 (1)"));
+    assert!(stdout.contains("### 해결됨 (1)"));
     assert!(stdout.contains("./missing-b"));
 }
 
@@ -60,9 +60,9 @@ fn diff_defaults_to_summary_and_rejects_invalid_format() {
     );
     assert!(summary_output.status.success());
     let stdout = String::from_utf8_lossy(&summary_output.stdout);
-    assert!(stdout.contains("Kratos diff complete."));
-    assert!(stdout.contains("Broken imports: introduced 1, resolved 1, persisted 1"));
-    assert!(stdout.contains("Totals: introduced 1, resolved 1, persisted 1"));
+    assert!(stdout.contains("Kratos diff 완료."));
+    assert!(stdout.contains("깨진 import: 새로 발생 1, 해결됨 1, 유지됨 1"));
+    assert!(stdout.contains("합계: 새로 발생 1, 해결됨 1, 유지됨 1"));
 
     let invalid_output = run_cli_in_dir(
         &before_root,

--- a/crates/kratos-core/src/report_diff.rs
+++ b/crates/kratos-core/src/report_diff.rs
@@ -129,41 +129,38 @@ pub fn format_diff_summary(
     after_report_path: &Path,
 ) -> KratosResult<String> {
     let mut lines = vec![
-        "Kratos diff complete.".to_string(),
+        "Kratos diff 완료.".to_string(),
         String::new(),
-        format!("Before: {}", path_to_string(before_report_path)),
-        format!("After: {}", path_to_string(after_report_path)),
+        format!("이전: {}", path_to_string(before_report_path)),
+        format!("이후: {}", path_to_string(after_report_path)),
         String::new(),
     ];
 
     lines.extend(render_summary_line(
-        "Broken imports",
+        "깨진 import",
         &diff.summary.broken_imports,
     ));
+    lines.extend(render_summary_line("고아 파일", &diff.summary.orphan_files));
     lines.extend(render_summary_line(
-        "Orphan files",
-        &diff.summary.orphan_files,
-    ));
-    lines.extend(render_summary_line(
-        "Dead exports",
+        "사용되지 않는 export",
         &diff.summary.dead_exports,
     ));
     lines.extend(render_summary_line(
-        "Unused imports",
+        "사용되지 않는 import",
         &diff.summary.unused_imports,
     ));
     lines.extend(render_summary_line(
-        "Route entrypoints",
+        "라우트 진입점",
         &diff.summary.route_entrypoints,
     ));
     lines.extend(render_summary_line(
-        "Deletion candidates",
+        "삭제 후보",
         &diff.summary.deletion_candidates,
     ));
 
     lines.push(String::new());
     lines.push(format!(
-        "Totals: introduced {}, resolved {}, persisted {}",
+        "합계: 새로 발생 {}, 해결됨 {}, 유지됨 {}",
         diff.summary.totals.introduced, diff.summary.totals.resolved, diff.summary.totals.persisted
     ));
 
@@ -171,7 +168,7 @@ pub fn format_diff_summary(
         && diff.summary.totals.resolved == 0
         && diff.summary.totals.persisted == 0
     {
-        lines.push("No finding changes.".to_string());
+        lines.push("변경된 항목이 없습니다.".to_string());
     }
 
     Ok(lines.join("\n"))
@@ -183,22 +180,22 @@ pub fn format_diff_markdown(
     after_report_path: &Path,
 ) -> KratosResult<String> {
     let mut lines = vec![
-        "# Kratos Diff".to_string(),
+        "# Kratos Diff 결과".to_string(),
         String::new(),
-        format!("- Before: {}", path_to_string(before_report_path)),
-        format!("- After: {}", path_to_string(after_report_path)),
+        format!("- 이전: {}", path_to_string(before_report_path)),
+        format!("- 이후: {}", path_to_string(after_report_path)),
         String::new(),
     ];
 
     push_markdown_finding_diff(
         &mut lines,
-        "Broken imports",
+        "깨진 import",
         &diff.findings.broken_imports,
         |item| format!("{} -> `{}`", path_to_string(&item.file), item.source),
     );
     push_markdown_finding_diff(
         &mut lines,
-        "Orphan files",
+        "고아 파일",
         &diff.findings.orphan_files,
         |item| {
             format!(
@@ -210,17 +207,17 @@ pub fn format_diff_markdown(
     );
     push_markdown_finding_diff(
         &mut lines,
-        "Dead exports",
+        "사용되지 않는 export",
         &diff.findings.dead_exports,
         |item| format!("{} -> `{}`", path_to_string(&item.file), item.export_name),
     );
     push_markdown_finding_diff(
         &mut lines,
-        "Unused imports",
+        "사용되지 않는 import",
         &diff.findings.unused_imports,
         |item| {
             format!(
-                "{} -> `{}` from `{}`",
+                "{} -> `{}` (출처: `{}`)",
                 path_to_string(&item.file),
                 item.local,
                 item.source
@@ -229,7 +226,7 @@ pub fn format_diff_markdown(
     );
     push_markdown_finding_diff(
         &mut lines,
-        "Route entrypoints",
+        "라우트 진입점",
         &diff.findings.route_entrypoints,
         |item| {
             format!(
@@ -241,13 +238,13 @@ pub fn format_diff_markdown(
     );
     push_markdown_finding_diff(
         &mut lines,
-        "Deletion candidates",
+        "삭제 후보",
         &diff.findings.deletion_candidates,
         |item| {
             format!(
-                "{} ({}, confidence {})",
+                "{} ({}, 신뢰도 {})",
                 path_to_string(&item.file),
-                item.reason,
+                display_known_reason(&item.reason),
                 item.confidence
             )
         },
@@ -360,9 +357,24 @@ fn all_group_keys<T>(
         .collect()
 }
 
+fn display_known_reason(reason: &str) -> &str {
+    match reason {
+        "Component-like module has no inbound references." => {
+            "컴포넌트로 보이는 모듈에 참조가 없습니다."
+        }
+        "Route-like module is not connected to any router entry." => {
+            "라우트로 보이는 모듈이 어떤 라우터 진입점에도 연결되지 않았습니다."
+        }
+        "Module has no inbound references and is not treated as an entrypoint." => {
+            "모듈에 참조가 없고 진입점으로 취급되지 않습니다."
+        }
+        other => other,
+    }
+}
+
 fn render_summary_line(label: &str, counts: &FindingDiffCounts) -> Vec<String> {
     vec![format!(
-        "{label}: introduced {}, resolved {}, persisted {}",
+        "{label}: 새로 발생 {}, 해결됨 {}, 유지됨 {}",
         counts.introduced, counts.resolved, counts.persisted
     )]
 }
@@ -380,9 +392,9 @@ fn push_markdown_finding_diff<T>(
     lines.push(format!("## {title}"));
     lines.push(String::new());
 
-    push_markdown_change_group(lines, "Introduced", &diff.introduced, &render);
-    push_markdown_change_group(lines, "Resolved", &diff.resolved, &render);
-    push_markdown_change_group(lines, "Persisted", &diff.persisted, &render);
+    push_markdown_change_group(lines, "새로 발생", &diff.introduced, &render);
+    push_markdown_change_group(lines, "해결됨", &diff.resolved, &render);
+    push_markdown_change_group(lines, "유지됨", &diff.persisted, &render);
 }
 
 fn push_markdown_change_group<T>(
@@ -394,7 +406,7 @@ fn push_markdown_change_group<T>(
     lines.push(format!("### {label} ({})", items.len()));
 
     if items.is_empty() {
-        lines.push("- None".to_string());
+        lines.push("- 없음".to_string());
         lines.push(String::new());
         return;
     }
@@ -510,7 +522,11 @@ fn orphan_file_key(item: &OrphanFileFinding, report_root: &Path) -> String {
 }
 
 fn dead_export_key(item: &DeadExportFinding, report_root: &Path) -> String {
-    format!("{}|{}", finding_file_key(&item.file, report_root), item.export_name)
+    format!(
+        "{}|{}",
+        finding_file_key(&item.file, report_root),
+        item.export_name
+    )
 }
 
 fn unused_import_key(item: &UnusedImportFinding, report_root: &Path) -> String {

--- a/crates/kratos-core/tests/report_diff.rs
+++ b/crates/kratos-core/tests/report_diff.rs
@@ -175,18 +175,19 @@ fn diff_formatters_render_summary_markdown_and_json() {
 
     let summary =
         format_diff_summary(&diff, &before_path, &after_path).expect("summary should format");
-    assert!(summary.contains("Kratos diff complete."));
-    assert!(summary.contains("Before: /tmp/before-report.json"));
-    assert!(summary.contains("Broken imports: introduced 1, resolved 1, persisted 0"));
-    assert!(summary.contains("Totals: introduced 1, resolved 1, persisted 0"));
+    assert!(summary.contains("Kratos diff 완료."));
+    assert!(summary.contains("이전: /tmp/before-report.json"));
+    assert!(summary.contains("깨진 import: 새로 발생 1, 해결됨 1, 유지됨 0"));
+    assert!(summary.contains("합계: 새로 발생 1, 해결됨 1, 유지됨 0"));
 
     let markdown =
         format_diff_markdown(&diff, &before_path, &after_path).expect("markdown should format");
-    assert!(markdown.contains("# Kratos Diff"));
-    assert!(markdown.contains("## Broken imports"));
-    assert!(markdown.contains("### Introduced (1)"));
-    assert!(markdown.contains("### Resolved (1)"));
-    assert!(markdown.contains("### Persisted (0)"));
+    assert!(markdown.contains("# Kratos Diff 결과"));
+    assert!(markdown.contains("## 깨진 import"));
+    assert!(markdown.contains("### 새로 발생 (1)"));
+    assert!(markdown.contains("### 해결됨 (1)"));
+    assert!(markdown.contains("### 유지됨 (0)"));
+    assert!(markdown.contains("- 없음"));
 
     let json = format_diff_json(&diff, &before_path, &after_path).expect("json should format");
     let value: Value = serde_json::from_str(&json).expect("diff json should parse");
@@ -206,6 +207,73 @@ fn diff_formatters_render_summary_markdown_and_json() {
         value["findings"]["brokenImports"]["introduced"][0]["file"],
         Value::from("/repo/src/b.ts")
     );
+}
+
+#[test]
+fn diff_formatters_keep_human_markdown_labels_in_korean() {
+    let empty_report = report_v2(
+        "/repo/empty",
+        None,
+        None,
+        SummaryCounts::default(),
+        finding_set(vec![], vec![], vec![], vec![], vec![], vec![]),
+        vec![],
+    );
+    let empty_diff = diff_reports(&empty_report, &empty_report);
+    let before_path = PathBuf::from("/tmp/before-report.json");
+    let after_path = PathBuf::from("/tmp/after-report.json");
+    let empty_summary = format_diff_summary(&empty_diff, &before_path, &after_path)
+        .expect("empty summary should format");
+    assert!(empty_summary.contains("변경된 항목이 없습니다."));
+
+    let before = report_v2(
+        "/repo/before",
+        None,
+        None,
+        SummaryCounts::default(),
+        finding_set(vec![], vec![], vec![], vec![], vec![], vec![]),
+        vec![],
+    );
+    let after = report_v2(
+        "/repo/after",
+        None,
+        None,
+        SummaryCounts::default(),
+        finding_set(
+            vec![],
+            vec![],
+            vec![],
+            vec![unused_import(
+                "/repo/after/src/use.ts",
+                "./lib",
+                "helper",
+                "helper",
+            )],
+            vec![route_entrypoint(
+                "/repo/after/src/page.tsx",
+                EntrypointKind::NextAppRoute,
+            )],
+            vec![deletion_candidate(
+                "/repo/after/src/delete.ts",
+                "Module has no inbound references and is not treated as an entrypoint.",
+                0.66,
+                true,
+            )],
+        ),
+        vec![],
+    );
+    let diff = diff_reports(&before, &after);
+    let summary =
+        format_diff_summary(&diff, &before_path, &after_path).expect("summary should format");
+    let markdown =
+        format_diff_markdown(&diff, &before_path, &after_path).expect("markdown should format");
+
+    assert!(summary.contains("라우트 진입점: 새로 발생 1, 해결됨 0, 유지됨 0"));
+    assert!(markdown.contains("## 라우트 진입점"));
+    assert!(markdown.contains("- /repo/after/src/use.ts -> `helper` (출처: `./lib`)"));
+    assert!(markdown.contains(
+        "- /repo/after/src/delete.ts (모듈에 참조가 없고 진입점으로 취급되지 않습니다., 신뢰도 0.66)"
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## 배경

`kratos diff --format summary|md`의 사람이 읽는 비교 결과물을 한국어 기본 출력으로 전환합니다.

## 변경 사항

- diff summary/Markdown 제목, 라벨, change group을 한국어로 변경
- Markdown 상세 항목의 `from`, `confidence` 잔여 영어 표현을 한국어로 변경
- deletion candidate의 저장 `reason`은 유지하고, Markdown 표시 단계에서 known reason만 한국어로 변환
- JSON diff key와 shape는 유지하면서 core/CLI 테스트를 보강

## 검증

- `cargo test -p kratos-core --test report_diff`
- `cargo test -p kratos-cli --test diff_cli`
- `rustfmt --edition 2021 --check crates/kratos-core/src/report_diff.rs crates/kratos-core/tests/report_diff.rs crates/kratos-cli/tests/diff_cli.rs`
- `git diff --check`
- `$devils-advocate-review-loop` delta review: Critical/High/Medium/Low 없음

## 브랜치 / 워크트리

- Branch: `feature/65-diff-ko-output`
- Worktree: `/private/tmp/kratos-ko-output-wave1/issue-65`

## 이슈 연결

Closes #65
