### PR TITLE
[Feat] CLI --version 출력 계약 추가

### DIFF
--- a/crates/kratos-cli/src/lib.rs
+++ b/crates/kratos-cli/src/lib.rs
@@ -31,6 +31,10 @@ fn run(
     let argv = &args[1..];
 
     match command.as_str() {
+        "--version" | "-V" => {
+            commands::write_output(stdout, &format!("kratos {}", package_version()))?;
+            Ok(0)
+        }
         "--help" | "-h" | "help" => {
             commands::write_output(stdout, &commands::format_root_help())?;
             Ok(0)
@@ -41,4 +45,16 @@ fn run(
             Ok(1)
         }
     }
+}
+
+fn package_version() -> String {
+    serde_json::from_str::<serde_json::Value>(include_str!("../../../package.json"))
+        .ok()
+        .and_then(|manifest| {
+            manifest
+                .get("version")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned)
+        })
+        .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string())
 }

--- a/crates/kratos-cli/tests/cli_smoke.rs
+++ b/crates/kratos-cli/tests/cli_smoke.rs
@@ -15,6 +15,30 @@ fn root_help_matches_expected_shape() {
 }
 
 #[test]
+fn root_version_flags_print_package_version() {
+    for flag in ["--version", "-V"] {
+        let output = run_cli(&[flag]);
+
+        assert!(output.status.success(), "{flag} should exit successfully");
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout),
+            format!("kratos {}\n", package_version())
+        );
+        assert!(output.stderr.is_empty(), "{flag} should not print stderr");
+    }
+}
+
+fn package_version() -> String {
+    let manifest: serde_json::Value =
+        serde_json::from_str(include_str!("../../../package.json")).expect("valid package.json");
+    manifest
+        .get("version")
+        .and_then(serde_json::Value::as_str)
+        .expect("package.json version")
+        .to_string()
+}
+
+#[test]
 fn command_help_matches_korean_policy() {
     let output = run_cli(&["clean", "--help"]);
 


### PR DESCRIPTION
## 배경

사용자와 자동화가 설치된 Kratos CLI 버전을 확인할 수 있도록 루트 CLI에 버전 출력 계약을 추가합니다.

## 변경 사항

- root dispatcher에서 `--version` / `-V` 처리
- 출력 형식을 `kratos <version>`으로 고정
- 버전 소스를 root `package.json` 기준으로 맞춰 npm 설치 버전 계약과 일치
- smoke test로 exit code, stdout, stderr를 회귀 검증

## 검증

- cargo run -p kratos-cli -- --version
- cargo run -p kratos-cli -- -V
- cargo test -p kratos-cli --test cli_smoke
- cargo test --workspace
- git diff --check
- Devil's Advocate review gate: 1차 High 1건 수정 후 2차 Critical 0 / High 0 / Medium 0 / Low 0

## 브랜치 / 워크트리

- base: master
- branch: feat/82-cli-version
- worktree: /private/tmp/kratos-v1-wave1/issue-82

## 이슈 연결

Closes #82