### PR TITLE
[Docs] SECURITY.md v1.0 지원 정책 정식화

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,15 +2,26 @@
 
 ## Supported Versions
 
-Kratos is in early development. Security fixes are currently applied to the
-latest code on `main` and the most recent published release once releases
-exist.
+Kratos security support starts with the v1.0 release line. Security fixes are
+prepared on the default development branch, `master`, and released through the
+supported release lines below.
 
-| Version | Supported |
-| --- | --- |
-| `main` | Yes |
-| Latest release | Yes |
-| Older releases | No |
+| Version or branch | Supported | Policy |
+| --- | --- | --- |
+| `master` | Yes | Default development branch for unreleased security fixes. |
+| Latest release | Yes | Newest published stable release. |
+| Current major | Yes | Supported release line sharing the latest stable major version, such as `1.x` for v1.0. |
+| Older releases | No | Earlier major versions and pre-v1.0 releases are unsupported unless maintainers announce an exception. |
+
+Definitions:
+
+- Latest release means the newest stable GitHub release or tag published from
+  `master`.
+- Current major means the active stable major release line that contains the
+  latest release. For v1.0, this is the `1.x` line.
+- Older releases means pre-v1.0 releases and any major release line older than
+  the current major. Upgrade to the latest supported release before requesting
+  a security fix.
 
 ## Reporting a Vulnerability
 
@@ -18,12 +29,13 @@ Please do not report security vulnerabilities in public GitHub issues,
 discussions, or pull requests.
 
 If GitHub Private Vulnerability Reporting is enabled for this repository, use
-that channel first.
+that channel first. It is the preferred way to share vulnerability details with
+the maintainers.
 
-If private reporting is not available yet, open a minimal public issue that
-does **not** include exploit details and request a private contact channel from
-the maintainers. Keep proof-of-concept code, payloads, and reproduction steps
-private until a secure channel is established.
+If Private Vulnerability Reporting is not available, open a minimal public
+issue that does **not** include exploit details and request a private contact
+channel from the maintainers. Keep proof-of-concept code, payloads, and
+reproduction steps private until a secure channel is established.
 
 When reporting a vulnerability, please include:
 


### PR DESCRIPTION
## 배경

v1.0.0 정식 출시 기준에서 SECURITY.md가 early-development 문구와 main 브랜치 표기를 유지하고 있어 실제 repo 흐름과 지원 정책을 맞춥니다.

## 변경 사항

- early-development / once releases exist 문구 제거
- 기본 개발 브랜치 표기를 master로 정정
- Latest release, Current major, Older releases 지원 범위 정의
- Private Vulnerability Reporting 우선 경로와 fallback 절차 정리

## 검증

- git diff --check
- Devil's Advocate review gate: Critical 0 / High 0 / Medium 0 / Low 0
- Runtime tests skipped: docs-only SECURITY.md 변경

## 브랜치 / 워크트리

- base: master
- branch: docs/84-security-policy
- worktree: /private/tmp/kratos-v1-wave1/issue-84

## 이슈 연결

Closes #84