### PR TITLE
feat(cli): clean/help/error 한국어 출력 전환

### DIFF
--- a/bin/kratos.js
+++ b/bin/kratos.js
@@ -73,7 +73,7 @@ export function runLauncher(argv, options = {}) {
     return Number.isInteger(exitCode) ? exitCode : 1;
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
-    stderr.write(`Kratos failed: ${detail}\n`);
+    stderr.write(`Kratos 실행 실패: ${detail}\n`);
     return 1;
   }
 }

--- a/crates/kratos-cli/src/commands/clean.rs
+++ b/crates/kratos-cli/src/commands/clean.rs
@@ -4,6 +4,7 @@ use std::io::Write;
 use kratos_core::clean::{clean_from_report_with_min_confidence, plan_clean_candidates};
 use kratos_core::config::load_clean_min_confidence;
 use kratos_core::report::parse_report_json;
+use kratos_core::report_format::display_known_reason;
 use kratos_core::KratosResult;
 
 use super::{parse_cli_options, resolve_report_input, write_output, CommandSpec, ParsedFlagValue};
@@ -11,7 +12,7 @@ use super::{parse_cli_options, resolve_report_input, write_output, CommandSpec, 
 pub const NAME: &str = "clean";
 pub const SPEC: CommandSpec = CommandSpec {
     name: NAME,
-    summary: "Show deletion candidates or delete them with --apply.",
+    summary: "삭제 후보를 표시하거나 --apply로 삭제합니다.",
     usage: &["kratos clean [report-path-or-root] [--apply] [--min-confidence value]"],
 };
 
@@ -30,7 +31,7 @@ pub fn run(args: &[String], stdout: &mut dyn Write) -> KratosResult<i32> {
     let report = parse_report_json(&raw)?;
 
     if report.findings.deletion_candidates.is_empty() {
-        write_output(stdout, "Kratos clean found no deletion candidates.")?;
+        write_output(stdout, "Kratos clean: 삭제 후보가 없습니다.")?;
         return Ok(0);
     }
 
@@ -49,7 +50,7 @@ pub fn run(args: &[String], stdout: &mut dyn Write) -> KratosResult<i32> {
     write_output(
         stdout,
         &format!(
-            "Kratos clean deleted {} file(s).\nskipped_files: {}",
+            "Kratos clean: 파일 {}개를 삭제했습니다.\n건너뛴 파일: {}",
             outcome.deleted_files, outcome.skipped_files
         ),
     )?;
@@ -60,7 +61,7 @@ fn parse_args(args: &[String]) -> KratosResult<CleanArgs> {
     let parsed = parse_cli_options(args, &["min-confidence"], &["apply"]);
     if parsed.positionals.len() > 1 {
         return Err(kratos_core::KratosError::Config(
-            "clean accepts at most one report-path-or-root argument".to_string(),
+            "clean은 report-path-or-root 인자를 최대 하나만 받을 수 있습니다".to_string(),
         ));
     }
 
@@ -92,7 +93,7 @@ fn parse_explicit_boolean(raw: &str) -> KratosResult<bool> {
         "true" | "1" | "yes" | "on" => Ok(true),
         "false" | "0" | "no" | "off" => Ok(false),
         _ => Err(kratos_core::KratosError::Config(
-            "--apply must be a boolean flag or an explicit boolean value".to_string(),
+            "--apply는 boolean flag이거나 명시적인 boolean 값이어야 합니다".to_string(),
         )),
     }
 }
@@ -101,7 +102,7 @@ fn parse_min_confidence(value: &ParsedFlagValue) -> KratosResult<f32> {
     let raw = match value {
         ParsedFlagValue::Present => {
             return Err(kratos_core::KratosError::Config(
-                "--min-confidence requires a value".to_string(),
+                "--min-confidence에는 값이 필요합니다".to_string(),
             ))
         }
         ParsedFlagValue::Value(raw) => raw.trim(),
@@ -109,17 +110,19 @@ fn parse_min_confidence(value: &ParsedFlagValue) -> KratosResult<f32> {
 
     if raw.is_empty() {
         return Err(kratos_core::KratosError::Config(
-            "--min-confidence requires a value".to_string(),
+            "--min-confidence에는 값이 필요합니다".to_string(),
         ));
     }
 
     let parsed = raw.parse::<f32>().map_err(|_| {
-        kratos_core::KratosError::Config("--min-confidence must be between 0.0 and 1.0".to_string())
+        kratos_core::KratosError::Config(
+            "--min-confidence는 0.0 이상 1.0 이하이어야 합니다".to_string(),
+        )
     })?;
 
     if !parsed.is_finite() || !(0.0..=1.0).contains(&parsed) {
         return Err(kratos_core::KratosError::Config(
-            "--min-confidence must be between 0.0 and 1.0".to_string(),
+            "--min-confidence는 0.0 이상 1.0 이하이어야 합니다".to_string(),
         ));
     }
 
@@ -128,9 +131,9 @@ fn parse_min_confidence(value: &ParsedFlagValue) -> KratosResult<f32> {
 
 fn format_clean_plan(plan: &kratos_core::clean::CleanThresholdPlan) -> String {
     let mut lines = vec![
-        "Kratos clean dry run.".to_string(),
+        "Kratos clean 미리보기입니다.".to_string(),
         String::new(),
-        format!("Deletion targets: {}", plan.deletion_targets.len()),
+        format!("삭제 대상: {}", plan.deletion_targets.len()),
     ];
 
     for candidate in &plan.deletion_targets {
@@ -140,7 +143,7 @@ fn format_clean_plan(plan: &kratos_core::clean::CleanThresholdPlan) -> String {
     if !plan.threshold_skipped_targets.is_empty() {
         lines.push(String::new());
         lines.push(format!(
-            "Threshold-skipped targets: {}",
+            "신뢰도 기준 미달로 건너뛴 대상: {}",
             plan.threshold_skipped_targets.len()
         ));
 
@@ -150,15 +153,15 @@ fn format_clean_plan(plan: &kratos_core::clean::CleanThresholdPlan) -> String {
     }
 
     lines.push(String::new());
-    lines.push("Re-run with --apply to delete these files.".to_string());
+    lines.push("삭제하려면 --apply로 다시 실행하세요.".to_string());
     lines.join("\n")
 }
 
 fn format_candidate_line(candidate: &kratos_core::model::DeletionCandidateFinding) -> String {
     format!(
-        "- {} (confidence {:.2}, {})",
+        "- {} (신뢰도 {:.2}, {})",
         candidate.file.display(),
         candidate.confidence,
-        candidate.reason
+        display_known_reason(&candidate.reason)
     )
 }

--- a/crates/kratos-cli/src/commands/mod.rs
+++ b/crates/kratos-cli/src/commands/mod.rs
@@ -25,7 +25,7 @@ pub fn dispatch(command: &str, args: &[String], stdout: &mut dyn Write) -> Krato
         report::NAME => dispatch_command(report::SPEC, report::run, args, stdout),
         diff::NAME => dispatch_command(diff::SPEC, diff::run, args, stdout),
         clean::NAME => dispatch_command(clean::SPEC, clean::run, args, stdout),
-        _ => Err(KratosError::Config(format!("Unknown command: {command}"))),
+        _ => Err(KratosError::Config(format!("알 수 없는 명령: {command}"))),
     }
 }
 
@@ -36,9 +36,9 @@ pub fn is_known_command(command: &str) -> bool {
 pub fn format_root_help() -> String {
     let mut lines = vec![
         "Kratos".to_string(),
-        "Destroy dead code ruthlessly.".to_string(),
+        "죽은 코드를 가차 없이 제거합니다.".to_string(),
         String::new(),
-        "Usage:".to_string(),
+        "사용법:".to_string(),
     ];
 
     for command in COMMANDS {
@@ -47,7 +47,7 @@ pub fn format_root_help() -> String {
         }
     }
 
-    lines.extend([String::new(), "Commands:".to_string()]);
+    lines.extend([String::new(), "명령:".to_string()]);
 
     let max_name_length = COMMANDS
         .iter()
@@ -58,7 +58,7 @@ pub fn format_root_help() -> String {
         lines.push(format!(
             "  {:<width$}  {}",
             command.name,
-            command.summary,
+            display_command_summary(*command),
             width = max_name_length
         ));
     }
@@ -69,12 +69,12 @@ pub fn format_root_help() -> String {
 pub fn format_command_help(spec: CommandSpec) -> String {
     let mut lines = vec![
         "Kratos".to_string(),
-        "Destroy dead code ruthlessly.".to_string(),
+        "죽은 코드를 가차 없이 제거합니다.".to_string(),
         String::new(),
-        format!("{} command", spec.name),
-        spec.summary.to_string(),
+        format!("{} 명령", spec.name),
+        display_command_summary(spec).to_string(),
         String::new(),
-        "Usage:".to_string(),
+        "사용법:".to_string(),
     ];
 
     for usage in spec.usage {
@@ -82,12 +82,22 @@ pub fn format_command_help(spec: CommandSpec) -> String {
     }
 
     lines.push(String::new());
-    lines.push("Run `kratos --help` to see every command.".to_string());
+    lines.push("전체 명령을 보려면 `kratos --help`를 실행하세요.".to_string());
     lines.join("\n")
 }
 
 pub fn format_unknown_command(command: &str) -> String {
-    format!("Unknown command: {command}\n\n{}", format_root_help())
+    format!("알 수 없는 명령: {command}\n\n{}", format_root_help())
+}
+
+fn display_command_summary(spec: CommandSpec) -> &'static str {
+    match spec.name {
+        scan::NAME => "코드베이스를 분석하고 최신 리포트를 저장합니다.",
+        report::NAME => "저장된 리포트를 summary, json, markdown 형식으로 출력합니다.",
+        diff::NAME => "저장된 두 리포트를 비교합니다.",
+        clean::NAME => "삭제 후보를 표시하거나 --apply로 삭제합니다.",
+        _ => spec.summary,
+    }
 }
 
 fn dispatch_command(

--- a/crates/kratos-cli/src/lib.rs
+++ b/crates/kratos-cli/src/lib.rs
@@ -12,7 +12,7 @@ pub fn run_cli_with_io(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn
     match run(args, stdout, stderr) {
         Ok(code) => code,
         Err(error) => {
-            let _ = writeln!(stderr, "Kratos failed: {error}");
+            let _ = writeln!(stderr, "Kratos 실행 실패: {error}");
             1
         }
     }

--- a/crates/kratos-cli/tests/clean_threshold_cli.rs
+++ b/crates/kratos-cli/tests/clean_threshold_cli.rs
@@ -13,17 +13,17 @@ fn clean_uses_config_threshold_and_flag_override() {
     let dry_run = run_cli_in_dir(&project_root, &["clean"]);
     assert!(dry_run.status.success());
     let dry_run_stdout = String::from_utf8_lossy(&dry_run.stdout);
-    assert!(dry_run_stdout.contains("Kratos clean dry run."));
-    assert!(dry_run_stdout.contains("Deletion targets: 0"));
-    assert!(dry_run_stdout.contains("Threshold-skipped targets: 2"));
+    assert!(dry_run_stdout.contains("Kratos clean 미리보기입니다."));
+    assert!(dry_run_stdout.contains("삭제 대상: 0"));
+    assert!(dry_run_stdout.contains("신뢰도 기준 미달로 건너뛴 대상: 2"));
     assert!(dry_run_stdout.contains("high-confidence.ts"));
     assert!(dry_run_stdout.contains("mid-confidence.ts"));
 
     let overridden = run_cli_in_dir(&project_root, &["clean", "--min-confidence", "0.9"]);
     assert!(overridden.status.success());
     let overridden_stdout = String::from_utf8_lossy(&overridden.stdout);
-    assert!(overridden_stdout.contains("Deletion targets: 1"));
-    assert!(overridden_stdout.contains("Threshold-skipped targets: 1"));
+    assert!(overridden_stdout.contains("삭제 대상: 1"));
+    assert!(overridden_stdout.contains("신뢰도 기준 미달로 건너뛴 대상: 1"));
     assert!(overridden_stdout.contains("high-confidence.ts"));
     assert!(overridden_stdout.contains("mid-confidence.ts"));
 
@@ -33,8 +33,8 @@ fn clean_uses_config_threshold_and_flag_override() {
     );
     assert!(apply.status.success());
     let apply_stdout = String::from_utf8_lossy(&apply.stdout);
-    assert!(apply_stdout.contains("Kratos clean deleted 1 file(s)."));
-    assert!(apply_stdout.contains("skipped_files: 1"));
+    assert!(apply_stdout.contains("Kratos clean: 파일 1개를 삭제했습니다."));
+    assert!(apply_stdout.contains("건너뛴 파일: 1"));
     assert!(!project_root.join("high-confidence.ts").exists());
     assert!(project_root.join("mid-confidence.ts").exists());
 }
@@ -47,7 +47,7 @@ fn clean_rejects_out_of_range_min_confidence_values() {
     let output = run_cli_in_dir(&project_root, &["clean", "--min-confidence", "1.5"]);
     assert_eq!(output.status.code(), Some(1));
     assert!(String::from_utf8_lossy(&output.stderr)
-        .contains("--min-confidence must be between 0.0 and 1.0"));
+        .contains("--min-confidence는 0.0 이상 1.0 이하이어야 합니다"));
 }
 
 #[test]
@@ -62,9 +62,8 @@ fn clean_rejects_invalid_thresholds_config_shape() {
 
     let output = run_cli_in_dir(&project_root, &["clean"]);
     assert_eq!(output.status.code(), Some(1));
-    assert!(String::from_utf8_lossy(&output.stderr).contains(
-        "thresholds must be an object when specifying thresholds.cleanMinConfidence"
-    ));
+    assert!(String::from_utf8_lossy(&output.stderr)
+        .contains("thresholds must be an object when specifying thresholds.cleanMinConfidence"));
 }
 
 #[test]
@@ -78,10 +77,9 @@ fn clean_noop_ignores_invalid_thresholds_config_shape() {
     .expect("config should write");
 
     let report_path = project_root.join(".kratos/latest-report.json");
-    let mut report: serde_json::Value = serde_json::from_str(
-        &std::fs::read_to_string(&report_path).expect("report should read"),
-    )
-    .expect("report should parse");
+    let mut report: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&report_path).expect("report should read"))
+            .expect("report should parse");
     report["summary"]["deletionCandidates"] = json!(0);
     report["findings"]["deletionCandidates"] = json!([]);
     std::fs::write(
@@ -92,7 +90,7 @@ fn clean_noop_ignores_invalid_thresholds_config_shape() {
 
     let output = run_cli_in_dir(&project_root, &["clean"]);
     assert!(output.status.success());
-    assert!(String::from_utf8_lossy(&output.stdout).contains("Kratos clean found no deletion candidates."));
+    assert!(String::from_utf8_lossy(&output.stdout).contains("Kratos clean: 삭제 후보가 없습니다."));
 }
 
 #[test]
@@ -106,7 +104,7 @@ fn clean_apply_false_stays_dry_run() {
     );
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("Kratos clean dry run."));
+    assert!(stdout.contains("Kratos clean 미리보기입니다."));
     assert!(project_root.join("high-confidence.ts").exists());
     assert!(project_root.join("mid-confidence.ts").exists());
 }
@@ -122,7 +120,7 @@ fn clean_apply_empty_string_stays_dry_run() {
     );
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("Kratos clean dry run."));
+    assert!(stdout.contains("Kratos clean 미리보기입니다."));
     assert!(project_root.join("high-confidence.ts").exists());
     assert!(project_root.join("mid-confidence.ts").exists());
 }
@@ -138,7 +136,7 @@ fn clean_rejects_invalid_apply_value() {
     );
     assert_eq!(output.status.code(), Some(1));
     assert!(String::from_utf8_lossy(&output.stderr)
-        .contains("--apply must be a boolean flag or an explicit boolean value"));
+        .contains("--apply는 boolean flag이거나 명시적인 boolean 값이어야 합니다"));
     assert!(project_root.join("high-confidence.ts").exists());
     assert!(project_root.join("mid-confidence.ts").exists());
 }
@@ -159,7 +157,7 @@ fn clean_rejects_surplus_positionals() {
     );
     assert_eq!(output.status.code(), Some(1));
     assert!(String::from_utf8_lossy(&output.stderr)
-        .contains("clean accepts at most one report-path-or-root argument"));
+        .contains("clean은 report-path-or-root 인자를 최대 하나만 받을 수 있습니다"));
 }
 
 #[test]

--- a/crates/kratos-cli/tests/cli_smoke.rs
+++ b/crates/kratos-cli/tests/cli_smoke.rs
@@ -10,7 +10,18 @@ fn root_help_matches_expected_shape() {
     assert!(output.status.success());
     assert_eq!(
         String::from_utf8_lossy(&output.stdout),
-        "Kratos\nDestroy dead code ruthlessly.\n\nUsage:\n  kratos scan [root] [--output path] [--json]\n  kratos report [report-path-or-root] [--format summary|json|md]\n  kratos diff [before-report-path-or-root] [after-report-path-or-root] [--format summary|json|md]\n  kratos clean [report-path-or-root] [--apply] [--min-confidence value]\n\nCommands:\n  scan    Analyze a codebase and save the latest report.\n  report  Print a saved report in summary, json, or markdown form.\n  diff    Compare two saved reports.\n  clean   Show deletion candidates or delete them with --apply.\n"
+        "Kratos\n죽은 코드를 가차 없이 제거합니다.\n\n사용법:\n  kratos scan [root] [--output path] [--json]\n  kratos report [report-path-or-root] [--format summary|json|md]\n  kratos diff [before-report-path-or-root] [after-report-path-or-root] [--format summary|json|md]\n  kratos clean [report-path-or-root] [--apply] [--min-confidence value]\n\n명령:\n  scan    코드베이스를 분석하고 최신 리포트를 저장합니다.\n  report  저장된 리포트를 summary, json, markdown 형식으로 출력합니다.\n  diff    저장된 두 리포트를 비교합니다.\n  clean   삭제 후보를 표시하거나 --apply로 삭제합니다.\n"
+    );
+}
+
+#[test]
+fn command_help_matches_korean_policy() {
+    let output = run_cli(&["clean", "--help"]);
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "Kratos\n죽은 코드를 가차 없이 제거합니다.\n\nclean 명령\n삭제 후보를 표시하거나 --apply로 삭제합니다.\n\n사용법:\n  kratos clean [report-path-or-root] [--apply] [--min-confidence value]\n\n전체 명령을 보려면 `kratos --help`를 실행하세요.\n"
     );
 }
 
@@ -21,7 +32,7 @@ fn unknown_command_returns_help_and_exit_code_one() {
     assert_eq!(output.status.code(), Some(1));
     assert_eq!(
         String::from_utf8_lossy(&output.stderr),
-        "Unknown command: nope\n\nKratos\nDestroy dead code ruthlessly.\n\nUsage:\n  kratos scan [root] [--output path] [--json]\n  kratos report [report-path-or-root] [--format summary|json|md]\n  kratos diff [before-report-path-or-root] [after-report-path-or-root] [--format summary|json|md]\n  kratos clean [report-path-or-root] [--apply] [--min-confidence value]\n\nCommands:\n  scan    Analyze a codebase and save the latest report.\n  report  Print a saved report in summary, json, or markdown form.\n  diff    Compare two saved reports.\n  clean   Show deletion candidates or delete them with --apply.\n"
+        "알 수 없는 명령: nope\n\nKratos\n죽은 코드를 가차 없이 제거합니다.\n\n사용법:\n  kratos scan [root] [--output path] [--json]\n  kratos report [report-path-or-root] [--format summary|json|md]\n  kratos diff [before-report-path-or-root] [after-report-path-or-root] [--format summary|json|md]\n  kratos clean [report-path-or-root] [--apply] [--min-confidence value]\n\n명령:\n  scan    코드베이스를 분석하고 최신 리포트를 저장합니다.\n  report  저장된 리포트를 summary, json, markdown 형식으로 출력합니다.\n  diff    저장된 두 리포트를 비교합니다.\n  clean   삭제 후보를 표시하거나 --apply로 삭제합니다.\n"
     );
 }
 
@@ -67,8 +78,8 @@ fn scan_report_and_clean_work_for_demo_fixture() {
     let clean = run_cli(&["clean", report_path.to_str().expect("path should be utf8")]);
     assert!(clean.status.success());
     let clean_stdout = String::from_utf8_lossy(&clean.stdout);
-    assert!(clean_stdout.contains("Kratos clean dry run."));
-    assert!(clean_stdout.contains("Re-run with --apply to delete these files."));
+    assert!(clean_stdout.contains("Kratos clean 미리보기입니다."));
+    assert!(clean_stdout.contains("삭제하려면 --apply로 다시 실행하세요."));
 }
 
 #[test]
@@ -156,7 +167,7 @@ fn clean_accepts_legacy_v1_reports_through_cli() {
         &["clean", report_path.to_str().expect("path should be utf8")],
     );
     assert!(dry_run.status.success());
-    assert!(String::from_utf8_lossy(&dry_run.stdout).contains("Kratos clean dry run."));
+    assert!(String::from_utf8_lossy(&dry_run.stdout).contains("Kratos clean 미리보기입니다."));
 
     let apply = run_cli_in_dir(
         &project_root,
@@ -167,7 +178,9 @@ fn clean_accepts_legacy_v1_reports_through_cli() {
         ],
     );
     assert!(apply.status.success());
-    assert!(String::from_utf8_lossy(&apply.stdout).contains("Kratos clean deleted 2 file(s)."));
+    assert!(
+        String::from_utf8_lossy(&apply.stdout).contains("Kratos clean: 파일 2개를 삭제했습니다.")
+    );
     assert!(!project_root.join("src/components/DeadWidget.tsx").exists());
     assert!(!project_root.join("src/lib/broken.ts").exists());
 }
@@ -198,7 +211,7 @@ fn unknown_flags_and_surplus_positionals_match_js_baseline() {
 
     let clean = run_cli_in_dir(&project_root, &["clean", "--bogus"]);
     assert!(clean.status.success());
-    assert!(String::from_utf8_lossy(&clean.stdout).contains("Kratos clean dry run."));
+    assert!(String::from_utf8_lossy(&clean.stdout).contains("Kratos clean 미리보기입니다."));
 }
 
 #[test]
@@ -221,7 +234,7 @@ fn invalid_report_format_is_an_error_per_plan_contract() {
     );
     assert_eq!(report.status.code(), Some(1));
     assert!(String::from_utf8_lossy(&report.stderr)
-        .contains("Kratos failed: Config error: Invalid report format: bogus"));
+        .contains("Kratos 실행 실패: Config error: Invalid report format: bogus"));
 
     let hyphenated_report = run_cli_in_dir(
         &project_root,
@@ -234,7 +247,7 @@ fn invalid_report_format_is_an_error_per_plan_contract() {
     );
     assert_eq!(hyphenated_report.status.code(), Some(1));
     assert!(String::from_utf8_lossy(&hyphenated_report.stderr)
-        .contains("Kratos failed: Config error: Invalid report format: -foo"));
+        .contains("Kratos 실행 실패: Config error: Invalid report format: -foo"));
 }
 
 #[test]
@@ -434,7 +447,7 @@ fn clean_accepts_future_schema_reports_when_the_shape_is_compatible() {
     );
     assert!(dry_run.status.success());
     let dry_run_stdout = String::from_utf8_lossy(&dry_run.stdout);
-    assert!(dry_run_stdout.contains("Kratos clean dry run."));
+    assert!(dry_run_stdout.contains("Kratos clean 미리보기입니다."));
     assert!(dry_run_stdout.contains(&dead_file.display().to_string()));
     assert!(dead_file.exists());
 
@@ -447,7 +460,9 @@ fn clean_accepts_future_schema_reports_when_the_shape_is_compatible() {
         ],
     );
     assert!(apply.status.success());
-    assert!(String::from_utf8_lossy(&apply.stdout).contains("Kratos clean deleted 1 file(s)."));
+    assert!(
+        String::from_utf8_lossy(&apply.stdout).contains("Kratos clean: 파일 1개를 삭제했습니다.")
+    );
     assert!(!dead_file.exists());
 }
 
@@ -463,7 +478,7 @@ fn scan_output_empty_string_defaults_and_missing_value_errors() {
     let missing_output = run_cli_in_dir(&project_root, &["scan", "--output", "--json"]);
     assert_eq!(missing_output.status.code(), Some(1));
     assert!(String::from_utf8_lossy(&missing_output.stderr)
-        .contains("Kratos failed: Config error: --output requires a path value"));
+        .contains("Kratos 실행 실패: Config error: --output requires a path value"));
     assert!(
         !project_root.join("--json").exists(),
         "missing output value should not create a stray report file"
@@ -497,7 +512,9 @@ fn boolean_flags_do_not_consume_following_positionals() {
         ],
     );
     assert!(clean.status.success());
-    assert!(String::from_utf8_lossy(&clean.stdout).contains("Kratos clean deleted 2 file(s)."));
+    assert!(
+        String::from_utf8_lossy(&clean.stdout).contains("Kratos clean: 파일 2개를 삭제했습니다.")
+    );
     assert!(!project_root.join("src/components/DeadWidget.tsx").exists());
     assert!(!project_root.join("src/lib/broken.ts").exists());
 }
@@ -534,7 +551,7 @@ fn empty_inline_boolean_flags_stay_falsey_like_js() {
     );
     assert!(clean.status.success());
     let clean_stdout = String::from_utf8_lossy(&clean.stdout);
-    assert!(clean_stdout.contains("Kratos clean dry run."));
+    assert!(clean_stdout.contains("Kratos clean 미리보기입니다."));
     assert!(project_root.join("src/components/DeadWidget.tsx").exists());
     assert!(project_root.join("src/lib/broken.ts").exists());
 }

--- a/crates/kratos-cli/tests/diff_cli.rs
+++ b/crates/kratos-cli/tests/diff_cli.rs
@@ -78,7 +78,7 @@ fn diff_defaults_to_summary_and_rejects_invalid_format() {
     );
     assert_eq!(invalid_output.status.code(), Some(1));
     assert!(String::from_utf8_lossy(&invalid_output.stderr)
-        .contains("Kratos failed: Config error: Invalid diff format: bogus"));
+        .contains("Kratos 실행 실패: Config error: Invalid diff format: bogus"));
 }
 
 #[test]

--- a/test/npm-launcher.test.js
+++ b/test/npm-launcher.test.js
@@ -52,7 +52,7 @@ test("runLauncher forwards argv to runCli and returns its exit code", () => {
   assert.equal(stderr.read(), "");
 });
 
-test("runLauncher formats missing addon failures with Kratos prefix", () => {
+test("runLauncher formats missing addon failures with Korean Kratos prefix", () => {
   const stderr = captureStream();
 
   const exitCode = runLauncher(["node", "bin/kratos.js", "scan"], {
@@ -67,7 +67,7 @@ test("runLauncher formats missing addon failures with Kratos prefix", () => {
   assert.equal(exitCode, 1);
   assert.match(
     stderr.read(),
-    /Kratos failed: Failed to load native addon package @jeremyfellaz\/kratos-linux-x64-gnu:/,
+    /Kratos 실행 실패: Failed to load native addon package @jeremyfellaz\/kratos-linux-x64-gnu:/,
   );
 });
 
@@ -174,6 +174,6 @@ function expectedMissingAddonPattern() {
   const expectedPackageName = resolveAddonPackageName(process.platform, process.arch);
 
   return new RegExp(
-    `Kratos failed: Failed to load native addon package ${escapeForRegex(expectedPackageName)}:`,
+    `Kratos 실행 실패: Failed to load native addon package ${escapeForRegex(expectedPackageName)}:`,
   );
 }


### PR DESCRIPTION
## 배경

Kratos의 `scan/report/diff` 사람용 출력은 한국어로 전환되어 있지만, `clean`, CLI help, unknown command, error prefix, npm launcher failure prefix는 아직 영어가 기본값입니다.

## 변경 사항

- `kratos clean`의 no-candidate, dry-run, threshold skipped, apply 결과 문구를 한국어로 전환했습니다.
- `--apply`, `--min-confidence`, surplus positional 오류 문구를 한국어로 전환했습니다.
- root help, command help, unknown command 출력은 명령 이름과 usage shape를 유지하면서 한국어 설명을 표시하도록 변경했습니다.
- Rust CLI와 npm launcher의 `Kratos failed:` prefix를 한국어 prefix로 통일했습니다.
- clean deletion candidate reason은 report formatter의 known-reason 한국어 표시 정책을 재사용합니다.

## 검증

- `cargo test -p kratos-cli --test clean_threshold_cli`
- `cargo test -p kratos-cli --test cli_smoke`
- `cargo test -p kratos-cli --test diff_cli`
- `npm test`
- `npm run verify`
- `cargo test --workspace`
- `git diff --check`
- `rustfmt --check crates/kratos-cli/src/commands/clean.rs crates/kratos-cli/src/commands/mod.rs crates/kratos-cli/src/lib.rs crates/kratos-cli/tests/clean_threshold_cli.rs crates/kratos-cli/tests/cli_smoke.rs crates/kratos-cli/tests/diff_cli.rs`

참고: 전체 `cargo fmt --check`는 이번 lane 밖 기존 파일 포맷 차이로 실패했습니다. touched Rust 파일은 scoped `rustfmt --check`로 통과 확인했습니다.

## 리뷰 게이트

- `$devils-advocate-review-loop` Round 1: 의미 있는 finding 없음
- `gate_result: pass`
- `blocking_summary: none`

## 브랜치 / 워크트리

- base: `origin/master` (`ea565d7`)
- branch: `feat/66-clean-help-error-ko-output`
- worktree: `/tmp/kratos-issue-66`

## 이슈 연결

Closes #66
