### PR TITLE
feat(report): 자동 정리와 수동 검토 요약 분리

### DIFF
--- a/crates/kratos-cli/tests/cli_smoke.rs
+++ b/crates/kratos-cli/tests/cli_smoke.rs
@@ -46,7 +46,7 @@ fn scan_report_and_clean_work_for_demo_fixture() {
     let scan_stdout = String::from_utf8_lossy(&scan.stdout);
     assert!(scan_stdout.contains("Kratos 스캔 완료."));
     assert!(scan_stdout.contains(
-        "영향: 조치할 항목 6개: 깨진 import 1개, 정리 후보 2개, 사용되지 않는 export 3개."
+        "영향: 즉시 수정 대상 1개: 깨진 import 1개. 자동 정리 후보 2개: 삭제 후보 2개. 수동 검토 대상 3개: 사용되지 않는 export 3개."
     ));
     assert!(
         scan_stdout.contains("다음 권장 작업: 파일을 삭제하기 전에 깨진 import를 먼저 수정하세요.")
@@ -58,7 +58,27 @@ fn scan_report_and_clean_work_for_demo_fixture() {
     assert!(scan_stdout.contains("다음 단계:"));
     assert!(scan_stdout.contains("상위 정리 후보:"));
     assert!(scan_stdout.contains("- src/components/DeadWidget.tsx"));
+    assert!(scan_stdout.contains(
+        "설정 안내: kratos.config.json의 keepPatterns 또는 suppressions로 의도된 공개 API와 보존 파일을 고정하세요."
+    ));
+    assert!(!scan_stdout.contains("pages/home.tsx (next-pages-route)"));
     assert!(report_path.exists());
+
+    let summary_report = run_cli(&[
+        "report",
+        report_path.to_str().expect("path should be utf8"),
+        "--format",
+        "summary",
+    ]);
+    assert!(summary_report.status.success());
+    let summary_stdout = String::from_utf8_lossy(&summary_report.stdout);
+    assert!(summary_stdout.contains(
+        "영향: 즉시 수정 대상 1개: 깨진 import 1개. 자동 정리 후보 2개: 삭제 후보 2개. 수동 검토 대상 3개: 사용되지 않는 export 3개."
+    ));
+    assert!(summary_stdout.contains(
+        "설정 안내: kratos.config.json의 keepPatterns 또는 suppressions로 의도된 공개 API와 보존 파일을 고정하세요."
+    ));
+    assert!(!summary_stdout.contains("pages/home.tsx (next-pages-route)"));
 
     let report = run_cli(&[
         "report",

--- a/crates/kratos-core/src/report_format.rs
+++ b/crates/kratos-core/src/report_format.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::path::Path;
 
 use crate::model::ReportV2;
@@ -43,12 +44,7 @@ pub fn format_summary_report(
         |item| format!("{} -> {}", display_path(report, &item.file), item.source),
     );
     append_deletion_preview(&mut lines, report);
-    append_preview(
-        &mut lines,
-        "고아 파일",
-        &report.findings.orphan_files,
-        |item| display_path(report, &item.file),
-    );
+    append_orphan_preview(&mut lines, report);
     append_preview(
         &mut lines,
         "사용되지 않는 export",
@@ -68,19 +64,6 @@ pub fn format_summary_report(
             )
         },
     );
-    append_preview(
-        &mut lines,
-        "라우트 진입점",
-        &report.findings.route_entrypoints,
-        |item| {
-            format!(
-                "{} ({})",
-                display_path(report, &item.file),
-                entrypoint_kind_to_string(&item.kind)
-            )
-        },
-    );
-
     Ok(lines.join("\n"))
 }
 
@@ -199,39 +182,55 @@ fn impact_summary(report: &ReportV2) -> ImpactSummary {
     let cleanup_candidates = report.summary.deletion_candidates;
     let dead_exports = report.summary.dead_exports;
     let unused_imports = report.summary.unused_imports;
-    let actionable_total = breakages + cleanup_candidates + dead_exports + unused_imports;
+    let fix_candidates = breakages + unused_imports;
 
-    let headline = if actionable_total == 0 {
+    let headline = if fix_candidates == 0 && cleanup_candidates == 0 && dead_exports == 0 {
         format!(
-            "스캔한 파일 {}개에서 조치할 항목이 없습니다.",
+            "스캔한 파일 {}개에서 자동 정리 후보와 수동 검토 대상이 없습니다.",
             report.summary.files_scanned
         )
     } else {
         let mut parts = Vec::new();
-        if breakages > 0 {
-            parts.push(count_label(breakages, "깨진 import"));
+        if fix_candidates > 0 {
+            let mut fix_parts = Vec::new();
+            if breakages > 0 {
+                fix_parts.push(count_label(breakages, "깨진 import"));
+            }
+            if unused_imports > 0 {
+                fix_parts.push(count_label(unused_imports, "사용되지 않는 import"));
+            }
+            parts.push(format!(
+                "즉시 수정 대상 {}개: {}",
+                fix_candidates,
+                fix_parts.join(", ")
+            ));
         }
         if cleanup_candidates > 0 {
-            parts.push(count_label(cleanup_candidates, "정리 후보"));
+            parts.push(format!(
+                "자동 정리 후보 {}개: {}",
+                cleanup_candidates,
+                count_label(cleanup_candidates, "삭제 후보")
+            ));
         }
         if dead_exports > 0 {
-            parts.push(count_label(dead_exports, "사용되지 않는 export"));
-        }
-        if unused_imports > 0 {
-            parts.push(count_label(unused_imports, "사용되지 않는 import"));
+            parts.push(format!(
+                "수동 검토 대상 {}개: {}",
+                dead_exports,
+                count_label(dead_exports, "사용되지 않는 export")
+            ));
         }
 
-        format!("조치할 항목 {}개: {}.", actionable_total, parts.join(", "))
+        format!("{}.", parts.join(". "))
     };
 
     let best_next_move = if breakages > 0 {
         "파일을 삭제하기 전에 깨진 import를 먼저 수정하세요.".to_string()
     } else if cleanup_candidates > 0 {
         "정리 미리보기를 실행하고 신뢰도 높은 미사용 파일을 제거하세요.".to_string()
-    } else if dead_exports > 0 {
-        "사용되지 않는 export를 제거하거나 의도된 공개 API인지 확인하세요.".to_string()
     } else if unused_imports > 0 {
         "사용되지 않는 import를 제거해 불필요한 의존성을 줄이세요.".to_string()
+    } else if dead_exports > 0 {
+        "사용되지 않는 export는 삭제 후보가 아니므로 공개 API 여부를 수동 검토하세요.".to_string()
     } else {
         "향후 diff 기준선으로 JSON 리포트를 보관하세요.".to_string()
     };
@@ -258,6 +257,12 @@ fn append_next_steps(lines: &mut Vec<String>, report: &ReportV2, report_path: &P
     lines.push(format!(
         "- 공유용 Markdown: kratos report {report_arg} --format md"
     ));
+    if needs_config_guidance(report) {
+        lines.push(
+            "- 설정 안내: kratos.config.json의 keepPatterns 또는 suppressions로 의도된 공개 API와 보존 파일을 고정하세요."
+                .to_string(),
+        );
+    }
 }
 
 fn push_markdown_impact(lines: &mut Vec<String>, report: &ReportV2, report_path: &Path) {
@@ -274,6 +279,12 @@ fn push_markdown_impact(lines: &mut Vec<String>, report: &ReportV2, report_path:
     lines.push(format!(
         "- Markdown 갱신: `kratos report {report_arg} --format md`"
     ));
+    if needs_config_guidance(report) {
+        lines.push(
+            "- 설정 안내: `kratos.config.json`의 `keepPatterns` 또는 `suppressions`로 의도된 공개 API와 보존 파일을 고정하세요."
+                .to_string(),
+        );
+    }
     lines.push(String::new());
 }
 
@@ -300,6 +311,56 @@ fn append_deletion_preview(lines: &mut Vec<String>, report: &ReportV2) {
             report.findings.deletion_candidates.len() - 5
         ));
     }
+}
+
+fn append_orphan_preview(lines: &mut Vec<String>, report: &ReportV2) {
+    if report.findings.orphan_files.is_empty() {
+        return;
+    }
+
+    let deletion_files = report
+        .findings
+        .deletion_candidates
+        .iter()
+        .map(|item| item.file.as_path())
+        .collect::<HashSet<_>>();
+    let visible_orphans = report
+        .findings
+        .orphan_files
+        .iter()
+        .filter(|item| !deletion_files.contains(item.file.as_path()))
+        .collect::<Vec<_>>();
+    let omitted_count = report.findings.orphan_files.len() - visible_orphans.len();
+
+    lines.push(String::new());
+    lines.push("고아 파일:".to_string());
+
+    if visible_orphans.is_empty() {
+        lines.push(format!(
+            "- 정리 후보와 동일한 파일 {}개는 위 목록에서 확인하세요.",
+            omitted_count
+        ));
+        return;
+    }
+
+    for item in visible_orphans.iter().take(5) {
+        lines.push(format!("- {}", display_path(report, &item.file)));
+    }
+
+    if visible_orphans.len() > 5 {
+        lines.push(format!("- ...외 {}개", visible_orphans.len() - 5));
+    }
+    if omitted_count > 0 {
+        lines.push(format!(
+            "- 정리 후보와 중복된 {}개는 위 목록에서 확인하세요.",
+            omitted_count
+        ));
+    }
+}
+
+fn needs_config_guidance(report: &ReportV2) -> bool {
+    report.config_path.is_none()
+        && (report.summary.deletion_candidates > 0 || report.summary.dead_exports > 0)
 }
 
 fn display_path(report: &ReportV2, path: &Path) -> String {

--- a/crates/kratos-core/tests/report_format.rs
+++ b/crates/kratos-core/tests/report_format.rs
@@ -33,6 +33,210 @@ fn markdown_formatter_uses_korean_fallback_when_generated_at_is_missing() {
 }
 
 #[test]
+fn summary_separates_cleanup_candidates_from_manual_review_dead_exports() {
+    let report = parse_report_json(
+        r#"{
+          "schemaVersion": 2,
+          "project": { "root": "/tmp/demo", "configPath": null },
+          "summary": {
+            "filesScanned": 2,
+            "entrypoints": 0,
+            "brokenImports": 0,
+            "orphanFiles": 1,
+            "deadExports": 2,
+            "unusedImports": 0,
+            "routeEntrypoints": 0,
+            "deletionCandidates": 1
+          },
+          "findings": {
+            "brokenImports": [],
+            "orphanFiles": [
+              {
+                "file": "/tmp/demo/src/dead.ts",
+                "kind": "orphan-module",
+                "reason": "Module has no inbound references and is not treated as an entrypoint.",
+                "confidence": 0.95
+              }
+            ],
+            "deadExports": [
+              { "file": "/tmp/demo/src/api.ts", "exportName": "unusedPublicApi" },
+              { "file": "/tmp/demo/src/dead.ts", "exportName": "deadHelper" }
+            ],
+            "unusedImports": [],
+            "routeEntrypoints": [],
+            "deletionCandidates": [
+              {
+                "file": "/tmp/demo/src/dead.ts",
+                "reason": "Module has no inbound references and is not treated as an entrypoint.",
+                "confidence": 0.95,
+                "safe": true
+              }
+            ]
+          },
+          "graph": { "modules": [] }
+        }"#,
+    )
+    .expect("report should parse");
+
+    let rendered = format_summary_report(
+        &report,
+        Path::new("/tmp/demo/.kratos/latest-report.json"),
+        "Kratos report.",
+    )
+    .expect("summary should format");
+
+    assert!(rendered.contains(
+        "자동 정리 후보 1개: 삭제 후보 1개. 수동 검토 대상 2개: 사용되지 않는 export 2개."
+    ));
+    assert!(!rendered.contains("조치할 항목 3개"));
+    assert!(!rendered.contains("자동 정리 후보 3개"));
+    assert!(rendered.contains(
+        "설정 안내: kratos.config.json의 keepPatterns 또는 suppressions로 의도된 공개 API와 보존 파일을 고정하세요."
+    ));
+}
+
+#[test]
+fn dead_export_only_summary_recommends_manual_review_instead_of_cleanup() {
+    let report = parse_report_json(
+        r#"{
+          "schemaVersion": 2,
+          "project": { "root": "/tmp/demo", "configPath": null },
+          "summary": {
+            "filesScanned": 1,
+            "entrypoints": 0,
+            "brokenImports": 0,
+            "orphanFiles": 0,
+            "deadExports": 1,
+            "unusedImports": 0,
+            "routeEntrypoints": 0,
+            "deletionCandidates": 0
+          },
+          "findings": {
+            "brokenImports": [],
+            "orphanFiles": [],
+            "deadExports": [
+              { "file": "/tmp/demo/src/api.ts", "exportName": "unusedPublicApi" }
+            ],
+            "unusedImports": [],
+            "routeEntrypoints": [],
+            "deletionCandidates": []
+          },
+          "graph": { "modules": [] }
+        }"#,
+    )
+    .expect("report should parse");
+
+    let rendered = format_summary_report(
+        &report,
+        Path::new("/tmp/demo/.kratos/latest-report.json"),
+        "Kratos report.",
+    )
+    .expect("summary should format");
+
+    assert!(rendered.contains("수동 검토 대상 1개: 사용되지 않는 export 1개."));
+    assert!(rendered.contains(
+        "다음 권장 작업: 사용되지 않는 export는 삭제 후보가 아니므로 공개 API 여부를 수동 검토하세요."
+    ));
+    assert!(!rendered.contains("정리 미리보기:"));
+}
+
+#[test]
+fn summary_does_not_repeat_orphan_files_already_shown_as_deletion_candidates() {
+    let report = parse_report_json(
+        r#"{
+          "schemaVersion": 2,
+          "project": { "root": "/tmp/demo", "configPath": null },
+          "summary": {
+            "filesScanned": 1,
+            "entrypoints": 0,
+            "brokenImports": 0,
+            "orphanFiles": 1,
+            "deadExports": 0,
+            "unusedImports": 0,
+            "routeEntrypoints": 0,
+            "deletionCandidates": 1
+          },
+          "findings": {
+            "brokenImports": [],
+            "orphanFiles": [
+              {
+                "file": "/tmp/demo/src/dead.ts",
+                "kind": "orphan-module",
+                "reason": "Module has no inbound references and is not treated as an entrypoint.",
+                "confidence": 0.95
+              }
+            ],
+            "deadExports": [],
+            "unusedImports": [],
+            "routeEntrypoints": [],
+            "deletionCandidates": [
+              {
+                "file": "/tmp/demo/src/dead.ts",
+                "reason": "Module has no inbound references and is not treated as an entrypoint.",
+                "confidence": 0.95,
+                "safe": true
+              }
+            ]
+          },
+          "graph": { "modules": [] }
+        }"#,
+    )
+    .expect("report should parse");
+
+    let rendered = format_summary_report(
+        &report,
+        Path::new("/tmp/demo/.kratos/latest-report.json"),
+        "Kratos report.",
+    )
+    .expect("summary should format");
+
+    assert_eq!(rendered.matches("src/dead.ts").count(), 1);
+    assert!(rendered.contains("정리 후보와 동일한 파일 1개는 위 목록에서 확인하세요."));
+}
+
+#[test]
+fn summary_hides_route_entrypoint_details_but_markdown_keeps_them() {
+    let report = parse_report_json(
+        r#"{
+          "schemaVersion": 2,
+          "project": { "root": "/tmp/demo", "configPath": null },
+          "summary": {
+            "filesScanned": 1,
+            "entrypoints": 1,
+            "brokenImports": 0,
+            "orphanFiles": 0,
+            "deadExports": 0,
+            "unusedImports": 0,
+            "routeEntrypoints": 1,
+            "deletionCandidates": 0
+          },
+          "findings": {
+            "brokenImports": [],
+            "orphanFiles": [],
+            "deadExports": [],
+            "unusedImports": [],
+            "routeEntrypoints": [
+              { "file": "/tmp/demo/pages/home.tsx", "kind": "next-pages-route" }
+            ],
+            "deletionCandidates": []
+          },
+          "graph": { "modules": [] }
+        }"#,
+    )
+    .expect("report should parse");
+    let report_path = Path::new("/tmp/demo/.kratos/latest-report.json");
+
+    let summary = format_summary_report(&report, report_path, "Kratos report.")
+        .expect("summary should format");
+    let markdown = format_markdown_report(&report, report_path).expect("markdown should format");
+
+    assert!(summary.contains("라우트 진입점: 1"));
+    assert!(!summary.contains("pages/home.tsx (next-pages-route)"));
+    assert!(markdown.contains("## 라우트 진입점"));
+    assert!(markdown.contains("pages/home.tsx (next-pages-route)"));
+}
+
+#[test]
 fn summary_and_markdown_formatters_accept_future_schema_versions() {
     let report = parse_report_json(
         "{\"schemaVersion\":3,\"project\":{\"root\":\"/tmp/demo\",\"configPath\":null},\"summary\":{\"filesScanned\":0,\"entrypoints\":0,\"brokenImports\":0,\"orphanFiles\":0,\"deadExports\":0,\"unusedImports\":0,\"routeEntrypoints\":0,\"deletionCandidates\":0},\"findings\":{\"brokenImports\":[],\"orphanFiles\":[],\"deadExports\":[],\"unusedImports\":[],\"routeEntrypoints\":[],\"deletionCandidates\":[]},\"graph\":{\"modules\":[]}}",

--- a/fixtures/parity/demo-app/report-markdown.md
+++ b/fixtures/parity/demo-app/report-markdown.md
@@ -1,6 +1,6 @@
 # Kratos 리포트
 
-> 조치할 항목 6개: 깨진 import 1개, 정리 후보 2개, 사용되지 않는 export 3개.
+> 즉시 수정 대상 1개: 깨진 import 1개. 자동 정리 후보 2개: 삭제 후보 2개. 수동 검토 대상 3개: 사용되지 않는 export 3개.
 
 - 생성 시각: <GENERATED_AT>
 - 루트: <ROOT>
@@ -19,10 +19,11 @@
 
 ## 영향
 
-- 조치할 항목 6개: 깨진 import 1개, 정리 후보 2개, 사용되지 않는 export 3개.
+- 즉시 수정 대상 1개: 깨진 import 1개. 자동 정리 후보 2개: 삭제 후보 2개. 수동 검토 대상 3개: 사용되지 않는 export 3개.
 - 다음 권장 작업: 파일을 삭제하기 전에 깨진 import를 먼저 수정하세요.
 - 정리 미리보기: `kratos clean <REPORT>`
 - Markdown 갱신: `kratos report <REPORT> --format md`
+- 설정 안내: `kratos.config.json`의 `keepPatterns` 또는 `suppressions`로 의도된 공개 API와 보존 파일을 고정하세요.
 
 ## 깨진 import
 

--- a/fixtures/parity/demo-app/report-summary.txt
+++ b/fixtures/parity/demo-app/report-summary.txt
@@ -1,6 +1,6 @@
 Kratos 리포트.
 
-영향: 조치할 항목 6개: 깨진 import 1개, 정리 후보 2개, 사용되지 않는 export 3개.
+영향: 즉시 수정 대상 1개: 깨진 import 1개. 자동 정리 후보 2개: 삭제 후보 2개. 수동 검토 대상 3개: 사용되지 않는 export 3개.
 다음 권장 작업: 파일을 삭제하기 전에 깨진 import를 먼저 수정하세요.
 
 루트: <ROOT>
@@ -18,6 +18,7 @@ Kratos 리포트.
 다음 단계:
 - 정리 미리보기: kratos clean <REPORT>
 - 공유용 Markdown: kratos report <REPORT> --format md
+- 설정 안내: kratos.config.json의 keepPatterns 또는 suppressions로 의도된 공개 API와 보존 파일을 고정하세요.
 
 깨진 import:
 - src/lib/broken.ts -> ./missing-helper
@@ -27,13 +28,9 @@ Kratos 리포트.
 - src/lib/broken.ts (신뢰도 0.88, 모듈에 참조가 없고 진입점으로 취급되지 않습니다.)
 
 고아 파일:
-- src/components/DeadWidget.tsx
-- src/lib/broken.ts
+- 정리 후보와 동일한 파일 2개는 위 목록에서 확인하세요.
 
 사용되지 않는 export:
 - src/components/DeadWidget.tsx#DeadWidget
 - src/lib/broken.ts#brokenFeature
 - src/lib/math.ts#multiply
-
-라우트 진입점:
-- pages/home.tsx (next-pages-route)


### PR DESCRIPTION
## 배경

Orbit Dashboard 같은 큰 Next.js repo에서 `scan`/`report` 사람이 읽는 출력이 자동 정리 후보와 수동 검토 대상인 dead export를 같은 조치 bucket으로 묶어 보여주던 문제를 개선합니다.

## 변경 사항

- summary headline을 즉시 수정 대상, 자동 정리 후보, 수동 검토 대상으로 분리했습니다.
- dead export는 삭제 후보가 아니라 공개 API 여부를 수동 검토해야 하는 대상으로 안내합니다.
- deletion candidate와 orphan file이 같은 파일일 때 기본 summary 목록에서 중복 노출을 줄였습니다.
- 기본 summary에서는 route entrypoint 상세 목록을 숨기고, markdown report에는 상세 섹션을 유지했습니다.
- config가 없는 상태에서 보존/억제 정책이 필요할 때 `kratos.config.json` 안내를 추가했습니다.
- formatter 단위 테스트, CLI smoke, parity summary/markdown fixture를 갱신했습니다.

## 검증

- `cargo test -p kratos-core --test report_format`
- `cargo test -p kratos-core --test report_v2`
- `cargo test -p kratos-cli --test cli_smoke`
- `git diff --check`
- Devil's Advocate review Round 1: `APPROVE`, Critical 0 / High 0 / Medium 0 / Low 1
- Low finding 반영 후 `cargo test -p kratos-cli --test cli_smoke`
- Devil's Advocate delta review: `APPROVE`, Critical 0 / High 0 / Medium 0 / Low 0
- `npm run verify`
- `cargo test --workspace`

## 브랜치 / 워크트리

- base: `master`
- head: `feat/72-actionable-summary`
- worktree: `/tmp/kratos-issue-72`

## 이슈 연결

Closes #72
