### PR TITLE
feat(report): dead export 근거 필드 추가

### DIFF
--- a/crates/kratos-core/src/analyze.rs
+++ b/crates/kratos-core/src/analyze.rs
@@ -242,6 +242,13 @@ pub fn analyze_with_config(config: &ProjectConfig) -> KratosResult<ReportV2> {
                 dead_exports.push(DeadExportFinding {
                     file: module.file_path.clone(),
                     export_name: exported.name.clone(),
+                    export_kind: exported.kind.clone(),
+                    reason: dead_export_reason(module, &export_usage).to_string(),
+                    confidence: dead_export_confidence(module, &export_usage),
+                    imported_by_count: module.imported_by.len(),
+                    used_export_names: export_usage.used_names.iter().cloned().collect(),
+                    has_namespace_or_unknown_usage: export_usage.uses_namespace
+                        || export_usage.uses_unknown,
                 });
             }
         }
@@ -337,6 +344,30 @@ fn summarize_export_usage(module: &ModuleRecord) -> ExportUsage {
         used_names,
         uses_namespace,
         uses_unknown,
+    }
+}
+
+fn dead_export_reason(module: &ModuleRecord, export_usage: &ExportUsage) -> &'static str {
+    if module.imported_by.is_empty() {
+        "Module has no inbound references, so the export is not reached by known imports."
+    } else if export_usage.used_names.is_empty() {
+        "Known importers do not reference any concrete export names from this module."
+    } else {
+        "Known importers reference other concrete export names from this module."
+    }
+}
+
+fn dead_export_confidence(module: &ModuleRecord, export_usage: &ExportUsage) -> f32 {
+    if export_usage.uses_namespace || export_usage.uses_unknown {
+        return 0.0;
+    }
+
+    if module.imported_by.is_empty() {
+        0.84
+    } else if export_usage.used_names.is_empty() {
+        0.86
+    } else {
+        0.9
     }
 }
 

--- a/crates/kratos-core/src/model.rs
+++ b/crates/kratos-core/src/model.rs
@@ -146,6 +146,7 @@ pub enum ExportKind {
     Reexport,
     ReexportAll,
     ReexportNamespace,
+    Unknown,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -249,10 +250,16 @@ pub enum OrphanKind {
     RouteModule,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct DeadExportFinding {
     pub file: PathBuf,
     pub export_name: String,
+    pub export_kind: ExportKind,
+    pub reason: String,
+    pub confidence: f32,
+    pub imported_by_count: usize,
+    pub used_export_names: Vec<String>,
+    pub has_namespace_or_unknown_usage: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/kratos-core/src/report.rs
+++ b/crates/kratos-core/src/report.rs
@@ -4,9 +4,9 @@ use serde_json::{json, Value};
 
 use crate::error::{KratosError, KratosResult};
 use crate::model::{
-    BrokenImportFinding, DeadExportFinding, DeletionCandidateFinding, EntrypointKind, ImportKind,
-    ModuleRecord, OrphanFileFinding, OrphanKind, ReportV2, RouteEntrypointFinding, SummaryCounts,
-    UnusedImportFinding, REPORT_V2,
+    BrokenImportFinding, DeadExportFinding, DeletionCandidateFinding, EntrypointKind, ExportKind,
+    ImportKind, ModuleRecord, OrphanFileFinding, OrphanKind, ReportV2, RouteEntrypointFinding,
+    SummaryCounts, UnusedImportFinding, REPORT_V2,
 };
 
 pub fn validate_report_version(report: &ReportV2) -> KratosResult<()> {
@@ -214,6 +214,12 @@ fn serialize_dead_export(item: &DeadExportFinding) -> Value {
     json!({
         "file": path_to_string(&item.file),
         "exportName": item.export_name,
+        "exportKind": export_kind_to_string(&item.export_kind),
+        "reason": item.reason,
+        "confidence": round_confidence(item.confidence),
+        "importedByCount": item.imported_by_count,
+        "usedExportNames": item.used_export_names,
+        "hasNamespaceOrUnknownUsage": item.has_namespace_or_unknown_usage,
     })
 }
 
@@ -410,9 +416,43 @@ fn parse_dead_exports(value: Option<&Value>) -> Vec<DeadExportFinding> {
     read_array(value)
         .iter()
         .filter_map(|item| {
+            let object = item.as_object()?;
             Some(DeadExportFinding {
-                file: item.get("file")?.as_str()?.into(),
-                export_name: item.get("exportName")?.as_str()?.to_string(),
+                file: object.get("file")?.as_str()?.into(),
+                export_name: object.get("exportName")?.as_str()?.to_string(),
+                export_kind: object
+                    .get("exportKind")
+                    .and_then(Value::as_str)
+                    .and_then(parse_export_kind)
+                    .unwrap_or(ExportKind::Unknown),
+                reason: object
+                    .get("reason")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string(),
+                confidence: object
+                    .get("confidence")
+                    .and_then(Value::as_f64)
+                    .unwrap_or_default() as f32,
+                imported_by_count: object
+                    .get("importedByCount")
+                    .and_then(Value::as_u64)
+                    .unwrap_or_default() as usize,
+                used_export_names: object
+                    .get("usedExportNames")
+                    .and_then(Value::as_array)
+                    .map(|items| {
+                        items
+                            .iter()
+                            .filter_map(Value::as_str)
+                            .map(str::to_string)
+                            .collect()
+                    })
+                    .unwrap_or_default(),
+                has_namespace_or_unknown_usage: object
+                    .get("hasNamespaceOrUnknownUsage")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false),
             })
         })
         .collect()
@@ -439,6 +479,36 @@ fn parse_required_dead_exports(values: &[Value]) -> KratosResult<Vec<DeadExportF
                     &format!("findings.deadExports[{index}].exportName"),
                 )?
                 .to_string(),
+                export_kind: read_optional_export_kind(
+                    object,
+                    "exportKind",
+                    &format!("findings.deadExports[{index}].exportKind"),
+                )?,
+                reason: read_optional_string_owned(
+                    object,
+                    "reason",
+                    &format!("findings.deadExports[{index}].reason"),
+                )?,
+                confidence: read_optional_f64(
+                    object,
+                    "confidence",
+                    &format!("findings.deadExports[{index}].confidence"),
+                )? as f32,
+                imported_by_count: read_optional_usize(
+                    object,
+                    "importedByCount",
+                    &format!("findings.deadExports[{index}].importedByCount"),
+                )?,
+                used_export_names: read_optional_string_vec(
+                    object,
+                    "usedExportNames",
+                    &format!("findings.deadExports[{index}].usedExportNames"),
+                )?,
+                has_namespace_or_unknown_usage: read_optional_bool(
+                    object,
+                    "hasNamespaceOrUnknownUsage",
+                    &format!("findings.deadExports[{index}].hasNamespaceOrUnknownUsage"),
+                )?,
             })
         })
         .collect()
@@ -709,6 +779,17 @@ pub(crate) fn entrypoint_kind_to_string(kind: &EntrypointKind) -> &'static str {
     }
 }
 
+pub(crate) fn export_kind_to_string(kind: &ExportKind) -> &'static str {
+    match kind {
+        ExportKind::Default => "default",
+        ExportKind::Named => "named",
+        ExportKind::Reexport => "reexport",
+        ExportKind::ReexportAll => "reexport-all",
+        ExportKind::ReexportNamespace => "reexport-namespace",
+        ExportKind::Unknown => "unknown",
+    }
+}
+
 fn import_kind_to_string(kind: &ImportKind) -> &'static str {
     match kind {
         ImportKind::Static => "static",
@@ -753,6 +834,18 @@ fn parse_import_kind(value: &str) -> Option<ImportKind> {
         "require" => Some(ImportKind::Require),
         "dynamic" => Some(ImportKind::Dynamic),
         "unknown" => Some(ImportKind::Unknown),
+        _ => None,
+    }
+}
+
+fn parse_export_kind(value: &str) -> Option<ExportKind> {
+    match value {
+        "default" => Some(ExportKind::Default),
+        "named" => Some(ExportKind::Named),
+        "reexport" => Some(ExportKind::Reexport),
+        "reexport-all" => Some(ExportKind::ReexportAll),
+        "reexport-namespace" => Some(ExportKind::ReexportNamespace),
+        "unknown" => Some(ExportKind::Unknown),
         _ => None,
     }
 }
@@ -847,6 +940,87 @@ fn read_optional_usize(
             .ok_or_else(|| KratosError::Json(format!("Report has invalid number `{path}`"))),
         Some(_) => Err(KratosError::Json(format!(
             "Report has invalid number `{path}`"
+        ))),
+    }
+}
+
+fn read_optional_f64(
+    value: &serde_json::Map<String, Value>,
+    key: &str,
+    path: &str,
+) -> KratosResult<f64> {
+    match value.get(key) {
+        None | Some(Value::Null) => Ok(0.0),
+        Some(Value::Number(number)) => number
+            .as_f64()
+            .ok_or_else(|| KratosError::Json(format!("Report has invalid number `{path}`"))),
+        Some(_) => Err(KratosError::Json(format!(
+            "Report has invalid number `{path}`"
+        ))),
+    }
+}
+
+fn read_optional_bool(
+    value: &serde_json::Map<String, Value>,
+    key: &str,
+    path: &str,
+) -> KratosResult<bool> {
+    match value.get(key) {
+        None | Some(Value::Null) => Ok(false),
+        Some(Value::Bool(value)) => Ok(*value),
+        Some(_) => Err(KratosError::Json(format!(
+            "Report has invalid boolean `{path}`"
+        ))),
+    }
+}
+
+fn read_optional_string_owned(
+    value: &serde_json::Map<String, Value>,
+    key: &str,
+    path: &str,
+) -> KratosResult<String> {
+    match value.get(key) {
+        None | Some(Value::Null) => Ok(String::new()),
+        Some(Value::String(value)) => Ok(value.clone()),
+        Some(_) => Err(KratosError::Json(format!(
+            "Report has invalid string field `{path}`"
+        ))),
+    }
+}
+
+fn read_optional_string_vec(
+    value: &serde_json::Map<String, Value>,
+    key: &str,
+    path: &str,
+) -> KratosResult<Vec<String>> {
+    match value.get(key) {
+        None | Some(Value::Null) => Ok(Vec::new()),
+        Some(Value::Array(items)) => items
+            .iter()
+            .enumerate()
+            .map(|(index, item)| {
+                item.as_str().map(str::to_string).ok_or_else(|| {
+                    KratosError::Json(format!("Report has invalid string `{path}[{index}]`"))
+                })
+            })
+            .collect(),
+        Some(_) => Err(KratosError::Json(format!(
+            "Report has invalid array `{path}`"
+        ))),
+    }
+}
+
+fn read_optional_export_kind(
+    value: &serde_json::Map<String, Value>,
+    key: &str,
+    path: &str,
+) -> KratosResult<ExportKind> {
+    match value.get(key) {
+        None | Some(Value::Null) => Ok(ExportKind::Unknown),
+        Some(Value::String(raw)) => parse_export_kind(raw)
+            .ok_or_else(|| KratosError::Json(format!("Report has invalid export kind `{path}`"))),
+        Some(_) => Err(KratosError::Json(format!(
+            "Report has invalid export kind `{path}`"
         ))),
     }
 }

--- a/crates/kratos-core/src/report_diff.rs
+++ b/crates/kratos-core/src/report_diff.rs
@@ -7,7 +7,7 @@ use crate::model::{
     BrokenImportFinding, DeadExportFinding, DeletionCandidateFinding, OrphanFileFinding,
     OrphanKind, ReportV2, RouteEntrypointFinding, UnusedImportFinding,
 };
-use crate::report::{entrypoint_kind_to_string, path_to_string};
+use crate::report::{entrypoint_kind_to_string, export_kind_to_string, path_to_string};
 use crate::{KratosError, KratosResult};
 
 #[derive(Clone, Debug, PartialEq)]
@@ -474,6 +474,12 @@ fn serialize_dead_export(item: &DeadExportFinding) -> Value {
     json!({
         "file": path_to_string(&item.file),
         "exportName": item.export_name,
+        "exportKind": export_kind_to_string(&item.export_kind),
+        "reason": item.reason,
+        "confidence": round_confidence(item.confidence),
+        "importedByCount": item.imported_by_count,
+        "usedExportNames": item.used_export_names,
+        "hasNamespaceOrUnknownUsage": item.has_namespace_or_unknown_usage,
     })
 }
 
@@ -584,6 +590,6 @@ fn orphan_kind_to_string(kind: &OrphanKind) -> &'static str {
     }
 }
 
-fn round_confidence(value: f32) -> f32 {
-    (value * 100.0).round() / 100.0
+fn round_confidence(value: f32) -> f64 {
+    ((value as f64) * 100.0).round() / 100.0
 }

--- a/crates/kratos-core/tests/analyze_demo_app.rs
+++ b/crates/kratos-core/tests/analyze_demo_app.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use kratos_core::analyze::analyze_project;
-use kratos_core::model::{EntrypointKind, OrphanKind};
+use kratos_core::model::{EntrypointKind, ExportKind, OrphanKind};
 
 #[test]
 fn analyze_demo_app_matches_expected_graph_and_findings() {
@@ -54,7 +54,18 @@ fn analyze_demo_app_matches_expected_graph_and_findings() {
         .findings
         .dead_exports
         .iter()
-        .map(|item| (item.file.clone(), item.export_name.clone()))
+        .map(|item| {
+            (
+                item.file.clone(),
+                item.export_name.clone(),
+                item.export_kind.clone(),
+                item.reason.clone(),
+                item.confidence,
+                item.imported_by_count,
+                item.used_export_names.clone(),
+                item.has_namespace_or_unknown_usage,
+            )
+        })
         .collect::<Vec<_>>();
     assert_eq!(
         dead_exports,
@@ -62,12 +73,36 @@ fn analyze_demo_app_matches_expected_graph_and_findings() {
             (
                 demo_root.join("src/components/DeadWidget.tsx"),
                 "DeadWidget".to_string(),
+                ExportKind::Named,
+                "Module has no inbound references, so the export is not reached by known imports."
+                    .to_string(),
+                0.84,
+                0,
+                Vec::<String>::new(),
+                false,
             ),
             (
                 demo_root.join("src/lib/broken.ts"),
                 "brokenFeature".to_string(),
+                ExportKind::Named,
+                "Module has no inbound references, so the export is not reached by known imports."
+                    .to_string(),
+                0.84,
+                0,
+                Vec::<String>::new(),
+                false,
             ),
-            (demo_root.join("src/lib/math.ts"), "multiply".to_string(),),
+            (
+                demo_root.join("src/lib/math.ts"),
+                "multiply".to_string(),
+                ExportKind::Named,
+                "Known importers reference other concrete export names from this module."
+                    .to_string(),
+                0.9,
+                1,
+                vec!["sum".to_string()],
+                false,
+            ),
         ]
     );
 
@@ -239,6 +274,18 @@ export const helper = 1;
         project.root().join("app/page.tsx")
     );
     assert_eq!(report.findings.dead_exports[0].export_name, "helper");
+    assert_eq!(
+        report.findings.dead_exports[0].export_kind,
+        ExportKind::Named
+    );
+    assert_eq!(
+        report.findings.dead_exports[0].reason,
+        "Module has no inbound references, so the export is not reached by known imports."
+    );
+    assert_eq!(report.findings.dead_exports[0].confidence, 0.84);
+    assert_eq!(report.findings.dead_exports[0].imported_by_count, 0);
+    assert!(report.findings.dead_exports[0].used_export_names.is_empty());
+    assert!(!report.findings.dead_exports[0].has_namespace_or_unknown_usage);
 }
 
 #[test]

--- a/crates/kratos-core/tests/report_diff.rs
+++ b/crates/kratos-core/tests/report_diff.rs
@@ -1,9 +1,9 @@
 use std::path::PathBuf;
 
 use kratos_core::model::{
-    BrokenImportFinding, DeadExportFinding, DeletionCandidateFinding, EntrypointKind, FindingSet,
-    ImportKind, ModuleRecord, OrphanFileFinding, OrphanKind, ReportV2, RouteEntrypointFinding,
-    SummaryCounts, UnusedImportFinding,
+    BrokenImportFinding, DeadExportFinding, DeletionCandidateFinding, EntrypointKind, ExportKind,
+    FindingSet, ImportKind, ModuleRecord, OrphanFileFinding, OrphanKind, ReportV2,
+    RouteEntrypointFinding, SummaryCounts, UnusedImportFinding,
 };
 use kratos_core::report_diff::{
     diff_reports, format_diff_json, format_diff_markdown, format_diff_summary,
@@ -435,6 +435,90 @@ fn diff_reports_treat_deletion_candidate_metadata_changes_as_real_changes() {
     );
 }
 
+#[test]
+fn diff_reports_keep_dead_export_evidence_out_of_identity_key() {
+    let before_dead_export = dead_export_with_evidence(
+        "/repo/before/src/dead.ts",
+        "helper",
+        ExportKind::Named,
+        "Old evidence.",
+        0.42,
+        0,
+        vec![],
+        false,
+    );
+    let after_dead_export = dead_export_with_evidence(
+        "/repo/after/src/dead.ts",
+        "helper",
+        ExportKind::Reexport,
+        "New evidence.",
+        0.9,
+        2,
+        vec!["used".to_string()],
+        true,
+    );
+    let before = report_v2(
+        "/repo/before",
+        None,
+        None,
+        SummaryCounts::default(),
+        finding_set(
+            vec![],
+            vec![],
+            vec![before_dead_export],
+            vec![],
+            vec![],
+            vec![],
+        ),
+        vec![],
+    );
+    let after = report_v2(
+        "/repo/after",
+        None,
+        None,
+        SummaryCounts::default(),
+        finding_set(
+            vec![],
+            vec![],
+            vec![after_dead_export.clone()],
+            vec![],
+            vec![],
+            vec![],
+        ),
+        vec![],
+    );
+
+    let diff = diff_reports(&before, &after);
+
+    assert_eq!(diff.summary.dead_exports.introduced, 0);
+    assert_eq!(diff.summary.dead_exports.resolved, 0);
+    assert_eq!(diff.summary.dead_exports.persisted, 1);
+    assert_eq!(
+        diff.findings.dead_exports.persisted,
+        vec![after_dead_export]
+    );
+
+    let json = format_diff_json(
+        &diff,
+        &PathBuf::from("/tmp/before-report.json"),
+        &PathBuf::from("/tmp/after-report.json"),
+    )
+    .expect("json should format");
+    let value: Value = serde_json::from_str(&json).expect("diff json should parse");
+    assert_eq!(
+        value["findings"]["deadExports"]["persisted"][0]["exportKind"],
+        Value::from("reexport")
+    );
+    assert_eq!(
+        value["findings"]["deadExports"]["persisted"][0]["confidence"],
+        Value::from(0.9)
+    );
+    assert_eq!(
+        value["findings"]["deadExports"]["persisted"][0]["usedExportNames"],
+        Value::from(vec!["used"])
+    );
+}
+
 fn report_v2(
     root: &str,
     config_path: Option<&str>,
@@ -522,9 +606,37 @@ fn orphan_file(file: &str, kind: OrphanKind, reason: &str, confidence: f32) -> O
 }
 
 fn dead_export(file: &str, export_name: &str) -> DeadExportFinding {
+    dead_export_with_evidence(
+        file,
+        export_name,
+        ExportKind::Named,
+        "Known importers do not reference this export.",
+        0.9,
+        1,
+        Vec::new(),
+        false,
+    )
+}
+
+fn dead_export_with_evidence(
+    file: &str,
+    export_name: &str,
+    export_kind: ExportKind,
+    reason: &str,
+    confidence: f32,
+    imported_by_count: usize,
+    used_export_names: Vec<String>,
+    has_namespace_or_unknown_usage: bool,
+) -> DeadExportFinding {
     DeadExportFinding {
         file: PathBuf::from(file),
         export_name: export_name.to_string(),
+        export_kind,
+        reason: reason.to_string(),
+        confidence,
+        imported_by_count,
+        used_export_names,
+        has_namespace_or_unknown_usage,
     }
 }
 

--- a/crates/kratos-core/tests/report_v2.rs
+++ b/crates/kratos-core/tests/report_v2.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use kratos_core::analyze::analyze_project;
+use kratos_core::model::ExportKind;
 use kratos_core::report::{
     format_markdown_report, format_summary_report, parse_report_json, serialize_report_pretty,
     validate_report_version,
@@ -375,11 +376,48 @@ fn report_v2_rejects_invalid_required_enum_values() {
         "modules": []
       }
     }"#;
+    let invalid_dead_export_kind = r#"{
+      "schemaVersion": 2,
+      "generatedAt": "2026-04-19T00:00:00Z",
+      "project": {
+        "root": "/tmp/kratos",
+        "configPath": null
+      },
+      "summary": {
+        "filesScanned": 0,
+        "entrypoints": 0,
+        "brokenImports": 0,
+        "orphanFiles": 0,
+        "deadExports": 1,
+        "unusedImports": 0,
+        "routeEntrypoints": 0,
+        "deletionCandidates": 0
+      },
+      "findings": {
+        "brokenImports": [],
+        "orphanFiles": [],
+        "deadExports": [
+          {
+            "file": "/tmp/kratos/src/dead.ts",
+            "exportName": "helper",
+            "exportKind": 123
+          }
+        ],
+        "unusedImports": [],
+        "routeEntrypoints": [],
+        "deletionCandidates": []
+      },
+      "graph": {
+        "modules": []
+      }
+    }"#;
 
     let import_error =
         parse_report_json(invalid_import_kind).expect_err("invalid import kind should fail");
     let orphan_error =
         parse_report_json(invalid_orphan_kind).expect_err("invalid orphan kind should fail");
+    let export_error =
+        parse_report_json(invalid_dead_export_kind).expect_err("invalid export kind should fail");
 
     assert!(
         import_error
@@ -392,6 +430,16 @@ fn report_v2_rejects_invalid_required_enum_values() {
             .to_string()
             .contains("findings.orphanFiles[0].kind"),
         "expected orphan kind error, got: {orphan_error}"
+    );
+    assert!(
+        export_error
+            .to_string()
+            .contains("findings.deadExports[0].exportKind"),
+        "expected export kind error path, got: {export_error}"
+    );
+    assert!(
+        export_error.to_string().contains("invalid export kind"),
+        "expected export kind invalid-type message, got: {export_error}"
     );
 }
 
@@ -439,6 +487,83 @@ fn legacy_report_parses_into_renderable_v2_report() {
     serialize_report_pretty(&parsed).expect("legacy report should serialize");
     format_summary_report(&parsed, report_path).expect("legacy report should format as summary");
     format_markdown_report(&parsed, report_path).expect("legacy report should format as markdown");
+}
+
+#[test]
+fn report_v2_dead_exports_include_evidence_and_legacy_shape_still_parses() {
+    let legacy_dead_export_report = r#"{
+      "schemaVersion": 2,
+      "generatedAt": "2026-04-19T00:00:00Z",
+      "project": {
+        "root": "/tmp/kratos",
+        "configPath": null
+      },
+      "summary": {
+        "filesScanned": 1,
+        "entrypoints": 0,
+        "brokenImports": 0,
+        "orphanFiles": 0,
+        "deadExports": 1,
+        "unusedImports": 0,
+        "routeEntrypoints": 0,
+        "deletionCandidates": 0
+      },
+      "findings": {
+        "brokenImports": [],
+        "orphanFiles": [],
+        "deadExports": [
+          {
+            "file": "/tmp/kratos/src/dead.ts",
+            "exportName": "helper"
+          }
+        ],
+        "unusedImports": [],
+        "routeEntrypoints": [],
+        "deletionCandidates": []
+      },
+      "graph": {
+        "modules": [
+          {
+            "file": "/tmp/kratos/src/dead.ts",
+            "relativePath": "src/dead.ts",
+            "entrypointKind": null,
+            "importedByCount": 0,
+            "importCount": 0,
+            "exportCount": 1
+          }
+        ]
+      }
+    }"#;
+
+    let parsed =
+        parse_report_json(legacy_dead_export_report).expect("legacy dead export should parse");
+    let finding = &parsed.findings.dead_exports[0];
+
+    assert_eq!(finding.file, PathBuf::from("/tmp/kratos/src/dead.ts"));
+    assert_eq!(finding.export_name, "helper");
+    assert_eq!(finding.export_kind, ExportKind::Unknown);
+    assert_eq!(finding.reason, "");
+    assert_eq!(finding.confidence, 0.0);
+    assert_eq!(finding.imported_by_count, 0);
+    assert!(finding.used_export_names.is_empty());
+    assert!(!finding.has_namespace_or_unknown_usage);
+
+    let serialized = serialize_report_pretty(&parsed).expect("report should serialize");
+    let serialized_value: Value =
+        serde_json::from_str(&serialized).expect("serialized report should be valid JSON");
+    let serialized_finding = &serialized_value["findings"]["deadExports"][0];
+    assert_eq!(serialized_finding["exportKind"], Value::from("unknown"));
+    assert_eq!(serialized_finding["reason"], Value::from(""));
+    assert_eq!(serialized_finding["confidence"], Value::from(0.0));
+    assert_eq!(serialized_finding["importedByCount"], Value::from(0));
+    assert_eq!(
+        serialized_finding["usedExportNames"],
+        Value::from(Vec::<Value>::new())
+    );
+    assert_eq!(
+        serialized_finding["hasNamespaceOrUnknownUsage"],
+        Value::from(false)
+    );
 }
 
 #[test]

--- a/crates/kratos-core/tests/suppressions.rs
+++ b/crates/kratos-core/tests/suppressions.rs
@@ -2,8 +2,9 @@ use std::path::{Path, PathBuf};
 
 use kratos_core::analyze::analyze_project;
 use kratos_core::model::{
-    BrokenImportFinding, DeadExportFinding, DeletionCandidateFinding, EntrypointKind, FindingSet,
-    ImportKind, OrphanFileFinding, OrphanKind, RouteEntrypointFinding, UnusedImportFinding,
+    BrokenImportFinding, DeadExportFinding, DeletionCandidateFinding, EntrypointKind, ExportKind,
+    FindingSet, ImportKind, OrphanFileFinding, OrphanKind, RouteEntrypointFinding,
+    UnusedImportFinding,
 };
 use kratos_core::report::{parse_report_json, serialize_report_pretty};
 use kratos_core::report_format::{format_markdown_report, format_summary_report};
@@ -85,10 +86,22 @@ fn apply_suppressions_matches_exact_fields_and_counts_each_finding_once() {
             DeadExportFinding {
                 file: root.join("src/dead.ts"),
                 export_name: "default".to_string(),
+                export_kind: ExportKind::Default,
+                reason: "Known importers do not reference this export.".to_string(),
+                confidence: 0.91,
+                imported_by_count: 1,
+                used_export_names: vec!["helper".to_string()],
+                has_namespace_or_unknown_usage: false,
             },
             DeadExportFinding {
                 file: root.join("src/dead.ts"),
                 export_name: "helper".to_string(),
+                export_kind: ExportKind::Named,
+                reason: "Known importers do not reference this export.".to_string(),
+                confidence: 0.9,
+                imported_by_count: 1,
+                used_export_names: vec!["default".to_string()],
+                has_namespace_or_unknown_usage: false,
             },
         ],
         unused_imports: vec![

--- a/fixtures/parity/demo-app/latest-report.v1.json
+++ b/fixtures/parity/demo-app/latest-report.v1.json
@@ -40,15 +40,35 @@
     "deadExports": [
       {
         "file": "<ROOT>/src/components/DeadWidget.tsx",
-        "exportName": "DeadWidget"
+        "exportName": "DeadWidget",
+        "exportKind": "named",
+        "reason": "Module has no inbound references, so the export is not reached by known imports.",
+        "confidence": 0.84,
+        "importedByCount": 0,
+        "usedExportNames": [],
+        "hasNamespaceOrUnknownUsage": false
       },
       {
         "file": "<ROOT>/src/lib/broken.ts",
-        "exportName": "brokenFeature"
+        "exportName": "brokenFeature",
+        "exportKind": "named",
+        "reason": "Module has no inbound references, so the export is not reached by known imports.",
+        "confidence": 0.84,
+        "importedByCount": 0,
+        "usedExportNames": [],
+        "hasNamespaceOrUnknownUsage": false
       },
       {
         "file": "<ROOT>/src/lib/math.ts",
-        "exportName": "multiply"
+        "exportName": "multiply",
+        "exportKind": "named",
+        "reason": "Known importers reference other concrete export names from this module.",
+        "confidence": 0.9,
+        "importedByCount": 1,
+        "usedExportNames": [
+          "sum"
+        ],
+        "hasNamespaceOrUnknownUsage": false
       }
     ],
     "unusedImports": [],


### PR DESCRIPTION
## 배경

unused export 결과가 `file + exportName`만 제공해 수동 검토 시 근거가 부족했습니다. 이 PR은 dead export finding에 export 종류와 confidence, importer/use evidence를 추가하되 기존 report 호환성과 diff/suppression 계약을 유지합니다.

## 변경 사항

- `DeadExportFinding`에 `exportKind`, `reason`, `confidence`, `importedByCount`, `usedExportNames`, `hasNamespaceOrUnknownUsage`를 추가했습니다.
- analyzer가 dead export를 생성할 때 export record와 usage summary를 기반으로 evidence를 채웁니다.
- report JSON serialize/parse에 새 필드를 추가하고 legacy `{file, exportName}` shape는 기본값으로 계속 parse합니다.
- report diff는 evidence를 출력하되 identity key는 기존 `file + exportName`으로 유지합니다.
- suppression matching은 기존 `file + export` semantics를 유지합니다.
- parity fixture와 schema/diff/suppression/analyzer 회귀 테스트를 갱신했습니다.

## 검증

- `cargo test -p kratos-core --test report_v2`
- `cargo test -p kratos-core --test report_diff`
- `cargo test -p kratos-core --test suppressions`
- `cargo test -p kratos-core --test analyze_demo_app`
- `cargo test -p kratos-core`
- `git diff --check`
- Devil's Advocate review Round 1: `APPROVE`, Critical 0 / High 0 / Medium 0 / Low 1
- Low finding 반영 후 `cargo test -p kratos-core --test report_v2`
- Devil's Advocate delta review: `APPROVE`, Critical 0 / High 0 / Medium 0 / Low 0
- `npm run verify`
- `cargo test --workspace`

## 브랜치 / 워크트리

- base: `master`
- head: `feat/74-dead-export-evidence`
- worktree: `/tmp/kratos-issue-74`

## 이슈 연결

Closes #74
